### PR TITLE
Ajuste na classe para funcionamento do manifesto.

### DIFF
--- a/src/main/java/com/fincatto/nfe310/classes/evento/manifestacaodestinatario/NFInfoManifestacaoDestinatario.java
+++ b/src/main/java/com/fincatto/nfe310/classes/evento/manifestacaodestinatario/NFInfoManifestacaoDestinatario.java
@@ -1,9 +1,13 @@
 package com.fincatto.nfe310.classes.evento.manifestacaodestinatario;
 
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
 
 import com.fincatto.nfe310.classes.evento.NFTipoEvento;
 
+@Root(name = "detEvento")
+@Namespace(reference = "http://www.portalfiscal.inf.br/nfe")
 public class NFInfoManifestacaoDestinatario extends NFTipoEvento {
 
     @Element(name = "xJust", required = false)

--- a/src/test/java/com/fincatto/nfe310/classes/evento/manifestacaodestinatario/NFEventoManifestacaoTest.java
+++ b/src/test/java/com/fincatto/nfe310/classes/evento/manifestacaodestinatario/NFEventoManifestacaoTest.java
@@ -20,7 +20,7 @@ public class NFEventoManifestacaoTest {
     @Test
     public void deveObterVersaoComoFoiSetado() {
         final NFEventoManifestacaoDestinatario eventoManifestacaoDestinatario = new NFEventoManifestacaoDestinatario();
-        final BigDecimal versao = new BigDecimal("3.10");
+        final BigDecimal versao = new BigDecimal("1.00");
         eventoManifestacaoDestinatario.setVersao(versao);
         Assert.assertEquals(versao.toString(), eventoManifestacaoDestinatario.getVersao());
     }
@@ -36,7 +36,7 @@ public class NFEventoManifestacaoTest {
     public void devePermitirAssinaturaNula() {
         final NFEventoManifestacaoDestinatario eventoManifestacaoDestinatario = new NFEventoManifestacaoDestinatario();
         eventoManifestacaoDestinatario.setInfoEvento(FabricaDeObjetosFake.getNFInfoEventoManifestacaoDestinatario());
-        eventoManifestacaoDestinatario.setVersao(new BigDecimal("3.10"));
+        eventoManifestacaoDestinatario.setVersao(new BigDecimal("1.00"));
         eventoManifestacaoDestinatario.toString();
     }
 
@@ -44,7 +44,7 @@ public class NFEventoManifestacaoTest {
     public void naoDevePermitirInfoEventoNulo() {
         final NFEventoManifestacaoDestinatario eventoManifestacaoDestinatario = new NFEventoManifestacaoDestinatario();
         eventoManifestacaoDestinatario.setAssinatura("assinatura");
-        eventoManifestacaoDestinatario.setVersao(new BigDecimal("3.10"));
+        eventoManifestacaoDestinatario.setVersao(new BigDecimal("1.00"));
         eventoManifestacaoDestinatario.toString();
     }
 
@@ -58,7 +58,7 @@ public class NFEventoManifestacaoTest {
 
     @Test
     public void deveGerarXMLDeAcordoComOPadraoEstabelecido() {
-        final String xmlEsperado = "<NFEventoManifestacaoDestinatario versao=\"3.10\"><infEvento Id=\"hluU2zKt4QK5bEktOiGfpZw64535p2A4Z5m5egLQbMpjnCH48c1aw6\"><cOrgao>42</cOrgao><tpAmb>2</tpAmb><CNPJ>12345678901234</CNPJ><chNFe>81568004734874930428983724940883089298523837</chNFe><dhEvento>2014-01-01T10:10:10-02:00</dhEvento><tpEvento>123456</tpEvento><nSeqEvento>2</nSeqEvento><verEvento>2.49</verEvento><detEvento versao=\"3.10\"><descEvento>Operacao nao Realizada</descEvento><xJust>Justificativa qualquer coisa</xJust></detEvento></infEvento></NFEventoManifestacaoDestinatario>";
+        final String xmlEsperado = "<NFEventoManifestacaoDestinatario versao=\"1.00\"><infEvento Id=\"hluU2zKt4QK5bEktOiGfpZw64535p2A4Z5m5egLQbMpjnCH48c1aw6\"><cOrgao>42</cOrgao><tpAmb>2</tpAmb><CNPJ>12345678901234</CNPJ><chNFe>81568004734874930428983724940883089298523837</chNFe><dhEvento>2014-01-01T10:10:10-02:00</dhEvento><tpEvento>123456</tpEvento><nSeqEvento>2</nSeqEvento><verEvento>2.49</verEvento><detEvento versao=\"1.00\"><descEvento>Operacao nao Realizada</descEvento><xJust>Justificativa qualquer coisa</xJust></detEvento></infEvento></NFEventoManifestacaoDestinatario>";
         Assert.assertEquals(xmlEsperado, FabricaDeObjetosFake.getNFEventoManifestacaoDestinatario().toString());
     }
 }


### PR DESCRIPTION
A SEFAZ estava retornado erro na estrutura ao tentar comunicar o XML. 