### PR TITLE
 Retira static do método getVersao em configurações da Nota, para poder configurar com a nota 4.00

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/nfe/NFeConfig.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe/NFeConfig.java
@@ -33,7 +33,11 @@ public abstract class NFeConfig extends DFConfig {
         return NFTipoEmissao.EMISSAO_NORMAL;
     }
 
-    public static String getVersao() {
+    /**
+     * Retorna a versão do XML na receita.
+     * @return versão nota fiscal
+     */
+    public String getVersao() {
         return "3.10";
     }
 }

--- a/src/main/java/com/fincatto/documentofiscal/nfe310/webservices/WSLoteConsulta.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe310/webservices/WSLoteConsulta.java
@@ -1,15 +1,5 @@
 package com.fincatto.documentofiscal.nfe310.webservices;
 
-import java.math.BigDecimal;
-import java.rmi.RemoteException;
-
-import org.apache.axiom.om.OMElement;
-import org.apache.axiom.om.util.AXIOMUtil;
-import org.simpleframework.xml.core.Persister;
-import org.simpleframework.xml.stream.Format;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.nfe.NFeConfig;
 import com.fincatto.documentofiscal.nfe310.classes.NFAutorizador31;
@@ -18,6 +8,15 @@ import com.fincatto.documentofiscal.nfe310.classes.lote.consulta.NFLoteConsultaR
 import com.fincatto.documentofiscal.nfe310.webservices.gerado.NfeRetAutorizacaoStub;
 import com.fincatto.documentofiscal.nfe310.webservices.gerado.NfeRetAutorizacaoStub.NfeRetAutorizacaoLoteResult;
 import com.fincatto.documentofiscal.transformers.DFRegistryMatcher;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.util.AXIOMUtil;
+import org.simpleframework.xml.core.Persister;
+import org.simpleframework.xml.stream.Format;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigDecimal;
+import java.rmi.RemoteException;
 
 class WSLoteConsulta {
 
@@ -41,7 +40,7 @@ class WSLoteConsulta {
     private OMElement efetuaConsulta(final OMElement omElement, final DFModelo modelo) throws RemoteException {
         final NfeRetAutorizacaoStub.NfeCabecMsg cabec = new NfeRetAutorizacaoStub.NfeCabecMsg();
         cabec.setCUF(this.config.getCUF().getCodigoIbge());
-        cabec.setVersaoDados(NFeConfig.getVersao());
+        cabec.setVersaoDados(this.config.getVersao());
 
         final NfeRetAutorizacaoStub.NfeCabecMsgE cabecE = new NfeRetAutorizacaoStub.NfeCabecMsgE();
         cabecE.setNfeCabecMsg(cabec);
@@ -63,7 +62,7 @@ class WSLoteConsulta {
         final NFLoteConsulta consulta = new NFLoteConsulta();
         consulta.setRecibo(numeroRecibo);
         consulta.setAmbiente(this.config.getAmbiente());
-        consulta.setVersao(new BigDecimal(NFeConfig.getVersao()));
+        consulta.setVersao(new BigDecimal(this.config.getVersao()));
         return consulta;
     }
 }

--- a/src/main/java/com/fincatto/documentofiscal/nfe310/webservices/WSLoteEnvio.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe310/webservices/WSLoteEnvio.java
@@ -1,18 +1,5 @@
 package com.fincatto.documentofiscal.nfe310.webservices;
 
-import java.io.StringReader;
-import java.util.Iterator;
-
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamReader;
-
-import org.apache.axiom.om.OMElement;
-import org.apache.axiom.om.impl.builder.StAXOMBuilder;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.assinatura.AssinaturaDigital;
 import com.fincatto.documentofiscal.nfe.NFeConfig;
@@ -32,6 +19,17 @@ import com.fincatto.documentofiscal.nfe310.webservices.gerado.NfeAutorizacaoStub
 import com.fincatto.documentofiscal.parsers.DFParser;
 import com.fincatto.documentofiscal.persister.DFPersister;
 import com.fincatto.documentofiscal.validadores.xsd.XMLValidador;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.impl.builder.StAXOMBuilder;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import java.io.StringReader;
+import java.util.Iterator;
 
 class WSLoteEnvio {
 
@@ -126,7 +124,7 @@ class WSLoteEnvio {
     private NfeCabecMsgE getCabecalhoSOAP() {
         final NfeCabecMsg cabecalho = new NfeCabecMsg();
         cabecalho.setCUF(this.config.getCUF().getCodigoIbge());
-        cabecalho.setVersaoDados(NFeConfig.getVersao());
+        cabecalho.setVersaoDados(this.config.getVersao());
         final NfeCabecMsgE cabecalhoSOAP = new NfeCabecMsgE();
         cabecalhoSOAP.setNfeCabecMsg(cabecalho);
         return cabecalhoSOAP;

--- a/src/main/java/com/fincatto/documentofiscal/nfe310/webservices/WSStatusConsulta.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe310/webservices/WSStatusConsulta.java
@@ -1,14 +1,5 @@
 package com.fincatto.documentofiscal.nfe310.webservices;
 
-import java.rmi.RemoteException;
-
-import org.apache.axiom.om.OMElement;
-import org.apache.axiom.om.util.AXIOMUtil;
-import org.simpleframework.xml.core.Persister;
-import org.simpleframework.xml.stream.Format;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.DFUnidadeFederativa;
 import com.fincatto.documentofiscal.nfe.NFeConfig;
@@ -18,6 +9,14 @@ import com.fincatto.documentofiscal.nfe310.classes.statusservico.consulta.NFStat
 import com.fincatto.documentofiscal.nfe310.webservices.statusservico.consulta.NfeStatusServico2Stub;
 import com.fincatto.documentofiscal.nfe310.webservices.statusservico.consulta.NfeStatusServicoStub;
 import com.fincatto.documentofiscal.transformers.DFRegistryMatcher;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.util.AXIOMUtil;
+import org.simpleframework.xml.core.Persister;
+import org.simpleframework.xml.stream.Format;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.rmi.RemoteException;
 
 class WSStatusConsulta {
 
@@ -44,7 +43,7 @@ class WSStatusConsulta {
         final NFStatusServicoConsulta consStatServ = new NFStatusServicoConsulta();
         consStatServ.setUf(unidadeFederativa);
         consStatServ.setAmbiente(this.config.getAmbiente());
-        consStatServ.setVersao(NFeConfig.getVersao());
+        consStatServ.setVersao(this.config.getVersao());
         consStatServ.setServico(WSStatusConsulta.NOME_SERVICO);
         return consStatServ;
     }
@@ -52,7 +51,7 @@ class WSStatusConsulta {
     private OMElement efetuaConsultaStatus(final OMElement omElement, final DFUnidadeFederativa unidadeFederativa, final DFModelo modelo) throws RemoteException {
         final NfeStatusServico2Stub.NfeCabecMsg cabec = new NfeStatusServico2Stub.NfeCabecMsg();
         cabec.setCUF(unidadeFederativa.getCodigoIbge());
-        cabec.setVersaoDados(NFeConfig.getVersao());
+        cabec.setVersaoDados(this.config.getVersao());
 
         final NfeStatusServico2Stub.NfeCabecMsgE cabecEnv = new NfeStatusServico2Stub.NfeCabecMsgE();
         cabecEnv.setNfeCabecMsg(cabec);
@@ -72,7 +71,7 @@ class WSStatusConsulta {
     private OMElement efetuaConsultaStatusBahia(final OMElement omElement) throws RemoteException {
         final NfeStatusServicoStub.NfeCabecMsg cabec = new NfeStatusServicoStub.NfeCabecMsg();
         cabec.setCUF(DFUnidadeFederativa.BA.getCodigoIbge());
-        cabec.setVersaoDados(NFeConfig.getVersao());
+        cabec.setVersaoDados(this.config.getVersao());
 
         final NfeStatusServicoStub.NfeCabecMsgE cabecEnv = new NfeStatusServicoStub.NfeCabecMsgE();
         cabecEnv.setNfeCabecMsg(cabec);

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/webservices/WSLoteConsulta.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/webservices/WSLoteConsulta.java
@@ -1,15 +1,5 @@
 package com.fincatto.documentofiscal.nfe400.webservices;
 
-import java.math.BigDecimal;
-import java.rmi.RemoteException;
-
-import org.apache.axiom.om.OMElement;
-import org.apache.axiom.om.util.AXIOMUtil;
-import org.simpleframework.xml.core.Persister;
-import org.simpleframework.xml.stream.Format;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.nfe.NFeConfig;
 import com.fincatto.documentofiscal.nfe400.classes.NFAutorizador400;
@@ -18,6 +8,15 @@ import com.fincatto.documentofiscal.nfe400.classes.lote.consulta.NFLoteConsultaR
 import com.fincatto.documentofiscal.nfe400.webservices.gerado.NFeRetAutorizacao4Stub;
 import com.fincatto.documentofiscal.nfe400.webservices.gerado.NFeRetAutorizacao4Stub.NfeResultMsg;
 import com.fincatto.documentofiscal.transformers.DFRegistryMatcher;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.util.AXIOMUtil;
+import org.simpleframework.xml.core.Persister;
+import org.simpleframework.xml.stream.Format;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.math.BigDecimal;
+import java.rmi.RemoteException;
 
 class WSLoteConsulta {
 
@@ -55,7 +54,7 @@ class WSLoteConsulta {
         final NFLoteConsulta consulta = new NFLoteConsulta();
         consulta.setRecibo(numeroRecibo);
         consulta.setAmbiente(this.config.getAmbiente());
-        consulta.setVersao(new BigDecimal(NFeConfig.getVersao()));
+        consulta.setVersao(new BigDecimal(this.config.getVersao()));
         return consulta;
     }
 }

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/webservices/WSStatusConsulta.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/webservices/WSStatusConsulta.java
@@ -1,14 +1,5 @@
 package com.fincatto.documentofiscal.nfe400.webservices;
 
-import java.rmi.RemoteException;
-
-import org.apache.axiom.om.OMElement;
-import org.apache.axiom.om.util.AXIOMUtil;
-import org.simpleframework.xml.core.Persister;
-import org.simpleframework.xml.stream.Format;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.DFUnidadeFederativa;
 import com.fincatto.documentofiscal.nfe.NFeConfig;
@@ -17,6 +8,14 @@ import com.fincatto.documentofiscal.nfe400.classes.statusservico.consulta.NFStat
 import com.fincatto.documentofiscal.nfe400.classes.statusservico.consulta.NFStatusServicoConsultaRetorno;
 import com.fincatto.documentofiscal.nfe400.webservices.statusservico.consulta.NfeStatusServico4Stub;
 import com.fincatto.documentofiscal.transformers.DFRegistryMatcher;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.util.AXIOMUtil;
+import org.simpleframework.xml.core.Persister;
+import org.simpleframework.xml.stream.Format;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.rmi.RemoteException;
 
 class WSStatusConsulta {
 
@@ -42,7 +41,7 @@ class WSStatusConsulta {
         final NFStatusServicoConsulta consStatServ = new NFStatusServicoConsulta();
         consStatServ.setUf(unidadeFederativa);
         consStatServ.setAmbiente(this.config.getAmbiente());
-        consStatServ.setVersao(NFeConfig.getVersao());
+        consStatServ.setVersao(this.config.getVersao());
         consStatServ.setServico(WSStatusConsulta.NOME_SERVICO);
         return consStatServ;
     }


### PR DESCRIPTION
 Retira static do método getVersao em configurações da Nota, para poder configurar com a nota 4.00 e evitar o erro:
<cStat>215</cStat><xMotivo>Falha no schema XML</xMotivo><cUF>41</cUF><dhRecbto>2018-03-02T08:32:21-03:00</dhRecbto><xObs>org.xml.sax.SAXParseException; lineNumber: 1; columnNumber: 72; cvc-pattern-valid: Value &apos;3.10&apos; is not facet-valid with respect to pattern &apos;4\.00&apos; for type &apos;TVerConsStatServ&apos;.</xObs>