### PR TITLE
Correção de problema para cancelar NFe na SVAN

### DIFF
--- a/src/main/java/com/fincatto/nfe310/classes/evento/NFEnviaEventoRetorno.java
+++ b/src/main/java/com/fincatto/nfe310/classes/evento/NFEnviaEventoRetorno.java
@@ -10,6 +10,8 @@ import org.simpleframework.xml.Root;
 import com.fincatto.nfe310.classes.NFAmbiente;
 import com.fincatto.nfe310.classes.NFBase;
 import com.fincatto.nfe310.classes.NFUnidadeFederativa;
+import com.fincatto.nfe310.converters.StringNullConverter;
+import org.simpleframework.xml.convert.Convert;
 
 @Root(name = "retEnvEvento")
 public class NFEnviaEventoRetorno extends NFBase {
@@ -17,7 +19,13 @@ public class NFEnviaEventoRetorno extends NFBase {
     @Attribute(name = "versao", required = true)
     private String versao;
 
+    /**
+     * O Converter StringNullConverter está sendo utilizado para<br>
+     * resolver um problema da autorizadora SVAN, que está retornando<br>
+     * o atributo idLote vazio.
+     */
     @Element(name = "idLote", required = true)
+    @Convert(StringNullConverter.class)
     private String idLote;
 
     @Element(name = "tpAmb", required = true)

--- a/src/test/java/com/fincatto/nfe310/classes/evento/cancelamento/NFEnviaEventoRetornoCancelamentoTest.java
+++ b/src/test/java/com/fincatto/nfe310/classes/evento/cancelamento/NFEnviaEventoRetornoCancelamentoTest.java
@@ -1,0 +1,15 @@
+package com.fincatto.nfe310.classes.evento.cancelamento;
+
+import com.fincatto.nfe310.classes.evento.NFEnviaEventoRetorno;
+import com.fincatto.nfe310.persister.NFPersister;
+import org.junit.Test;
+
+public class NFEnviaEventoRetornoCancelamentoTest {
+
+    @Test
+    public void deveReceberIdLoteVazio() throws Exception {
+        String xml = "<retEnvEvento versao=\"1.00\"><idLote/><tpAmb>1</tpAmb><verAplic>Serpro.Sped.NFe.Sefaz.Evento_1.0.1</verAplic><cOrgao>53</cOrgao><cStat>128</cStat><xMotivo>Lote de evento processado</xMotivo><retEvento versao=\"1.00\"><infEvento Id=\"ID422160008693146\"><tpAmb>1</tpAmb><verAplic>Serpro.Sped.NFe.Sefaz.Evento_1.0.1</verAplic><cOrgao>22</cOrgao><cStat>135</cStat><xMotivo>Evento registrado e vinculado a NF-e</xMotivo><chNFe>22160773815060000217550010000002881396616175</chNFe><tpEvento>110111</tpEvento><nSeqEvento>1</nSeqEvento><dhRegEvento>2016-07-05T09:25:19-03:00</dhRegEvento><nProt>422160008693146</nProt></infEvento></retEvento></retEnvEvento>";
+        NFEnviaEventoRetorno enviaEventoRetorno = new NFPersister().read(NFEnviaEventoRetorno.class, xml);
+    }
+    
+}


### PR DESCRIPTION
Seguindo a sugestão do Diego foi adicionada uma anotação @Convert(StringNullConverter.class) ao atributo idLote da classe com.fincatto.nfe310.classes.evento.NFEnviaEventoRetorno para resolver o problema na SVAN que está enviando o atributo (idLote) vazio.

Criei um teste para o converter.