### PR TITLE
Ajustes para funcionamento correto em MG

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/cancelamento/NFRetornoInfoCancelamento.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/cancelamento/NFRetornoInfoCancelamento.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 public class NFRetornoInfoCancelamento extends DFBase {
     private static final long serialVersionUID = -6506326636846776612L;
 
-    @Attribute(name = "ID", required = false)
+    @Attribute(name = "Id", required = false)
     private String identificador;
     
     @Element(name = "tpAmb")

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/consulta/NFProtocoloEvento.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/consulta/NFProtocoloEvento.java
@@ -13,7 +13,7 @@ import org.simpleframework.xml.Root;
 public class NFProtocoloEvento extends DFBase {
     private static final long serialVersionUID = -1075773716893722198L;
     
-    @Attribute(name = "versao")
+    @Attribute(name = "versao", required = false)
     private String versao;
     
     @Element(name = "evento")

--- a/src/main/java/com/fincatto/documentofiscal/transformers/DFLocalDateTimeTransformer.java
+++ b/src/main/java/com/fincatto/documentofiscal/transformers/DFLocalDateTimeTransformer.java
@@ -9,13 +9,18 @@ public class DFLocalDateTimeTransformer implements Transform<LocalDateTime> {
     
     private static final DateTimeFormatter SIMPLE_DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
     private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssXXX");
+    private static final DateTimeFormatter DATETIME_FORMATTER_2 = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
     
     @Override
     public LocalDateTime read(final String data) {
         try {
             return LocalDateTime.parse(data, DFLocalDateTimeTransformer.DATETIME_FORMATTER);
         } catch (final Exception e) {
-            return LocalDateTime.from(DFLocalDateTimeTransformer.SIMPLE_DATETIME_FORMATTER.parse(data));
+        	try {
+            	return LocalDateTime.parse(data, DFLocalDateTimeTransformer.DATETIME_FORMATTER_2);
+			} catch (Exception e2) {
+	            return LocalDateTime.from(DFLocalDateTimeTransformer.SIMPLE_DATETIME_FORMATTER.parse(data));
+			}
         }
     }
     


### PR DESCRIPTION
Alteração do nome do atributo ID para Id conforme especificação em manual. Já a alteração na classe DateTimeFormatter e devido a SEFAZ estar retornando os milissegundos e quando se fazia o parser era ocasionado erro.