### PR TITLE
Alteração idLote para eventos de carta correção e cancelamento

### DIFF
--- a/src/main/java/com/fincatto/nfe310/webservices/WSCancelamento.java
+++ b/src/main/java/com/fincatto/nfe310/webservices/WSCancelamento.java
@@ -101,7 +101,7 @@ class WSCancelamento {
 
         final NFEnviaEventoCancelamento enviaEvento = new NFEnviaEventoCancelamento();
         enviaEvento.setEvento(Collections.singletonList(evento));
-        enviaEvento.setIdLote("1");
+        enviaEvento.setIdLote(Long.toString(DateTime.now().getMillis()));
         enviaEvento.setVersao(WSCancelamento.VERSAO_LEIAUTE);
         return enviaEvento;
     }

--- a/src/main/java/com/fincatto/nfe310/webservices/WSCartaCorrecao.java
+++ b/src/main/java/com/fincatto/nfe310/webservices/WSCartaCorrecao.java
@@ -108,7 +108,7 @@ class WSCartaCorrecao {
 
         final NFEnviaEventoCartaCorrecao enviaEvento = new NFEnviaEventoCartaCorrecao();
         enviaEvento.setEvento(Collections.singletonList(evento));
-        enviaEvento.setIdLote("1");
+        enviaEvento.setIdLote(Long.toString(DateTime.now().getMillis()));
         enviaEvento.setVersao(WSCartaCorrecao.VERSAO_LEIAUTE);
         return enviaEvento;
     }


### PR DESCRIPTION
Ao analisar o emissor gratuito verifiquei que o valor atribuído ao idLote para eventos de carta correção e cancelamento é o milissegundos (ex: 1467724330155) da data atual.

Documentação da NF-e para o idLote:
Identificador de controle do Lote de envio do Evento. Número sequencial autoincremental único para identificação do Lote. A responsabilidade de gerar e controlar é exclusiva do autor do evento. O Web Service não faz qualquer uso deste identificador.