### PR TITLE
Ajuste nas URLs relacionadas a autorização de NFC-e no Amazonas

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/NFAutorizador400.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/NFAutorizador400.java
@@ -56,12 +56,12 @@ public enum NFAutorizador400 {
 
         @Override
         public String getNfceAutorizacao(final DFAmbiente ambiente) {
-            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homnfce.sefaz.am.gov.br/nfce-services-nac/services/NfeAutorizacao" : "https://nfce.sefaz.am.gov.br/nfce-services/services/NfeAutorizacao";
+            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homnfce.sefaz.am.gov.br/nfce-services-nac/services/NfeAutorizacao4" : "https://nfce.sefaz.am.gov.br/nfce-services/services/NfeAutorizacao4";
         }
 
         @Override
         public String getNfceRetAutorizacao(final DFAmbiente ambiente) {
-            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homnfce.sefaz.am.gov.br/nfce-services-nac/services/NfeRetAutorizacao" : "https://nfce.sefaz.am.gov.br/nfce-services/services/NfeRetAutorizacao";
+            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homnfce.sefaz.am.gov.br/nfce-services-nac/services/NfeRetAutorizacao4" : "https://nfce.sefaz.am.gov.br/nfce-services/services/NfeRetAutorizacao4";
         }
 
         @Override


### PR DESCRIPTION
Testes de envio de notas à SEFAZ/AM funcionam com estas modificações. Sem elas ocorre um erro semelhante a este: The endpoint reference (EPR) for the Operation not found is https://nfce.sefaz.am.gov.br:443/nfce-services/services/NfeAutorizacao and the WSA Action = http://www.portalfiscal.inf.br/nfe/wsdl/.

Suspeito que isto ocorra porque o endpoint da versão 3.10 ainda está no ar e esteja sendo usado para tratar as requisições para a URL https://nfce.sefaz.am.gov.br:443/nfce-services/services/NfeAutorizacao.