### PR TITLE
Could com.github.wmixvideo:nfe:3.1.09-SNAPSHOT drop off redundant dependencies? 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,12 @@
             <groupId>org.simpleframework</groupId>
             <artifactId>simple-xml</artifactId>
             <version>${simple-xml.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>stax</groupId>
+                    <artifactId>stax-api</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <!-- Commons Lang -->
@@ -83,6 +89,26 @@
                     <groupId>javax.servlet</groupId>
                     <artifactId>servlet-api</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-ws-metadata_2.0_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.ws.rs</groupId>
+                    <artifactId>jsr311-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-jta_1.1_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-stax-api_1.0_spec</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-activation_1.1_spec</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -90,6 +116,12 @@
             <artifactId>axis2-adb</artifactId>
             <version>${axis2.version}</version>
             <scope>compile</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.geronimo.specs</groupId>
+                    <artifactId>geronimo-activation_1.1_spec</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.axis2</groupId>


### PR DESCRIPTION
Hi! I found the pom file of project **_com.github.wmixvideo:nfe:3.1.09-SNAPSHOT_** introduced **_38_** dependencies. However, among them, **_6_** libraries (**_15%_**) are not used by your project. I list the redundant dependencies below (labelled as red ones in the figure):
## Redundant dependencies
org.apache.geronimo.specs:geronimo-jta_1.1_spec:jar:1.1:compile
javax.ws.rs:jsr311-api:jar:1.1.1:compile
org.apache.geronimo.specs:geronimo-stax-api_1.0_spec:jar:1.0.1:compile
org.apache.geronimo.specs:geronimo-activation_1.1_spec:jar:1.0.2:compile
org.apache.geronimo.specs:geronimo-ws-metadata_2.0_spec:jar:1.1.2:compile
stax:stax-api:jar:1.0.1:compile

---
Removing the redundant dependencies can reduce the size of project and prevent potential dependency conflict issues (i.e., multiple versions of the same library). More importantly, one of the redundant dependencies **_javax.ws.rs:jsr311-api:jar:1.1.1:compile_** incorporates an incompatible license CDDL LICENSE (CDDL LICENSE cannot be used by the project with license Apache License, Version 2.0). As such, I suggest a refactoring operation for **_com.github.wmixvideo:nfe:3.1.09-SNAPSHOT_**’s pom file.

The attached PR helps resolve the reported problem. It is safe to remove the unused libraries (we considered Java reflection relations when analyzing the dependencies). These changes have passed **_com.github.wmixvideo:nfe:3.1.09-SNAPSHOT_**’s maven tests.

Best regards