### PR TITLE
Atualizando tipos de combustíveis.

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/NFNotaInfoCombustivelTipo.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/NFNotaInfoCombustivelTipo.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang3.StringUtils;
 
 public enum NFNotaInfoCombustivelTipo {
 
+    OUTROS("00", "Outros"),
     ALCOOL("01", "\u00c1lcool"),
     GASOLINA("02", "Gasolina"),
     DIESEL("03", "Diesel"),
@@ -21,7 +22,10 @@ public enum NFNotaInfoCombustivelTipo {
     GAS_NATURAL_VEICULAR("15", "G\u00e1s natural veicular"),
     ALCOOL_GASOLINA("16", "\u00c1lcool/Gasolina"),
     GASOLINA_ALCOOL_GAS_NATURAL("17", "Gasolina/\u00c1lcool/G\u00e1s natural"),
-    GASOLINA_ELETRICO("18", "Gasolina/El\u00e9trico");
+    GASOLINA_ELETRICO("18", "Gasolina/El\u00e9trico"),
+    GASOLINA_ALCOOL_ELETRICO("19", "Gasolina/\u00c1lcool/El\u00e9trico"),
+    GAS_NATURAL_LIQUEFEITO("20", "G\u00e1s natural liquefeito"),
+    DIESEL_ELETRICO("21", "Diesel/El\u00e9trico");
 
     private final String codigo;
     private final String descricao;


### PR DESCRIPTION
Não consegui realizar a leitura de algumas notas, pois recebi os tipos de combustíveis "0" e "19". Como não encontrei a tabela online, realizamos o contato com a Sefaz e conseguimos a seguinte resposta:

[SEI_MINFRA - 4515457 - Nota Informativa.pdf](https://github.com/wmixvideo/nfe/files/7143750/SEI_MINFRA.-.4515457.-.Nota.Informativa.pdf)

Como não consta o "0", tentei seguir o padrão da lib e adicionei como "Outros". De resto, apenas atualizei com a tabela recebida.
