### PR TITLE
Inclusão URL QRCODE para Alagoas e alteração URL QRCODE Rio de Janeiro

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/DFUnidadeFederativa.java
+++ b/src/main/java/com/fincatto/documentofiscal/DFUnidadeFederativa.java
@@ -7,7 +7,7 @@ package com.fincatto.documentofiscal;
 public enum DFUnidadeFederativa {
     
     AC("AC", "Acre", "12", "http://hml.sefaznet.ac.gov.br/nfce/qrcode", "http://hml.sefaznet.ac.gov.br/nfce/qrcode", "http://hml.sefaznet.ac.gov.br/nfce/consulta", "www.sefaznet.ac.gov.br/nfce/consulta"),
-    AL("AL", "Alagoas", "27", null, null, "http://nfce.sefaz.al.gov.br/consultaNFCe.htm", "http://nfce.sefaz.al.gov.br/consultaNFCe.htm"),
+    AL("AL", "Alagoas", "27", "http://nfce.sefaz.al.gov.br/QRCode/consultarNFCe.jsp", "http://nfce.sefaz.al.gov.br/QRCode/consultarNFCe.jsp", "http://nfce.sefaz.al.gov.br/consultaNFCe.htm", "http://nfce.sefaz.al.gov.br/consultaNFCe.htm"),
     AP("AP", "Amap\u00E1", "16", "https://www.sefaz.ap.gov.br/nfcehml/nfce.php", "https://www.sefaz.ap.gov.br/nfce/nfce.php", "https://www.sefaz.ap.gov.br/sate1/seg/SEGf_AcessarFuncao.jsp?cdFuncao=FIS_1261", "https://www.sefaz.ap.gov.br/sate/seg/SEGf_AcessarFuncao.jsp?cdFuncao=FIS_1261"),
     AM("AM", "Amazonas", "13", "http://homnfce.sefaz.am.gov.br/nfceweb/consultarNFCe.jsp", "http://sistemas.sefaz.am.gov.br/nfceweb/consultarNFCe.jsp", "homnfce.sefaz.am.gov.br/nfceweb/formConsulta.do", "sistemas.sefaz.am.gov.br/nfceweb/formConsulta.do"),
     BA("BA", "Bahia", "29", "http://hnfe.sefaz.ba.gov.br/servicos/nfce/modulos/geral/NFCEC_consulta_chave_acesso.aspx", "http://nfe.sefaz.ba.gov.br/servicos/nfce/modulos/geral/NFCEC_consulta_chave_acesso.aspx", "http://hnfe.sefaz.ba.gov.br/servicos/nfce/default.aspx", "nfe.sefaz.ba.gov.br/servicos/nfce/default.aspx"),
@@ -24,7 +24,7 @@ public enum DFUnidadeFederativa {
     PR("PR", "Paran\u00E1", "41", "http://www.fazenda.pr.gov.br/nfce/qrcode", "http://www.fazenda.pr.gov.br/nfce/qrcode", "http://www.fazenda.pr.gov.br", "http://www.fazenda.pr.gov.br"),
     PE("PE", "Pernambuco", "26", "http://nfcehomolog.sefaz.pe.gov.br/nfce-web/consultarNFCe", "http://nfce.sefaz.pe.gov.br/nfce-web/consultarNFCe", "http://nfcehomolog.sefaz.pe.gov.br/nfce/consulta", "http://nfce.sefaz.pe.gov.br/nfce/consulta"),
     PI("PI", "Piau\u00ED", "22", "http://www.sefaz.pi.gov.br/nfce/qrcode", "http://www.sefaz.pi.gov.br/nfce/qrcode" , "http://www.sefaz.pi.gov.br/nfce/consulta", "http://www.sefaz.pi.gov.br/nfce/consulta"),
-    RJ("RJ", "Rio de Janeiro", "33", "http://www.fazenda.rj.gov.br/nfce/consulta", "http://www.fazenda.rj.gov.br/nfce/consulta", "www.nfce.fazenda.rj.gov.br/consulta", "www.nfce.fazenda.rj.gov.br/consulta"),
+    RJ("RJ", "Rio de Janeiro", "33", "http://www4.fazenda.rj.gov.br/consultaNFCe/QRCode", "http://www4.fazenda.rj.gov.br/consultaNFCe/QRCode", "www.nfce.fazenda.rj.gov.br/consulta", "www.nfce.fazenda.rj.gov.br/consulta"),
     RN("RN", "Rio Grande do Norte", "24", "http://hom.nfce.set.rn.gov.br/consultarNFCe.aspx", "http://nfce.set.rn.gov.br/consultarNFCe.aspx", "http://nfce.set.rn.gov.br/consultarNFCe.aspx", "http://nfce.set.rn.gov.br/consultarNFCe.aspx"),
     RS("RS", "Rio Grande do Sul", "43", "https://www.sefaz.rs.gov.br/NFCE/NFCE-COM.aspx", "https://www.sefaz.rs.gov.br/NFCE/NFCE-COM.aspx", "https://www.sefaz.rs.gov.br/NFCE/NFCE-COM.aspx", "https://www.sefaz.rs.gov.br/NFCE/NFCE-COM.aspx"),
     RO("RO", "Rond\u00F4nia", "11", "http://www.nfce.sefin.ro.gov.br/consultanfce/consulta.jsp", "http://www.nfce.sefin.ro.gov.br/consultanfce/consulta.jsp", "http://www.nfce.sefin.ro.gov.br", "http://www.nfce.sefin.ro.gov.br"),

--- a/src/test/java/com/fincatto/documentofiscal/DFUnidadeFederativaTest.java
+++ b/src/test/java/com/fincatto/documentofiscal/DFUnidadeFederativaTest.java
@@ -15,8 +15,8 @@ public class DFUnidadeFederativaTest {
 
         Assert.assertEquals("AL", DFUnidadeFederativa.AL.getCodigo());
         Assert.assertEquals("27", DFUnidadeFederativa.AL.getCodigoIbge());
-        Assert.assertNull(DFUnidadeFederativa.AL.getQrCodeHomologacao());
-        Assert.assertNull(DFUnidadeFederativa.AL.getQrCodeProducao());
+        Assert.assertEquals("http://nfce.sefaz.al.gov.br/QRCode/consultarNFCe.jsp", DFUnidadeFederativa.AL.getQrCodeHomologacao());
+        Assert.assertEquals("http://nfce.sefaz.al.gov.br/QRCode/consultarNFCe.jsp", DFUnidadeFederativa.AL.getQrCodeProducao());
 
 
         Assert.assertEquals("AM", DFUnidadeFederativa.AM.getCodigo());
@@ -103,8 +103,8 @@ public class DFUnidadeFederativaTest {
 
         Assert.assertEquals("RJ", DFUnidadeFederativa.RJ.getCodigo());
         Assert.assertEquals("33", DFUnidadeFederativa.RJ.getCodigoIbge());
-        Assert.assertEquals("http://www.fazenda.rj.gov.br/nfce/consulta", DFUnidadeFederativa.RJ.getQrCodeHomologacao());
-        Assert.assertEquals("http://www.fazenda.rj.gov.br/nfce/consulta", DFUnidadeFederativa.RJ.getQrCodeProducao());
+        Assert.assertEquals("http://www4.fazenda.rj.gov.br/consultaNFCe/QRCode", DFUnidadeFederativa.RJ.getQrCodeHomologacao());
+        Assert.assertEquals("http://www4.fazenda.rj.gov.br/consultaNFCe/QRCode", DFUnidadeFederativa.RJ.getQrCodeProducao());
 
         Assert.assertEquals("RN", DFUnidadeFederativa.RN.getCodigo());
         Assert.assertEquals("24", DFUnidadeFederativa.RN.getCodigoIbge());


### PR DESCRIPTION
Inclusão da URL para gerar nota para o Estado de Alagoas.

Alteração na URL QRCODE para o Estado do Rio de Janeiro, estava retornando "Rejeição 395: Endereço do site da UF da Consulta via QR-Code diverge do previsto"