### PR TITLE
Corrigido para consultar o CT-e na UF em que ele foi emitido

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSNotaConsulta.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSNotaConsulta.java
@@ -48,7 +48,7 @@ class WSNotaConsulta implements DFLog {
     
         this.getLogger().debug(cabec.toString());
 
-        final CTAutorizador31 autorizador = CTAutorizador31.valueOfTipoEmissao(this.config.getTipoEmissao(), this.config.getCUF());
+        final CTAutorizador31 autorizador = CTAutorizador31.valueOfChaveAcesso(chaveDeAcesso);
         final String endpoint = autorizador.getCteConsultaProtocolo(this.config.getAmbiente());
         if (endpoint == null) {
             throw new IllegalArgumentException("Nao foi possivel encontrar URL para Consulta, autorizador " + autorizador.name() + ", UF " + this.config.getCUF().name());


### PR DESCRIPTION
A consulta de situação do CT-e deve ser feita na UF em que ele foi emitido originalmente e não na UF/ambiente da configuração atual. Esse mesmo tratamento já é feito na classe equivalente da NF-e.