### PR TITLE
Altera a ordem do atributo xMotivoIsencao

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemProdutoMedicamento.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemProdutoMedicamento.java
@@ -12,13 +12,13 @@ public class NFNotaInfoItemProdutoMedicamento extends DFBase {
     
     @Element(name = "cProdANVISA")
     private String codigoProdutoAnvisa;
-    
-    @Element(name = "vPMC")
-    private String precoMaximoConsumidor;
-    
+
     @Element(name = "xMotivoIsencao", required = false)
     private String motivoIsencao;
-    
+
+    @Element(name = "vPMC")
+    private String precoMaximoConsumidor;
+
     public NFNotaInfoItemProdutoMedicamento() {
         this.codigoProdutoAnvisa = null;
         this.precoMaximoConsumidor = null;


### PR DESCRIPTION
A tag xMotivoIsencao não é obrigatório, porém quando informada causava um erro de validação.

`org.xml.sax.SAXParseException; lineNumber: 1; columnNumber: 1846; cvc-complex-type.2.4.a: Foi detectado um conteúdo inválido começando com o elemento 'vPMC'. Era esperado um dos '{"http://www.portalfiscal.inf.br/nfe":xMotivoIsencao}'.`

Esse PR altera a ordem do atributo, foi testado em ambiente de homologação e o problema foi resolvido.