### PR TITLE
Corrige ordem da tag xPag (deve ter precedência sobre a tag vPag)

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoFormaPagamento.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoFormaPagamento.java
@@ -18,14 +18,14 @@ public class NFNotaInfoFormaPagamento extends DFBase {
     @Element(name = "tPag")
     private NFMeioPagamento meioPagamento;
 
+    @Element(name = "xPag", required = false)
+    private String descricaoMeioPagamento;
+
     @Element(name = "vPag")
     private String valorPagamento;
 
     @Element(name = "card", required = false)
     private NFNotaInfoCartao cartao;
-
-    @Element(name = "xPag", required = false)
-    private String descricaoMeioPagamento;
 
     public NFNotaInfoFormaPagamento setCartao(final NFNotaInfoCartao cartao) {
         this.cartao = cartao;


### PR DESCRIPTION
Corrige a ordem do xPag que afeta a issue #750 

O xPag deve ter precedência sobre a tag vPag, com isso é possível emitir Notas com o tPag 99 (Outros).

E apenas relembrando que a data prazo para essa modificação estar vigente em Produção é dia 01/09. Caso contrário não será possível emitir notas com o meio de pagamento "Outros".