### PR TITLE
Inclusão de método para passar o TimeZone na manifestação do destinatário

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/nfe310/webservices/WSFacade.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe310/webservices/WSFacade.java
@@ -6,6 +6,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
+import java.util.TimeZone;
 
 import org.apache.commons.httpclient.protocol.Protocol;
 
@@ -211,11 +212,25 @@ public class WSFacade {
      * @param tipoEvento tipo do evento da manifestacao do destinatario
      * @param motivo motivo do cancelamento
      * @param cnpj cnpj do autor do evento
+     * @param timeZone  timeZone a ser considerado para trabalhar com datas
+     * @return dados da manifestacao do destinatario da nota retornado pelo webservice
+     * @throws Exception caso nao consiga gerar o xml ou problema de conexao com o sefaz
+     */
+    public NFEnviaEventoRetorno manifestaDestinatarioNota(final String chave, final NFTipoEventoManifestacaoDestinatario tipoEvento, final String motivo, final String cnpj, TimeZone timeZone) throws Exception {
+        return this.wSManifestacaoDestinatario.manifestaDestinatarioNota(chave, tipoEvento, motivo, cnpj, timeZone);
+    }
+
+    /**
+     * Faz a manifestação do destinatário da nota
+     * @param chave chave de acesso da nota
+     * @param tipoEvento tipo do evento da manifestacao do destinatario
+     * @param motivo motivo do cancelamento
+     * @param cnpj cnpj do autor do evento
      * @return dados da manifestacao do destinatario da nota retornado pelo webservice
      * @throws Exception caso nao consiga gerar o xml ou problema de conexao com o sefaz
      */
     public NFEnviaEventoRetorno manifestaDestinatarioNota(final String chave, final NFTipoEventoManifestacaoDestinatario tipoEvento, final String motivo, final String cnpj) throws Exception {
-        return this.wSManifestacaoDestinatario.manifestaDestinatarioNota(chave, tipoEvento, motivo, cnpj);
+        return this.wSManifestacaoDestinatario.manifestaDestinatarioNota(chave, tipoEvento, motivo, cnpj, null);
     }
 
     /**

--- a/src/main/java/com/fincatto/documentofiscal/nfe310/webservices/WSManifestacaoDestinatario.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe310/webservices/WSManifestacaoDestinatario.java
@@ -21,6 +21,7 @@ import org.slf4j.LoggerFactory;
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 import java.util.Collections;
+import java.util.TimeZone;
 
 public class WSManifestacaoDestinatario {
 
@@ -37,8 +38,8 @@ public class WSManifestacaoDestinatario {
         return new DFPersister().read(NFEnviaEventoRetorno.class, omElementResult.toString());
     }
 
-    NFEnviaEventoRetorno manifestaDestinatarioNota(final String chaveAcesso, final NFTipoEventoManifestacaoDestinatario tipoEvento, final String motivo, final String cnpj) throws Exception {
-        final String manifestacaoDestinatarioNotaXML = this.gerarDadosManifestacaoDestinatario(chaveAcesso, tipoEvento, motivo, cnpj).toString();
+    NFEnviaEventoRetorno manifestaDestinatarioNota(final String chaveAcesso, final NFTipoEventoManifestacaoDestinatario tipoEvento, final String motivo, final String cnpj, TimeZone timeZone) throws Exception {
+        final String manifestacaoDestinatarioNotaXML = this.gerarDadosManifestacaoDestinatario(chaveAcesso, tipoEvento, motivo, cnpj, timeZone).toString();
         final String xmlAssinado = new AssinaturaDigital(this.config).assinarDocumento(manifestacaoDestinatarioNotaXML);
         final OMElement omElementResult = this.efetuaManifestacaoDestinatario(xmlAssinado, chaveAcesso);
         return new DFPersister().read(NFEnviaEventoRetorno.class, omElementResult.toString());
@@ -70,7 +71,7 @@ public class WSManifestacaoDestinatario {
         return omElementResult;
     }
 
-    private NFEnviaEventoManifestacaoDestinatario gerarDadosManifestacaoDestinatario(final String chaveAcesso, final NFTipoEventoManifestacaoDestinatario tipoEvento, final String motivo, final String cnpj) {
+    private NFEnviaEventoManifestacaoDestinatario gerarDadosManifestacaoDestinatario(final String chaveAcesso, final NFTipoEventoManifestacaoDestinatario tipoEvento, final String motivo, final String cnpj, TimeZone timeZone) {
         // final NotaFiscalChaveParser chaveParser = new NotaFiscalChaveParser(chaveAcesso);
 
         final NFInfoManifestacaoDestinatario manifestacaoDestinatario = new NFInfoManifestacaoDestinatario();
@@ -82,7 +83,11 @@ public class WSManifestacaoDestinatario {
         infoEvento.setAmbiente(this.config.getAmbiente());
         infoEvento.setChave(chaveAcesso);
         infoEvento.setCnpj(cnpj);
-        infoEvento.setDataHoraEvento(ZonedDateTime.now());
+        if(timeZone != null){
+            infoEvento.setDataHoraEvento(ZonedDateTime.now().withZoneSameInstant(timeZone.toZoneId()));
+        }else{
+            infoEvento.setDataHoraEvento(ZonedDateTime.now());
+        }
         infoEvento.setId(String.format("ID%s%s0%s", tipoEvento.getCodigo(), chaveAcesso, "1"));
         infoEvento.setNumeroSequencialEvento(1);
         infoEvento.setOrgao(DFUnidadeFederativa.RFB);

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/webservices/WSFacade.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/webservices/WSFacade.java
@@ -6,6 +6,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.CertificateException;
+import java.util.TimeZone;
 
 import com.fincatto.documentofiscal.nfe400.classes.evento.cartacorrecao.NFProtocoloEventoCartaCorrecao;
 import org.apache.commons.httpclient.protocol.Protocol;
@@ -233,11 +234,26 @@ public class WSFacade {
      * @param tipoEvento tipo do evento da manifestacao do destinatario
      * @param motivo motivo do cancelamento
      * @param cnpj cnpj do autor do evento
+     * @param timeZone  timeZone a ser considerado para trabalhar com datas
+     * @return dados da manifestacao do destinatario da nota retornado pelo webservice
+     * @throws Exception caso nao consiga gerar o xml ou problema de conexao com o sefaz
+     */
+    public NFEnviaEventoRetorno manifestaDestinatarioNota(final String chave, final NFTipoEventoManifestacaoDestinatario tipoEvento, final String motivo, final String cnpj, TimeZone timeZone) throws Exception {
+        System.out.println("MANIFESTACAO - Inicio - chamada metodo");
+        return this.wSManifestacaoDestinatario.manifestaDestinatarioNota(chave, tipoEvento, motivo, cnpj, timeZone);
+    }
+
+    /**
+     * Faz a manifestação do destinatário da nota
+     * @param chave chave de acesso da nota
+     * @param tipoEvento tipo do evento da manifestacao do destinatario
+     * @param motivo motivo do cancelamento
+     * @param cnpj cnpj do autor do evento
      * @return dados da manifestacao do destinatario da nota retornado pelo webservice
      * @throws Exception caso nao consiga gerar o xml ou problema de conexao com o sefaz
      */
     public NFEnviaEventoRetorno manifestaDestinatarioNota(final String chave, final NFTipoEventoManifestacaoDestinatario tipoEvento, final String motivo, final String cnpj) throws Exception {
-        return this.wSManifestacaoDestinatario.manifestaDestinatarioNota(chave, tipoEvento, motivo, cnpj);
+        return this.wSManifestacaoDestinatario.manifestaDestinatarioNota(chave, tipoEvento, motivo, cnpj, null);
     }
 
     /**

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/webservices/WSManifestacaoDestinatario.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/webservices/WSManifestacaoDestinatario.java
@@ -6,6 +6,8 @@ import java.util.Collections;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.util.AXIOMUtil;
 import java.time.ZonedDateTime;
+import java.util.TimeZone;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,8 +37,8 @@ public class WSManifestacaoDestinatario {
         return new DFPersister().read(NFEnviaEventoRetorno.class, omElementResult.toString());
     }
 
-    NFEnviaEventoRetorno manifestaDestinatarioNota(final String chaveAcesso, final NFTipoEventoManifestacaoDestinatario tipoEvento, final String motivo, final String cnpj) throws Exception {
-        final String manifestacaoDestinatarioNotaXML = this.gerarDadosManifestacaoDestinatario(chaveAcesso, tipoEvento, motivo, cnpj).toString();
+    NFEnviaEventoRetorno manifestaDestinatarioNota(final String chaveAcesso, final NFTipoEventoManifestacaoDestinatario tipoEvento, final String motivo, final String cnpj, TimeZone timeZone) throws Exception {
+        final String manifestacaoDestinatarioNotaXML = this.gerarDadosManifestacaoDestinatario(chaveAcesso, tipoEvento, motivo, cnpj, timeZone).toString();
         final String xmlAssinado = new AssinaturaDigital(this.config).assinarDocumento(manifestacaoDestinatarioNotaXML);
         final OMElement omElementResult = this.efetuaManifestacaoDestinatario(xmlAssinado, chaveAcesso);
         return new DFPersister().read(NFEnviaEventoRetorno.class, omElementResult.toString());
@@ -61,7 +63,7 @@ public class WSManifestacaoDestinatario {
         return omElementResult;
     }
 
-    private NFEnviaEventoManifestacaoDestinatario gerarDadosManifestacaoDestinatario(final String chaveAcesso, final NFTipoEventoManifestacaoDestinatario tipoEvento, final String motivo, final String cnpj) {
+    private NFEnviaEventoManifestacaoDestinatario gerarDadosManifestacaoDestinatario(final String chaveAcesso, final NFTipoEventoManifestacaoDestinatario tipoEvento, final String motivo, final String cnpj, TimeZone timeZone) {
         // final NotaFiscalChaveParser chaveParser = new NotaFiscalChaveParser(chaveAcesso);
 
         final NFInfoManifestacaoDestinatario manifestacaoDestinatario = new NFInfoManifestacaoDestinatario();
@@ -73,7 +75,11 @@ public class WSManifestacaoDestinatario {
         infoEvento.setAmbiente(this.config.getAmbiente());
         infoEvento.setChave(chaveAcesso);
         infoEvento.setCnpj(cnpj);
-        infoEvento.setDataHoraEvento(ZonedDateTime.now());
+        if(timeZone != null){
+            infoEvento.setDataHoraEvento(ZonedDateTime.now().withZoneSameInstant(timeZone.toZoneId()));
+        }else{
+            infoEvento.setDataHoraEvento(ZonedDateTime.now());
+        }
         infoEvento.setId(String.format("ID%s%s0%s", tipoEvento.getCodigo(), chaveAcesso, "1"));
         infoEvento.setNumeroSequencialEvento(1);
         infoEvento.setOrgao(DFUnidadeFederativa.RFB);

--- a/src/test/java/com/fincatto/documentofiscal/nfe310/FabricaDeObjetosFake.java
+++ b/src/test/java/com/fincatto/documentofiscal/nfe310/FabricaDeObjetosFake.java
@@ -36,6 +36,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.TimeZone;
 
 public class FabricaDeObjetosFake {
 
@@ -170,7 +171,8 @@ public class FabricaDeObjetosFake {
         infoEventoManifestacaoDestinatario.setChave("81568004734874930428983724940883089298523837");
         infoEventoManifestacaoDestinatario.setCnpj("12345678901234");
         infoEventoManifestacaoDestinatario.setCodigoEvento("123456");
-        infoEventoManifestacaoDestinatario.setDataHoraEvento(ZonedDateTime.of(LocalDateTime.from(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").parse("2014-01-01 10:10:10")), ZoneId.systemDefault()));
+        TimeZone timeZone = TimeZone.getTimeZone("America/Sao_Paulo");
+        infoEventoManifestacaoDestinatario.setDataHoraEvento(ZonedDateTime.of(LocalDateTime.from(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").parse("2014-01-01 10:10:10")), timeZone.toZoneId()));
         infoEventoManifestacaoDestinatario.setId("hluU2zKt4QK5bEktOiGfpZw64535p2A4Z5m5egLQbMpjnCH48c1aw6");
         infoEventoManifestacaoDestinatario.setNumeroSequencialEvento(2);
         infoEventoManifestacaoDestinatario.setOrgao(DFUnidadeFederativa.SC);

--- a/src/test/java/com/fincatto/documentofiscal/nfe400/FabricaDeObjetosFake.java
+++ b/src/test/java/com/fincatto/documentofiscal/nfe400/FabricaDeObjetosFake.java
@@ -39,6 +39,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.TimeZone;
 
 public class FabricaDeObjetosFake {
 
@@ -174,7 +175,8 @@ public class FabricaDeObjetosFake {
         infoEventoManifestacaoDestinatario.setChave("81568004734874930428983724940883089298523837");
         infoEventoManifestacaoDestinatario.setCnpj("12345678901234");
         infoEventoManifestacaoDestinatario.setCodigoEvento("123456");
-        infoEventoManifestacaoDestinatario.setDataHoraEvento(ZonedDateTime.of(LocalDateTime.from(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").parse("2014-01-01 10:10:10")), ZoneId.systemDefault()));
+        TimeZone timeZone = TimeZone.getTimeZone("America/Sao_Paulo");
+        infoEventoManifestacaoDestinatario.setDataHoraEvento(ZonedDateTime.of(LocalDateTime.from(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss").parse("2014-01-01 10:10:10")), timeZone.toZoneId()));
         infoEventoManifestacaoDestinatario.setId("hluU2zKt4QK5bEktOiGfpZw64535p2A4Z5m5egLQbMpjnCH48c1aw6");
         infoEventoManifestacaoDestinatario.setNumeroSequencialEvento(2);
         infoEventoManifestacaoDestinatario.setOrgao(DFUnidadeFederativa.SC);


### PR DESCRIPTION
Feita a inclusão do parâmetro de Timezone para que fosse possível informar o mesmo de acordo com a necessidade.
No nosso caso foi que o Servidor onde hospedamos o nosso sistema é do Google e la pega o UTC0, o que fazia com que ao pegar o ZonedDateTime.now() a string que iria para o Xml era `<dhEvento>2018-05-30T15:58:22Z</dhEvento>` que fica fora do padrão que deveria ser algo como `<dhEvento>2018-05-30T15:58:22-03:00</dhEvento>`

Att,