### PR TITLE
Tamanho campos pGLP, pGNn e pGNi - Nota Técnica 2016.002 - v 1.50.

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemProdutoCombustivel.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemProdutoCombustivel.java
@@ -69,15 +69,15 @@ public class NFNotaInfoItemProdutoCombustivel extends DFBase {
     }
 
     public void setPercentualGLPDerivadoPetroleo(final BigDecimal percentualGLPDerivadoPetroleo) {
-        this.percentualGLPDerivadoPetroleo = BigDecimalParser.tamanho1Com4CasasDecimais(percentualGLPDerivadoPetroleo, "Percentual GLP derivado petr\u00f3leo");
+        this.percentualGLPDerivadoPetroleo = BigDecimalParser.tamanho7ComAte4CasasDecimais(percentualGLPDerivadoPetroleo, "Percentual GLP derivado petr\u00f3leo");
     }
 
     public void setPercentualGasNaturalImportado(final BigDecimal percentualGasNaturalImportado) {
-        this.percentualGasNaturalImportado = BigDecimalParser.tamanho1Com4CasasDecimais(percentualGasNaturalImportado, "Percentual gas natural importado");
+        this.percentualGasNaturalImportado = BigDecimalParser.tamanho7ComAte4CasasDecimais(percentualGasNaturalImportado, "Percentual gas natural importado");
     }
 
     public void setPercentualGasNaturalNacional(final BigDecimal percentualGasNaturalNacional) {
-        this.percentualGasNaturalNacional = BigDecimalParser.tamanho1Com4CasasDecimais(percentualGasNaturalNacional, "Percentual gas natural nacional");
+        this.percentualGasNaturalNacional = BigDecimalParser.tamanho7ComAte4CasasDecimais(percentualGasNaturalNacional, "Percentual gas natural nacional");
     }
 
     public void setValorPartida(final BigDecimal valorPartida) {

--- a/src/main/java/com/fincatto/documentofiscal/validadores/BigDecimalParser.java
+++ b/src/main/java/com/fincatto/documentofiscal/validadores/BigDecimalParser.java
@@ -48,10 +48,6 @@ public abstract class BigDecimalParser {
         return BigDecimalParser.parse(valor, "0.00", 7, 2, info);
     }
 
-    public static String tamanho1Com4CasasDecimais(final BigDecimal valor, final String info) {
-        return BigDecimalParser.parse(valor, "0.0000", 6, 4, info);
-    }
-
     public static String tamanho7ComAte4CasasDecimais(final BigDecimal valor, final String info) {
         return BigDecimalParser.parse(valor, "0.00##", 8, 4, info);
     }

--- a/src/test/java/com/fincatto/documentofiscal/validadores/BigDecimalParserTest.java
+++ b/src/test/java/com/fincatto/documentofiscal/validadores/BigDecimalParserTest.java
@@ -133,14 +133,6 @@ public class BigDecimalParserTest {
         Assert.assertEquals("0.12", BigDecimalParser.tamanho4Com2CasasDecimais(new BigDecimal(".12"), ""));
     }
 
-    @Test
-    public void tamanho1Com4CasasDecimais() {
-        Assert.assertNull(BigDecimalParser.tamanho1Com4CasasDecimais(null, ""));
-        Assert.assertEquals("1.0000", BigDecimalParser.tamanho1Com4CasasDecimais(new BigDecimal("1.0000"), ""));
-        Assert.assertEquals("0.1178", BigDecimalParser.tamanho1Com4CasasDecimais(new BigDecimal(".1178"), ""));
-        Assert.assertEquals("0.1070", BigDecimalParser.tamanho1Com4CasasDecimais(new BigDecimal(".107"), ""));
-    }
-
     @Test(expected = NumberFormatException.class)
     public void naoDevePermitirExtrapolacaoDeInteiros() {
         BigDecimalParser.tamanho15Com2CasasDecimais(new BigDecimal("99999999999999.9"), "");


### PR DESCRIPTION
Alterado tamanho dos campos "percentualGLPDerivadoPetroleo", "percentualGasNaturalImportado" e "percentualGasNaturalNacional", da classe "NFNotaInfoItemProdutoCombustivel", de acordo com a Nota Técnica 2016.002 - v 1.50.