### PR TITLE
Modificando as URL's de envio de Cupom do estado da PB

### DIFF
--- a/src/main/java/com/fincatto/nfe310/classes/NFUnidadeFederativa.java
+++ b/src/main/java/com/fincatto/nfe310/classes/NFUnidadeFederativa.java
@@ -19,7 +19,7 @@ public enum NFUnidadeFederativa {
     MS("MS", "Mato Grosso do Sul", "50", "http://www.dfe.ms.gov.br/nfce/qrcode", "http://www.dfe.ms.gov.br/nfce/qrcode"),
     MG("MG", "Minas Gerais", "31"),
     PA("PA", "Par\u00E1", "15", "https://appnfc.sefa.pa.gov.br/portal-homologacao/view/consultas/nfce/nfceForm.seam", "https://appnfc.sefa.pa.gov.br/portal/view/consultas/nfce/nfceForm.seam"),
-    PB("PB", "Paraiba", "25", "www.receita.pb.gov.br/nfcehom", "www.receita.pb.gov.br/nfce"),
+    PB("PB", "Paraiba", "25", "https://www.receita.pb.gov.br/nfcehom", "https://www.receita.pb.gov.br/nfce"),
     PR("PR", "Paran\u00E1", "41", "http://www.dfeportal.fazenda.pr.gov.br/dfe-portal/rest/servico/consultaNFCe", "http://www.dfeportal.fazenda.pr.gov.br/dfe-portal/rest/servico/consultaNFCe"),
     PE("PE", "Pernambuco", "26", "http://nfcehomolog.sefaz.pe.gov.br/nfce-web/consultarNFCe", "http://nfce.sefaz.pe.gov.br/nfce-web/consultarNFCe"),
     PI("PI", "Piau\u00ED", "22", "http://webas.sefaz.pi.gov.br/nfceweb-homologacao/consultarNFCe.jsf", "http://webas.sefaz.pi.gov.br/nfceweb/consultarNFCe.jsf"),


### PR DESCRIPTION
As URL's para a geração de QRCode do cupom para a PB foram alteradas. O http/https é obrigatório.

Homologação: https://www.receita.pb.gov.br/nfcehom
Produção: https://www.receita.pb.gov.br/nfce

Fonte: http://nfce.encat.org/desenvolvedor/qrcode/