### PR TITLE
adicionado método getDescricao em NFNotaInfoImpostoTributacaoICMS e NFIndicadorPresencaComprador

### DIFF
--- a/src/main/java/com/fincatto/nfe310/classes/NFNotaInfoImpostoTributacaoICMS.java
+++ b/src/main/java/com/fincatto/nfe310/classes/NFNotaInfoImpostoTributacaoICMS.java
@@ -25,6 +25,10 @@ public enum NFNotaInfoImpostoTributacaoICMS {
     public String getCodigo() {
         return this.codigo;
     }
+    
+    public String getDescricao() {
+        return this.descricao;
+    }
 
     public static NFNotaInfoImpostoTributacaoICMS valueOfCodigo(final String codigoICMS) {
         for (final NFNotaInfoImpostoTributacaoICMS icms : NFNotaInfoImpostoTributacaoICMS.values()) {

--- a/src/main/java/com/fincatto/nfe310/classes/nota/NFIndicadorPresencaComprador.java
+++ b/src/main/java/com/fincatto/nfe310/classes/nota/NFIndicadorPresencaComprador.java
@@ -20,6 +20,10 @@ public enum NFIndicadorPresencaComprador {
     public String getCodigo() {
         return this.codigo;
     }
+    
+    public String getDescricao() {
+        return this.descricao;
+    }
 
     public static NFIndicadorPresencaComprador valueOfCodigo(final String codigo) {
         for (final NFIndicadorPresencaComprador indicador : NFIndicadorPresencaComprador.values()) {


### PR DESCRIPTION
adicionado método getDescricao em NFNotaInfoImpostoTributacaoICMS e NFIndicadorPresencaComprador, para ficar de acordo com algumas outras classes ENUM que continham este método e me parece que deveria ser adotado como um padrão