### PR TITLE
Alteradas as URLs do QRCode para o Maranhão

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/DFUnidadeFederativa.java
+++ b/src/main/java/com/fincatto/documentofiscal/DFUnidadeFederativa.java
@@ -24,8 +24,8 @@ public enum DFUnidadeFederativa {
             , "http://homolog.sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe", "http://nfe.sefaz.go.gov.br/nfeweb/sites/nfce/danfeNFCe"),
     ES("ES", "Esp\u00EDrito Santo", "32", "http://homologacao.sefaz.es.gov.br/ConsultaNFCe/qrcode.aspx", "http://app.sefaz.es.gov.br/ConsultaNFCe/qrcode.aspx"
             , "http://homologacao.sefaz.es.gov.br/ConsultaNFCe", "http://app.sefaz.es.gov.br/ConsultaNFCe"),
-    MA("MA", "Maranh\u00E3o", "21", "http://www.hom.nfce.sefaz.ma.gov.br/portal/consultarNFCe.jsp", "http://www.nfce.sefaz.ma.gov.br/portal/consultaNFe.do?method=preFilterCupom&"
-            , "http://www.hom.nfce.sefaz.ma.gov.br/portal/consultarNFCe.jsp", "http://www.nfce.sefaz.ma.gov.br/portal/consultaNFe.do?method=preFilterCupom&"),
+    MA("MA", "Maranh\u00E3o", "21", "http://www.hom.nfce.sefaz.ma.gov.br/portal/consultarNFCe.jsp", "http://www.nfce.sefaz.ma.gov.br/portal/consultarNFCe.jsp"
+            , "http://www.hom.nfce.sefaz.ma.gov.br/portal/consultarNFCe.jsp", "http://www.sefaz.ma.gov.br/nfce/consulta/"),
     MT("MT", "Mato Grosso", "51", "http://homologacao.sefaz.mt.gov.br/nfce/consultanfce", "http://www.sefaz.mt.gov.br/nfce/consultanfce"
             , "http://homologacao.sefaz.mt.gov.br/nfce/consultanfce", "http://www.sefaz.mt.gov.br/nfce/consultanfce"),
     MS("MS", "Mato Grosso do Sul", "50", "http://www.dfe.ms.gov.br/nfce/qrcode", "http://www.dfe.ms.gov.br/nfce/qrcode"

--- a/src/test/java/com/fincatto/documentofiscal/DFUnidadeFederativaTest.java
+++ b/src/test/java/com/fincatto/documentofiscal/DFUnidadeFederativaTest.java
@@ -57,7 +57,7 @@ public class DFUnidadeFederativaTest {
         Assert.assertEquals("MA", DFUnidadeFederativa.MA.getCodigo());
         Assert.assertEquals("21", DFUnidadeFederativa.MA.getCodigoIbge());
         Assert.assertEquals("http://www.hom.nfce.sefaz.ma.gov.br/portal/consultarNFCe.jsp", DFUnidadeFederativa.MA.getQrCodeHomologacao());
-        Assert.assertEquals("http://www.nfce.sefaz.ma.gov.br/portal/consultaNFe.do?method=preFilterCupom&", DFUnidadeFederativa.MA.getQrCodeProducao());
+        Assert.assertEquals("http://www.nfce.sefaz.ma.gov.br/portal/consultarNFCe.jsp", DFUnidadeFederativa.MA.getQrCodeProducao());
 
         Assert.assertEquals("MG", DFUnidadeFederativa.MG.getCodigo());
         Assert.assertEquals("31", DFUnidadeFederativa.MG.getCodigoIbge());


### PR DESCRIPTION
Estava dando erro na versão do QRCode devido a URL está desatualizada.