### PR TITLE
Correção na forma de construir o OMElement a partir do XML de envio de Lote para manter os campos CDATA.

### DIFF
--- a/src/main/java/com/fincatto/nfe310/webservices/WSLoteEnvio.java
+++ b/src/main/java/com/fincatto/nfe310/webservices/WSLoteEnvio.java
@@ -29,6 +29,10 @@ import com.fincatto.nfe310.webservices.gerado.NfeAutorizacaoStub.NfeAutorizacaoL
 import com.fincatto.nfe310.webservices.gerado.NfeAutorizacaoStub.NfeCabecMsg;
 import com.fincatto.nfe310.webservices.gerado.NfeAutorizacaoStub.NfeCabecMsgE;
 import com.fincatto.nfe310.webservices.gerado.NfeAutorizacaoStub.NfeDadosMsg;
+import java.io.StringReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamReader;
+import org.apache.axiom.om.impl.builder.StAXOMBuilder;
 
 class WSLoteEnvio {
 
@@ -125,7 +129,11 @@ class WSLoteEnvio {
     }
 
     private OMElement nfeToOMElement(final String documento) throws XMLStreamException {
-        final OMElement ome = AXIOMUtil.stringToOM(documento);
+        final XMLInputFactory factory = XMLInputFactory.newInstance();
+        factory.setProperty(XMLInputFactory.IS_COALESCING, false);
+        XMLStreamReader reader = factory.createXMLStreamReader(new StringReader(documento));        
+        StAXOMBuilder builder = new StAXOMBuilder(reader);
+        final OMElement ome = builder.getDocumentElement();
         final Iterator<?> children = ome.getChildrenWithLocalName(WSLoteEnvio.NFE_ELEMENTO);
         while (children.hasNext()) {
             final OMElement omElement = (OMElement) children.next();

--- a/src/main/java/com/fincatto/nfe310/webservices/WSLoteEnvio.java
+++ b/src/main/java/com/fincatto/nfe310/webservices/WSLoteEnvio.java
@@ -5,7 +5,6 @@ import java.util.Iterator;
 import javax.xml.stream.XMLStreamException;
 
 import org.apache.axiom.om.OMElement;
-import org.apache.axiom.om.util.AXIOMUtil;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;


### PR DESCRIPTION
Eu acabei verificando um erro para envio de lote onde era retirado o campo CDATA da tag qrCode, o problema é na hora de construir o OMElement, na linha: final OMElement ome = AXIOMUtil.stringToOM(documento);
Eu fiz uma solução mudando a forma de construir o OMElement para manter o campo CDATA.

final XMLInputFactory factory = XMLInputFactory.newInstance();
factory.setProperty(XMLInputFactory.IS_COALESCING, false);
XMLStreamReader reader = factory.createXMLStreamReader(new StringReader(documento));
StAXOMBuilder builder = new StAXOMBuilder(reader);
final OMElement ome = builder.getDocumentElement();

A propriedade IS_COALESCING como false que mantém o CDATA.
Segue o pull request.