### PR TITLE
Adicionando valor de DUPLICATA MERCANTIL ao enum NFMeioPagamento

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFMeioPagamento.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFMeioPagamento.java
@@ -11,6 +11,7 @@ public enum NFMeioPagamento {
     VALE_REFEICAO("11", "Vale refei\u00e7\u00e3o"),
     VALE_PRESENTE("12", "Vale presente"),
     VALE_COMBUSTIVEL("13", "Vale combust\u00edvel"),
+    DUPLICATA_MERCANTIL("14", "Duplicata Mercantil"),
     BOLETO_BANCARIO("15", "Boleto Bancario"),
     SEM_PAGAMENTO("90", "Sem pagamento"),
     OUTRO("99", "Outro");


### PR DESCRIPTION
Pessoal, o valor de duplicata mercantil foi removido do enum NFMeioPagamento impossibilitando o carregamento de XML's que possuem esse valor. Estou adicionando novamente tal valor no enum.