### PR TITLE
Fix violations of Sonar rule 2111

### DIFF
--- a/src/test/java/com/fincatto/documentofiscal/mdfe3/FabricaDeObjetosFakeMDFe.java
+++ b/src/test/java/com/fincatto/documentofiscal/mdfe3/FabricaDeObjetosFakeMDFe.java
@@ -91,7 +91,7 @@ public class FabricaDeObjetosFakeMDFe {
 
     public static MDFProcessado getMDFProcessado() {
         MDFProcessado a = new MDFProcessado();
-        a.setVersao(new BigDecimal(3.00));
+        a.setVersao(BigDecimal.valueOf(3.0));
         a.setSchemaLocation("");
         a.setMdfe(getMDFe1());
         a.setProtocolo(getMDFProtocolo());


### PR DESCRIPTION
Hi,

This PR fixes 1 violations of [Sonar Rule 2111: '"BigDecimal(double)" should not be used'](https://rules.sonarsource.com/java/RSPEC-2111). This is done without introducing any new violations of Sonar rules.

The patch was generated automatically with the tool [Sorald](https://github.com/SpoonLabs/sorald). For details on the fix applied here, please see [Sorald's documentation on rule 2111](https://github.com/SpoonLabs/sorald/blob/master/docs/HANDLED_RULES.md#bigdecimaldouble-should-not-be-used-sonar-rule-2111).

P.S.: Note that this PR is not created/submitted by a bot. If you have any feedback, please leave them as comments.