### PR TITLE
Adicionando autorizador para envio de notas nas contingências FSDA e offline

### DIFF
--- a/src/main/java/com/fincatto/nfe310/classes/NFAutorizador31.java
+++ b/src/main/java/com/fincatto/nfe310/classes/NFAutorizador31.java
@@ -1625,6 +1625,8 @@ public enum NFAutorizador31 {
 
     public static NFAutorizador31 valueOfTipoEmissao(final NFTipoEmissao tpEmissao, final NFUnidadeFederativa uf) {
         switch (tpEmissao) {
+        	case CONTIGENCIA_OFFLINE:
+        	case CONTINGENCIA_FSDA:
             case EMISSAO_NORMAL:
                 return NFAutorizador31.valueOfCodigoUF(uf);
             case CONTINGENCIA_SVCRS:

--- a/src/test/java/com/fincatto/nfe310/classes/NFAutorizador31Test.java
+++ b/src/test/java/com/fincatto/nfe310/classes/NFAutorizador31Test.java
@@ -489,4 +489,14 @@ public class NFAutorizador31Test {
         final List<NFUnidadeFederativa> ufsDaSVRS = Arrays.asList(NFUnidadeFederativa.AC, NFUnidadeFederativa.AL, NFUnidadeFederativa.AP, NFUnidadeFederativa.DF, NFUnidadeFederativa.ES, NFUnidadeFederativa.PA, NFUnidadeFederativa.PB, NFUnidadeFederativa.RJ, NFUnidadeFederativa.RN, NFUnidadeFederativa.RO, NFUnidadeFederativa.RR, NFUnidadeFederativa.SC, NFUnidadeFederativa.SE, NFUnidadeFederativa.TO);
         Assert.assertTrue(ufsDaSVRS.equals(Arrays.asList(NFAutorizador31.SVRS.getUFs())));
     }
+    
+    @Test
+    public void deveObterEmissorNormalCasoEstejaContingenciaFSDA() {
+        Assert.assertEquals(NFAutorizador31.RS, NFAutorizador31.valueOfTipoEmissao(NFTipoEmissao.CONTINGENCIA_FSDA, NFUnidadeFederativa.RS));
+    }
+    
+    @Test
+    public void deveObterEmissorNormalCasoEstejaContingenciaOffline() {
+        Assert.assertEquals(NFAutorizador31.RS, NFAutorizador31.valueOfTipoEmissao(NFTipoEmissao.CONTIGENCIA_OFFLINE, NFUnidadeFederativa.RS));
+    }
 }


### PR DESCRIPTION
1) Adicionando autorizador para envio de notas nas contingências fsda e offline; 
2) Adicionando testes