### PR TITLE
Sugestão para gerar a cadeia de certificados da unidade certificadora

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,15 @@ public static void main(String args[]){
 }
 ```
 
+##Sugestão
+Para a cadeia de certificados da SEFAZ necessária para o acesso, utilize a cadeia da unidade certificadora que emitiu o seu certificado. Após fazer o download da cadeia de certificado você obterá um arquivo no formato .cer como o exemplo abaixo:
+* certificado.cer
+
+Com este arquivo é possível gerar a sua chave jks através do seguinte comando:
+<b>
+keytool -import -alias certificado -keystore certificado.jks -file /path_arquivo/certificado.cer
+</b>
+
 ## Licença
 Apache 2.0
 


### PR DESCRIPTION
Tentamos durante 3 dias executar o método que faz a consulta do status do webService para retornar a mensagem:
"107 serviço em operação"

Não obtivemos êxito sempre recebiamos este erro na execução:

`
16:45:27,882 INFO [org.apache.axis2.transport.http.HTTPSender] (http--0.0.0.0-8080-4) Unable to sendViaPost to url[https://nfe-homologacao.svrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico2.asmx]: org.apache.axis2.AxisFault: Connection has been shutdown: javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
at org.apache.axis2.AxisFault.makeFault(AxisFault.java:430) [axis2-kernel-1.6.4.jar:1.6.4]
at org.apache.axis2.transport.http.SOAPMessageFormatter.writeTo(SOAPMessageFormatter.java:78) [axis2-kernel-1.6.4.jar:1.6.4]
.....
Caused by: com.ctc.wstx.exc.WstxIOException: Connection has been shutdown: javax.net.ssl.SSLHandshakeException: sun.security.validator.ValidatorException: PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target
at com.ctc.wstx.sw.BaseStreamWriter.flush(BaseStreamWriter.java:261) [woodstox-core-asl-4.2.0.jar:4.2.0]
`

Depois de algumas pesquisas e ver alguns stacks fizemos o seguinte trocamos nossa chave jks gerada através do certificado da AC Raiz do icpBrasil pelo certificado da empresa que emitiu o nosso certificado e ai conseguimos consumir o serviço.

Acreditamos que outras pessoas podem ter passado pelo mesmo problema que nós. Então segue a nossa sugestão de adição desta informação ao README.md
