### PR TITLE
Corrigido tipo de retorno do método WSDistribuicaoCTe.consultar para CTDistribuicaoIntRetorno

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/cte/webservices/distribuicao/WSDistribuicaoCTe.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte/webservices/distribuicao/WSDistribuicaoCTe.java
@@ -3,11 +3,11 @@ package com.fincatto.documentofiscal.cte.webservices.distribuicao;
 import com.fincatto.documentofiscal.DFUnidadeFederativa;
 import com.fincatto.documentofiscal.cte.classes.distribuicao.CTDistribuicaoConsultaNSU;
 import com.fincatto.documentofiscal.cte.classes.distribuicao.CTDistribuicaoInt;
+import com.fincatto.documentofiscal.cte.classes.distribuicao.CTDistribuicaoIntRetorno;
 import com.fincatto.documentofiscal.cte.classes.distribuicao.CTDistribuicaoNSU;
 import com.fincatto.documentofiscal.cte200.classes.CTAutorizador;
 import com.fincatto.documentofiscal.cte300.CTeConfig;
 import com.fincatto.documentofiscal.nfe.NFeConfig;
-import com.fincatto.documentofiscal.nfe.classes.distribuicao.NFDistribuicaoIntRetorno;
 import com.fincatto.documentofiscal.utils.DFSocketFactory;
 import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import java.io.BufferedReader;
@@ -57,7 +57,7 @@ public class WSDistribuicaoCTe {
         }
     }
 
-    public NFDistribuicaoIntRetorno consultar(final String cpfOuCnpj, final DFUnidadeFederativa uf, final String nsu, final String ultNsu) throws Exception {
+    public CTDistribuicaoIntRetorno consultar(final String cpfOuCnpj, final DFUnidadeFederativa uf, final String nsu, final String ultNsu) throws Exception {
         try {
             String xmlEnvio = this.gerarCTeDistribuicaoInt(cpfOuCnpj, uf, nsu, ultNsu).toString();
 
@@ -73,7 +73,7 @@ public class WSDistribuicaoCTe {
 
             final CTeDistribuicaoDFeSoapStub stub = new CTeDistribuicaoDFeSoapStub(CTAutorizador.AN.getDistribuicaoDFe(config.getAmbiente()), config);
             final CTeDistribuicaoDFeSoapStub.CteDistDFeInteresseResponse result = stub.cteDistDFeInteresse(distDFeInteresse);
-            return this.config.getPersister().read(NFDistribuicaoIntRetorno.class, result.getCteDistDFeInteresseResult().getExtraElement().toString());
+            return this.config.getPersister().read(CTDistribuicaoIntRetorno.class, result.getCteDistDFeInteresseResult().getExtraElement().toString());
         } catch (RemoteException | XMLStreamException e) {
             throw new Exception(e.getMessage());
         }

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSFacade.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSFacade.java
@@ -2,6 +2,7 @@ package com.fincatto.documentofiscal.cte300.webservices;
 
 import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.DFUnidadeFederativa;
+import com.fincatto.documentofiscal.cte.classes.distribuicao.CTDistribuicaoIntRetorno;
 import com.fincatto.documentofiscal.cte.webservices.distribuicao.WSDistribuicaoCTe;
 import com.fincatto.documentofiscal.cte300.CTeConfig;
 import com.fincatto.documentofiscal.cte300.classes.consultastatusservico.CTeConsStatServRet;
@@ -11,7 +12,6 @@ import com.fincatto.documentofiscal.cte300.classes.enviolote.consulta.CTeConsult
 import com.fincatto.documentofiscal.cte300.classes.evento.cancelamento.CTeRetornoCancelamento;
 import com.fincatto.documentofiscal.cte300.classes.evento.inutilizacao.CTeRetornoEventoInutilizacao;
 import com.fincatto.documentofiscal.cte300.classes.nota.consulta.CTeNotaConsultaRetorno;
-import com.fincatto.documentofiscal.nfe.classes.distribuicao.NFDistribuicaoIntRetorno;
 import com.fincatto.documentofiscal.utils.DFSocketFactory;
 import java.io.IOException;
 import java.security.KeyManagementException;
@@ -175,7 +175,7 @@ public class WSFacade {
      * @throws Exception caso nao consiga gerar o xml ou problema de conexao com
      * o sefaz
      */
-    public NFDistribuicaoIntRetorno consultarDistribuicaoCTe(final String cpfOuCnpj, final DFUnidadeFederativa uf, final String nsu, final String ultNsu) throws Exception {
+    public CTDistribuicaoIntRetorno consultarDistribuicaoCTe(final String cpfOuCnpj, final DFUnidadeFederativa uf, final String nsu, final String ultNsu) throws Exception {
         return this.wSDistribuicaoCTe.consultar(cpfOuCnpj, uf, nsu, ultNsu);
     }
 }


### PR DESCRIPTION
Olá,

Verifiquei que o método `consultar` do `WSDistribuicaoCTe` estava retornando um `NFDistribuicaoIntRetorno` em vez do `CTDistribuicaoIntRetorno`, que é o tipo correto e já existente no projeto. Isso fazia com que, ao pegarmos o objeto de retorno e convertê-lo para XML, o resultado ficava com o namespace errado (de nfe em vez de cte).