### PR TITLE
Inclusão de converter para Serializar objeto NFAmbiente

### DIFF
--- a/src/main/java/com/fincatto/nfe310/classes/NFAmbiente.java
+++ b/src/main/java/com/fincatto/nfe310/classes/NFAmbiente.java
@@ -1,5 +1,14 @@
 package com.fincatto.nfe310.classes;
 
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Root;
+import org.simpleframework.xml.convert.Convert;
+
+import com.fincatto.nfe310.converters.NFAmbienteConverter;
+
+@Element
+@Convert(NFAmbienteConverter.class)
+@Root(name = "tpAmb")
 public enum NFAmbiente {
 
     PRODUCAO("1", "Produ\u00e7\u00e3o"),

--- a/src/main/java/com/fincatto/nfe310/classes/NFAmbiente.java
+++ b/src/main/java/com/fincatto/nfe310/classes/NFAmbiente.java
@@ -11,32 +11,32 @@ import com.fincatto.nfe310.converters.NFAmbienteConverter;
 @Root(name = "tpAmb")
 public enum NFAmbiente {
 
-    PRODUCAO("1", "Produ\u00e7\u00e3o"),
-    HOMOLOGACAO("2", "Homologa\u00e7\u00e3o");
+	PRODUCAO("1", "Produ\u00e7\u00e3o"),
+	HOMOLOGACAO("2", "Homologa\u00e7\u00e3o");
 
-    private final String codigo;
-    private final String descricao;
+	private final String codigo;
+	private final String descricao;
 
-    NFAmbiente(final String codigo, final String descricao) {
-        this.codigo = codigo;
-        this.descricao = descricao;
-    }
+	NFAmbiente(final String codigo, final String descricao) {
+		this.codigo = codigo;
+		this.descricao = descricao;
+	}
 
-    public String getCodigo() {
-        return this.codigo;
-    }
+	public String getCodigo() {
+		return this.codigo;
+	}
 
-    public static NFAmbiente valueOfCodigo(final String codigo) {
-        for (NFAmbiente ambiente : NFAmbiente.values()) {
-            if (ambiente.getCodigo().equalsIgnoreCase(codigo)) {
-                return ambiente;
-            }
-        }
-        return null;
-    }
+	public static NFAmbiente valueOfCodigo(final String codigo) {
+		for (NFAmbiente ambiente : NFAmbiente.values()) {
+			if (ambiente.getCodigo().equalsIgnoreCase(codigo)) {
+				return ambiente;
+			}
+		}
+		return null;
+	}
 
-    @Override
-    public String toString() {
-        return codigo + " - " + descricao;
-    }
+	@Override
+	public String toString() {
+		return codigo + " - " + descricao;
+	}
 }

--- a/src/main/java/com/fincatto/nfe310/converters/NFAmbienteConverter.java
+++ b/src/main/java/com/fincatto/nfe310/converters/NFAmbienteConverter.java
@@ -1,0 +1,24 @@
+package com.fincatto.nfe310.converters;
+
+import org.simpleframework.xml.convert.Converter;
+import org.simpleframework.xml.stream.InputNode;
+import org.simpleframework.xml.stream.OutputNode;
+import com.fincatto.nfe310.classes.NFAmbiente;
+
+public class NFAmbienteConverter implements Converter<NFAmbiente> {
+
+	@Override
+	public NFAmbiente read(InputNode node) throws Exception {
+		// TODO Auto-generated method stub
+		NFAmbiente nfAmbiente = null;
+		for (NFAmbiente nfAmbienteAux : NFAmbiente.values()) {
+			nfAmbiente = nfAmbienteAux;
+		}
+		return nfAmbiente;
+	}
+
+	@Override
+	public void write(OutputNode node, NFAmbiente value) throws Exception {
+		node.setValue(value.toString());
+	}
+}

--- a/src/main/java/com/fincatto/nfe310/converters/NFAmbienteConverter.java
+++ b/src/main/java/com/fincatto/nfe310/converters/NFAmbienteConverter.java
@@ -9,7 +9,6 @@ public class NFAmbienteConverter implements Converter<NFAmbiente> {
 
 	@Override
 	public NFAmbiente read(InputNode node) throws Exception {
-		// TODO Auto-generated method stub
 		NFAmbiente nfAmbiente = null;
 		for (NFAmbiente nfAmbienteAux : NFAmbiente.values()) {
 			nfAmbiente = nfAmbienteAux;
@@ -19,6 +18,6 @@ public class NFAmbienteConverter implements Converter<NFAmbiente> {
 
 	@Override
 	public void write(OutputNode node, NFAmbiente value) throws Exception {
-		node.setValue(value.toString());
+		node.setValue(value.getCodigo());
 	}
 }


### PR DESCRIPTION
Criada a classe NFAmbienteConverter para permitir a correta conversão do enum NFAmbiente a fim de serializar o objeto NFProtocolo para utiliza-lo na geração da danfe.

@lucas85cunha 
@ambroiler