### PR TITLE
Alteração Url QrCode Paraná

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/DFUnidadeFederativa.java
+++ b/src/main/java/com/fincatto/documentofiscal/DFUnidadeFederativa.java
@@ -35,7 +35,7 @@ public enum DFUnidadeFederativa {
             , "https://appnfc.sefa.pa.gov.br/portal/view/consultas/nfce/consultanfce.seam", "https://appnfc.sefa.pa.gov.br/portal/view/consultas/nfce/consultanfce.seam"),
     PB("PB", "Paraiba", "25", "http://www.receita.pb.gov.br/nfcehom", "http://www.receita.pb.gov.br/nfce"
             , "http://www.receita.pb.gov.br/nfcehom", "www.receita.pb.gov.br/nfce"),
-    PR("PR", "Paran\u00E1", "41", "http://www.dfeportal.fazenda.pr.gov.br/dfe-portal/rest/servico/consultaNFCe", "http://www.dfeportal.fazenda.pr.gov.br/dfe-portal/rest/servico/consultaNFCe"
+    PR("PR", "Paran\u00E1", "41", "http://www.fazenda.pr.gov.br/nfce/qrcode", "http://www.fazenda.pr.gov.br/nfce/qrcode"
             , "http://www.fazenda.pr.gov.br", "http://www.fazenda.pr.gov.br"),
     PE("PE", "Pernambuco", "26", "http://nfcehomolog.sefaz.pe.gov.br/nfce-web/consultarNFCe", "http://nfce.sefaz.pe.gov.br/nfce-web/consultarNFCe"
             , "", ""),

--- a/src/test/java/com/fincatto/documentofiscal/DFUnidadeFederativaTest.java
+++ b/src/test/java/com/fincatto/documentofiscal/DFUnidadeFederativaTest.java
@@ -96,8 +96,8 @@ public class DFUnidadeFederativaTest {
 
         Assert.assertEquals("PR", DFUnidadeFederativa.PR.getCodigo());
         Assert.assertEquals("41", DFUnidadeFederativa.PR.getCodigoIbge());
-        Assert.assertEquals("http://www.dfeportal.fazenda.pr.gov.br/dfe-portal/rest/servico/consultaNFCe", DFUnidadeFederativa.PR.getQrCodeHomologacao());
-        Assert.assertEquals("http://www.dfeportal.fazenda.pr.gov.br/dfe-portal/rest/servico/consultaNFCe", DFUnidadeFederativa.PR.getQrCodeProducao());
+        Assert.assertEquals("http://www.fazenda.pr.gov.br/nfce/qrcode", DFUnidadeFederativa.PR.getQrCodeHomologacao());
+        Assert.assertEquals("http://www.fazenda.pr.gov.br/nfce/qrcode", DFUnidadeFederativa.PR.getQrCodeProducao());
 
         Assert.assertEquals("RJ", DFUnidadeFederativa.RJ.getCodigo());
         Assert.assertEquals("33", DFUnidadeFederativa.RJ.getCodigoIbge());


### PR DESCRIPTION
Com o ajuste para emissão com o `NFGeraQRCode20`, acabou não levando um Workarround que existia no `NFGeraQRCode`  para a URL do Paraná, o que está certo pois era um Workarround. Mudei então as Url's do QRCode para o Paraná na classe `DFUnidadeFederativa`. Testado emissão de nota com o QRCode 2 para o Paraná Offline e Online, com essa nova URL montou certo e o link abriu a nota corretamente.

Para conhecimento, o Workarround que existia era esse:
```
/* FIXME TODO Workaround para corrigir erro :
         *<cStat>395</cStat><xMotivo>Endereco do site da UF da Consulta via QR-Code diverge do previsto. Novo endereco:http://www.fazenda.pr.gov.br/nfce/qrcode</xMotivo>
         * corrigir em DFUnidadeFederativa quando a URL da versao 3.10 do PR for desabilitada.
        */
        if(this.nota.getInfo().getIdentificacao().getUf().equals(DFUnidadeFederativa.PR) &&this.nota.getInfo().getVersao().equals("4.00")){
           url = "http://www.fazenda.pr.gov.br/nfce/qrcode";
        }
```