### PR TITLE
Retirado a obrigatoriedade do retorno de xMotivo.

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/NFProtocoloInfo.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/NFProtocoloInfo.java
@@ -35,7 +35,7 @@ public class NFProtocoloInfo extends DFBase {
     @Element(name = "cStat", required = true)
     private String status;
 
-    @Element(name = "xMotivo", required = true)
+    @Element(name = "xMotivo", required = false)
     private String motivo;
 
     public void setAmbiente(final DFAmbiente ambiente) {


### PR DESCRIPTION
Classe: src/main/java/com/fincatto/documentofiscal/nfe400/classes/NFProtocoloInfo.java

Como o código já está mapeado no enum NFRetornoStatus e neste enum já tem a descrição, foi retirado a obrigatoriedade de xMotivo estar preenchido no retorno do WS da SEFAZ.