### PR TITLE
Mudança da URL do Qrcode para o estado ACRE, ambiente produção

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/DFUnidadeFederativa.java
+++ b/src/main/java/com/fincatto/documentofiscal/DFUnidadeFederativa.java
@@ -7,7 +7,7 @@ import org.apache.commons.lang3.StringUtils;
  **/
 public enum DFUnidadeFederativa {
     
-    AC("AC", "Acre", "12", "http://hml.sefaznet.ac.gov.br/nfce/qrcode", "http://hml.sefaznet.ac.gov.br/nfce/qrcode", "http://hml.sefaznet.ac.gov.br/nfce/consulta", "www.sefaznet.ac.gov.br/nfce/consulta"),
+    AC("AC", "Acre", "12", "http://hml.sefaznet.ac.gov.br/nfce/qrcode", "http://www.sefaznet.ac.gov.br/nfce/qrcode", "http://hml.sefaznet.ac.gov.br/nfce/consulta", "www.sefaznet.ac.gov.br/nfce/consulta"),
     AL("AL", "Alagoas", "27", "http://nfce.sefaz.al.gov.br/QRCode/consultarNFCe.jsp", "http://nfce.sefaz.al.gov.br/QRCode/consultarNFCe.jsp", "http://nfce.sefaz.al.gov.br/consultaNFCe.htm", "http://nfce.sefaz.al.gov.br/consultaNFCe.htm"),
     AP("AP", "Amap\u00E1", "16", "https://www.sefaz.ap.gov.br/nfcehml/nfce.php", "https://www.sefaz.ap.gov.br/nfce/nfce.php", "https://www.sefaz.ap.gov.br/sate1/seg/SEGf_AcessarFuncao.jsp?cdFuncao=FIS_1261", "https://www.sefaz.ap.gov.br/sate/seg/SEGf_AcessarFuncao.jsp?cdFuncao=FIS_1261"),
     AM("AM", "Amazonas", "13", "http://homnfce.sefaz.am.gov.br/nfceweb/consultarNFCe.jsp", "http://sistemas.sefaz.am.gov.br/nfceweb/consultarNFCe.jsp", "homnfce.sefaz.am.gov.br/nfceweb/formConsulta.do", "sistemas.sefaz.am.gov.br/nfceweb/formConsulta.do"),

--- a/src/test/java/com/fincatto/documentofiscal/DFUnidadeFederativaTest.java
+++ b/src/test/java/com/fincatto/documentofiscal/DFUnidadeFederativaTest.java
@@ -11,7 +11,7 @@ public class DFUnidadeFederativaTest {
         Assert.assertEquals("AC", DFUnidadeFederativa.AC.getCodigo());
         Assert.assertEquals("12", DFUnidadeFederativa.AC.getCodigoIbge());
         Assert.assertEquals("http://hml.sefaznet.ac.gov.br/nfce/qrcode", DFUnidadeFederativa.AC.getQrCodeHomologacao());
-        Assert.assertEquals("http://hml.sefaznet.ac.gov.br/nfce/qrcode", DFUnidadeFederativa.AC.getQrCodeProducao());
+        Assert.assertEquals("http://www.sefaznet.ac.gov.br/nfce/qrcode", DFUnidadeFederativa.AC.getQrCodeProducao());
 
         Assert.assertEquals("AL", DFUnidadeFederativa.AL.getCodigo());
         Assert.assertEquals("27", DFUnidadeFederativa.AL.getCodigoIbge());


### PR DESCRIPTION
Olá pessoal,

Fiz a alteração da URL para geração do QRCode para o Estado do Acre, Ambiente de produção.

Fizemos vários testes emitindo NFCE em ambiente de produção para clientes neste estado, todos com sucesso.