### PR TITLE
Remove obrigatoriedade da UF

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/lote/envio/NFLoteEnvioRetorno.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/lote/envio/NFLoteEnvioRetorno.java
@@ -31,7 +31,7 @@ public class NFLoteEnvioRetorno extends DFBase {
     @Element(name = "xMotivo")
     private String motivo;
     
-    @Element(name = "cUF")
+    @Element(name = "cUF", required = false)
     private DFUnidadeFederativa uf;
     
     @Element(name = "dhRecbto")


### PR DESCRIPTION
Quando a nota é emitida para SVRS e o retorno é uma rejeição de consumo indevido, no XML o nó cUF vem vazio e por esse motivo ocorre uma falha ao tentar fazer o parse para o objeto. Exemplo do retorno de rejeição que causou o erro:

`<retEnviNFe versao="4.00" xmlns="http://www.portalfiscal.inf.br/nfe"><tpAmb>1</tpAmb><verAplic>SVRSnfce201908091113</verAplic><cStat>656</cStat><xMotivo>Rejeicao: Consumo indevido pelo aplicativo da empresa [Quantidade rejeicoes: 973, NF-e: 22191007272825001690651050000032289661613580]</xMotivo><cUF /><dhRecbto>2019-11-20T19:49:57-03:00</dhRecbto></retEnviNFe>`