### PR TITLE
Inclusão da URL correta para emissão de NFCe em SC

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/DFUnidadeFederativa.java
+++ b/src/main/java/com/fincatto/documentofiscal/DFUnidadeFederativa.java
@@ -31,7 +31,7 @@ public enum DFUnidadeFederativa {
     RO("RO", "Rond\u00F4nia", "11", "http://www.nfce.sefin.ro.gov.br/consultanfce/consulta.jsp", "http://www.nfce.sefin.ro.gov.br/consultanfce/consulta.jsp", "http://www.nfce.sefin.ro.gov.br", "http://www.nfce.sefin.ro.gov.br"),
     RR("RR", "Roraima", "14", "http://200.174.88.103:8080/nfce/servlet/qrcode", "https://www.sefaz.rr.gov.br/nfce/servlet/qrcode", "http://200.174.88.103:8080/nfce/servlet/wp_consulta_nfce", "https://www.sefaz.rr.gov.br/nfce/servlet/wp_consulta_nfce"),
     SP("SP", "S\u00E3o Paulo", "35", "https://www.homologacao.nfce.fazenda.sp.gov.br/NFCeConsultaPublica/Paginas/ConsultaQRCode.aspx", "https://www.nfce.fazenda.sp.gov.br/NFCeConsultaPublica/Paginas/ConsultaQRCode.aspx", "https://www.homologacao.nfce.fazenda.sp.gov.br/NFCeConsultaPublica", "https://www.nfce.fazenda.sp.gov.br/NFCeConsultaPublica"),
-    SC("SC", "Santa Catarina", "42"),
+    SC("SC", "Santa Catarina", "42","https://hom.sat.sef.sc.gov.br/nfce/consulta","https://sat.sef.sc.gov.br/nfce/consulta","https://hom.sat.sef.sc.gov.br/nfce/consulta","https://sat.sef.sc.gov.br/nfce/consulta"),
     SE("SE", "Sergipe", "28", "http://www.hom.nfe.se.gov.br/portal/consultarNFCe.jsp", "http://www.nfce.se.gov.br/portal/consultarNFCe.jsp", "http://www.hom.nfe.se.gov.br/portal/portalNoticias.jsp", "http://www.nfce.se.gov.br/portal/portalNoticias.jsp"),
     TO("TO", "Tocantins", "17", "http://homologacao.sefaz.to.gov.br/nfce/qrcode", "http://www.sefaz.to.gov.br/nfce/qrcode", "http://homologacao.sefaz.to.gov.br/nfce/consulta.jsf", "http://www.sefaz.to.gov.br/nfce/consulta.jsf"),
     NACIONAL("NC", "Nacional", "90"),

--- a/src/test/java/com/fincatto/documentofiscal/DFUnidadeFederativaTest.java
+++ b/src/test/java/com/fincatto/documentofiscal/DFUnidadeFederativaTest.java
@@ -128,8 +128,8 @@ public class DFUnidadeFederativaTest {
 
         Assert.assertEquals("SC", DFUnidadeFederativa.SC.getCodigo());
         Assert.assertEquals("42", DFUnidadeFederativa.SC.getCodigoIbge());
-        Assert.assertNull(DFUnidadeFederativa.SC.getQrCodeHomologacao());
-        Assert.assertNull(DFUnidadeFederativa.SC.getQrCodeProducao());
+        Assert.assertEquals("https://hom.sat.sef.sc.gov.br/nfce/consulta", DFUnidadeFederativa.SC.getQrCodeHomologacao());
+        Assert.assertEquals("https://sat.sef.sc.gov.br/nfce/consulta", DFUnidadeFederativa.SC.getQrCodeProducao());
 
         Assert.assertEquals("SE", DFUnidadeFederativa.SE.getCodigo());
         Assert.assertEquals("28", DFUnidadeFederativa.SE.getCodigoIbge());


### PR DESCRIPTION
- Inclusão das Urls.
- Alteração dos Testes unitários.

Realizado Teste de emissão de NFCe em ambiente de Produção com configuração de SC e a nota foi emitida / cancelada com sucesso.

Acredito que resolve a Issue #706 