### PR TITLE
Obrigatoriedade atributos NotaConsultaRetorno

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/consulta/NFNotaConsultaRetorno.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/consulta/NFNotaConsultaRetorno.java
@@ -37,7 +37,7 @@ public class NFNotaConsultaRetorno extends DFBase {
     @Element(name = "dhRecbto", required = false)
     private LocalDateTime dataHoraRecibo;
 
-    @Element(name = "chNFe", required = true)
+    @Element(name = "chNFe", required = false)
     private String chave;
 
     @Element(name = "protNFe", required = false)

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/consulta/NFNotaConsultaRetorno.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/consulta/NFNotaConsultaRetorno.java
@@ -16,7 +16,7 @@ import com.fincatto.documentofiscal.nfe400.classes.evento.cancelamento.NFRetorno
 public class NFNotaConsultaRetorno extends DFBase {
     private static final long serialVersionUID = -5747228973124291025L;
 
-    @Attribute(name = "versao", required = true)
+    @Attribute(name = "versao", required = false)
     private String versao;
 
     @Element(name = "tpAmb", required = true)


### PR DESCRIPTION
Em algumas rejeições a sefaz do Paraná, não retorno os atributos versao e chNFe, sendo assim ocorre erro ao fazer o parce do XML, e consequentemente não sendo possível identificar o código de retorno.