### PR TITLE
Alteração para permitir a consulta de lotes em ambiente de contingencia

### DIFF
--- a/src/main/java/com/fincatto/nfe310/webservices/WSLoteConsulta.java
+++ b/src/main/java/com/fincatto/nfe310/webservices/WSLoteConsulta.java
@@ -49,7 +49,7 @@ class WSLoteConsulta {
 		final NfeRetAutorizacaoStub.NfeDadosMsg dados = new NfeRetAutorizacaoStub.NfeDadosMsg();
 		dados.setExtraElement(omElement);
 
-		final NFAutorizador31 autorizador = NFAutorizador31.valueOfCodigoUF(uf);
+		final NFAutorizador31 autorizador = NFAutorizador31.valueOfTipoEmissao(this.config.getTipoEmissao(), this.config.getCUF());
 		final String urlWebService = NFModelo.NFCE.equals(modelo) ? autorizador.getNfceRetAutorizacao(this.config.getAmbiente()) : autorizador.getNfeRetAutorizacao(this.config.getAmbiente());
 		if (urlWebService == null) {
 			throw new IllegalArgumentException("Nao foi possivel encontrar URL para RetAutorizacao " + modelo.name() + ", autorizador " + autorizador.name());


### PR DESCRIPTION
Observei que a consulta por chave não retornava a rejeição quando a nota não era autorizada em contingencia. Retornava "Rejeição 217: NF-e não consta na base de dados da SEFAZ". Ao consultar por lote é possível obter o estado da nota nas situações onde não é autorizada.
(PR com correção da tabulação que estava sendo entendida como espaço)