### PR TITLE
CT-e: Corrige id dos eventos, geração do EPEC e incluída validação de schema nos eventos

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/CTeDetalhamentoEvento.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/CTeDetalhamentoEvento.java
@@ -6,6 +6,7 @@ import com.fincatto.documentofiscal.cte300.classes.evento.cartacorrecao.CTeEnvia
 import com.fincatto.documentofiscal.cte300.classes.evento.comprovanteentrega.CTeEnviaEventoCancelamentoComprovanteEntrega;
 import com.fincatto.documentofiscal.cte300.classes.evento.comprovanteentrega.CTeEnviaEventoComprovanteEntrega;
 import com.fincatto.documentofiscal.cte300.classes.evento.desacordo.CTeEnviaEventoPrestacaoEmDesacordo;
+import com.fincatto.documentofiscal.cte300.classes.evento.epec.CTeEnviaEventoEpec;
 import com.fincatto.documentofiscal.cte300.classes.evento.gtv.CTeEnviaEventoGtv;
 import com.fincatto.documentofiscal.cte300.classes.evento.multimodal.CTeEnviaEventoRegistroMultimodal;
 import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
@@ -26,6 +27,7 @@ public class CTeDetalhamentoEvento extends DFBase {
             @Element(name = "evCancCTe", type = CTeEnviaEventoCancelamento.class),
             @Element(name = "evCCeCTe", type = CTeEnviaEventoCartaCorrecao.class),
             @Element(name = "evCECTe", type = CTeEnviaEventoComprovanteEntrega.class),
+            @Element(name = "evEPECCTe", type = CTeEnviaEventoEpec.class),
             @Element(name = "evPrestDesacordo", type = CTeEnviaEventoPrestacaoEmDesacordo.class),
             @Element(name = "evGTV", type = CTeEnviaEventoGtv.class),
             @Element(name = "evRegMultimodal", type = CTeEnviaEventoRegistroMultimodal.class),

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/CTeEventoRetorno.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/CTeEventoRetorno.java
@@ -5,9 +5,13 @@ import com.fincatto.documentofiscal.nfe310.classes.nota.assinatura.NFSignature;
 import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
 
 import java.math.BigDecimal;
 
+@Root(name = "retEventoCTe")
+@Namespace(reference = "http://www.portalfiscal.inf.br/cte")
 public class CTeEventoRetorno extends DFBase {
     private static final long serialVersionUID = -8952520263707135185L;
     

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/CTeInfoEventoRetorno.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/CTeInfoEventoRetorno.java
@@ -41,7 +41,7 @@ public class CTeInfoEventoRetorno extends DFBase {
     @Element(name = "nSeqEvento", required = false)
     private Integer numeroSequencialEvento;
     
-    @Element(name = "dhRegEvento")
+    @Element(name = "dhRegEvento", required = false)
     private LocalDateTime dataHoraRegistro;
 
     @Element(name = "nProt", required = false)

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/cancelamento/CTeEnviaEventoCancelamento.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/cancelamento/CTeEnviaEventoCancelamento.java
@@ -4,7 +4,11 @@ import com.fincatto.documentofiscal.cte300.classes.evento.CTeTipoEvento;
 import org.simpleframework.xml.Element;
 
 import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
 
+@Root(name = "evCancCTe")
+@Namespace(reference = "http://www.portalfiscal.inf.br/cte")
 public class CTeEnviaEventoCancelamento extends CTeTipoEvento {
     private static final long serialVersionUID = -6990304145768185274L;
 

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/cartacorrecao/CTeEnviaEventoCartaCorrecao.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/cartacorrecao/CTeEnviaEventoCartaCorrecao.java
@@ -2,9 +2,13 @@ package com.fincatto.documentofiscal.cte300.classes.evento.cartacorrecao;
 
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeTipoEvento;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
 
 import java.util.List;
 
+@Root(name = "evCCeCTe")
+@Namespace(reference = "http://www.portalfiscal.inf.br/cte")
 public class CTeEnviaEventoCartaCorrecao extends CTeTipoEvento {
     private static final long serialVersionUID = -6818585208080376005L;
 

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/comprovanteentrega/CTeEnviaEventoCancelamentoComprovanteEntrega.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/comprovanteentrega/CTeEnviaEventoCancelamentoComprovanteEntrega.java
@@ -3,7 +3,11 @@ package com.fincatto.documentofiscal.cte300.classes.evento.comprovanteentrega;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeTipoEvento;
 import com.fincatto.documentofiscal.validadores.DFStringValidador;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
 
+@Root(name = "evCancCECTe")
+@Namespace(reference = "http://www.portalfiscal.inf.br/cte")
 public class CTeEnviaEventoCancelamentoComprovanteEntrega extends CTeTipoEvento {
     private static final long serialVersionUID = -5488904753372508623L;
 

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/comprovanteentrega/CTeEnviaEventoComprovanteEntrega.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/comprovanteentrega/CTeEnviaEventoComprovanteEntrega.java
@@ -4,10 +4,14 @@ import com.fincatto.documentofiscal.cte300.classes.evento.CTeTipoEvento;
 import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
 import com.fincatto.documentofiscal.validadores.DFStringValidador;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
 
 import java.time.ZonedDateTime;
 import java.util.List;
 
+@Root(name = "evCECTe")
+@Namespace(reference = "http://www.portalfiscal.inf.br/cte")
 public class CTeEnviaEventoComprovanteEntrega extends CTeTipoEvento {
     private static final long serialVersionUID = -5488904753372508623L;
 

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/desacordo/CTeEnviaEventoPrestacaoEmDesacordo.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/desacordo/CTeEnviaEventoPrestacaoEmDesacordo.java
@@ -3,7 +3,11 @@ package com.fincatto.documentofiscal.cte300.classes.evento.desacordo;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeTipoEvento;
 import com.fincatto.documentofiscal.validadores.DFStringValidador;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
 
+@Root(name = "evPrestDesacordo")
+@Namespace(reference = "http://www.portalfiscal.inf.br/cte")
 public class CTeEnviaEventoPrestacaoEmDesacordo extends CTeTipoEvento {
     private static final long serialVersionUID = -7261255586164368554L;
 

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/epec/CTeEnviaEventoEpec.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/epec/CTeEnviaEventoEpec.java
@@ -6,10 +6,14 @@ import com.fincatto.documentofiscal.cte300.classes.evento.CTeTipoEvento;
 import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
 import com.fincatto.documentofiscal.validadores.DFStringValidador;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
 
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
 
+@Root(name = "evEPECCTe")
+@Namespace(reference = "http://www.portalfiscal.inf.br/cte")
 public class CTeEnviaEventoEpec extends CTeTipoEvento {
     private static final long serialVersionUID = -3353875431330243137L;
 

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/gtv/CTeEnviaEventoGtv.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/gtv/CTeEnviaEventoGtv.java
@@ -2,9 +2,13 @@ package com.fincatto.documentofiscal.cte300.classes.evento.gtv;
 
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeTipoEvento;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
 
 import java.util.List;
 
+@Root(name = "evGTV")
+@Namespace(reference = "http://www.portalfiscal.inf.br/cte")
 public class CTeEnviaEventoGtv extends CTeTipoEvento {
     private static final long serialVersionUID = -1779665170091598663L;
 

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/multimodal/CTeEnviaEventoRegistroMultimodal.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/multimodal/CTeEnviaEventoRegistroMultimodal.java
@@ -3,7 +3,11 @@ package com.fincatto.documentofiscal.cte300.classes.evento.multimodal;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeTipoEvento;
 import com.fincatto.documentofiscal.validadores.DFStringValidador;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
 
+@Root(name = "evRegMultimodal")
+@Namespace(reference = "http://www.portalfiscal.inf.br/cte")
 public class CTeEnviaEventoRegistroMultimodal extends CTeTipoEvento {
     private static final long serialVersionUID = -2748973737856358284L;
 

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSCancelamento.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSCancelamento.java
@@ -6,6 +6,7 @@ import com.fincatto.documentofiscal.cte300.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEventoRetorno;
 import com.fincatto.documentofiscal.cte300.classes.evento.cancelamento.*;
 import com.fincatto.documentofiscal.utils.DFAssinaturaDigital;
+import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
@@ -39,7 +40,7 @@ class WSCancelamento extends WSRecepcaoEvento {
         return super.efetuaEvento(xmlAssinado, chaveAcesso, WSCancelamento.VERSAO_LEIAUTE);
     }
 
-    private CTeEvento gerarDadosCancelamento(final String chaveAcesso, final String numeroProtocolo, final String motivo) {
+    private CTeEvento gerarDadosCancelamento(final String chaveAcesso, final String numeroProtocolo, final String motivo) throws Exception {
         final CTeEnviaEventoCancelamento cancelamento = new CTeEnviaEventoCancelamento();
         cancelamento.setDescricaoEvento(WSCancelamento.DESCRICAO_EVENTO);
         cancelamento.setJustificativa(motivo.trim());
@@ -47,6 +48,8 @@ class WSCancelamento extends WSRecepcaoEvento {
         CTeDetalhamentoEvento cTeDetalhamentoEventoCancelamento = new CTeDetalhamentoEvento();
         cTeDetalhamentoEventoCancelamento.setVersaoEvento(WSCancelamento.VERSAO_LEIAUTE);
         cTeDetalhamentoEventoCancelamento.setEvento(cancelamento);
+
+        DFXMLValidador.validaEventoCancelamentoCTe300(cancelamento.toString());
 
         return super.gerarEvento(chaveAcesso, WSCancelamento.VERSAO_LEIAUTE, cancelamento, WSCancelamento.EVENTO_CANCELAMENTO, null, 1);
     }

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSCancelamentoComprovanteEntrega.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSCancelamentoComprovanteEntrega.java
@@ -5,6 +5,7 @@ import com.fincatto.documentofiscal.cte300.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEventoRetorno;
 import com.fincatto.documentofiscal.cte300.classes.evento.comprovanteentrega.CTeEnviaEventoCancelamentoComprovanteEntrega;
 import com.fincatto.documentofiscal.utils.DFAssinaturaDigital;
+import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
@@ -39,11 +40,13 @@ class WSCancelamentoComprovanteEntrega extends WSRecepcaoEvento {
         return super.efetuaEvento(xmlAssinado, chaveAcesso, WSCancelamentoComprovanteEntrega.VERSAO_LEIAUTE);
     }
 
-    private CTeEvento gerarDadosCancelamentoComprovanteEntrega(final String chaveAcesso, final String protocoloAutorizacao, final String protocoloComprovanteEntrega, final int sequencialEvento) {
+    private CTeEvento gerarDadosCancelamentoComprovanteEntrega(final String chaveAcesso, final String protocoloAutorizacao, final String protocoloComprovanteEntrega, final int sequencialEvento) throws Exception {
         final CTeEnviaEventoCancelamentoComprovanteEntrega cancComprovanteEntrega = new CTeEnviaEventoCancelamentoComprovanteEntrega();
         cancComprovanteEntrega.setDescricaoEvento(WSCancelamentoComprovanteEntrega.DESCRICAO_EVENTO);
         cancComprovanteEntrega.setProtocoloAutorizacao(protocoloAutorizacao);
         cancComprovanteEntrega.setProtocoloComprovanteEntrega(protocoloComprovanteEntrega);
+
+        DFXMLValidador.validaEventoCancelamentoComprovanteEntregaCTe300(cancComprovanteEntrega.toString());
 
         return super.gerarEvento(chaveAcesso, WSCancelamentoComprovanteEntrega.VERSAO_LEIAUTE, cancComprovanteEntrega, WSCancelamentoComprovanteEntrega.EVENTO_COMPROVANTE_DE_ENTREGA, null, sequencialEvento);
     }

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSCartaCorrecao.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSCartaCorrecao.java
@@ -6,6 +6,7 @@ import com.fincatto.documentofiscal.cte300.classes.evento.CTeEventoRetorno;
 import com.fincatto.documentofiscal.cte300.classes.evento.cartacorrecao.CTeEnviaEventoCartaCorrecao;
 import com.fincatto.documentofiscal.cte300.classes.evento.cartacorrecao.CTeInformacaoCartaCorrecao;
 import com.fincatto.documentofiscal.utils.DFAssinaturaDigital;
+import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
@@ -51,11 +52,13 @@ class WSCartaCorrecao extends WSRecepcaoEvento {
         return super.efetuaEvento(xmlAssinado, chaveAcesso, WSCartaCorrecao.VERSAO_LEIAUTE);
     }
 
-    private CTeEvento gerarDadosCartaCorrecao(final String chaveAcesso, List<CTeInformacaoCartaCorrecao> correcoes, int sequencialEvento) {
+    private CTeEvento gerarDadosCartaCorrecao(final String chaveAcesso, List<CTeInformacaoCartaCorrecao> correcoes, int sequencialEvento) throws Exception {
         final CTeEnviaEventoCartaCorrecao cartaCorrecao = new CTeEnviaEventoCartaCorrecao();
         cartaCorrecao.setDescricaoEvento(WSCartaCorrecao.DESCRICAO_EVENTO);
         cartaCorrecao.setCorrecoes(correcoes);
         cartaCorrecao.setCondicaoUso("A Carta de Correcao e disciplinada pelo Art. 58-B do CONVENIO/SINIEF 06/89: Fica permitida a utilizacao de carta de correcao, para regularizacao de erro ocorrido na emissao de documentos fiscais relativos a prestacao de servico de transporte, desde que o erro nao esteja relacionado com: I - as variaveis que determinam o valor do imposto tais como: base de calculo, aliquota, diferenca de preco, quantidade, valor da prestacao;II - a correcao de dados cadastrais que implique mudanca do emitente, tomador, remetente ou do destinatario;III - a data de emissao ou de saida.");
+
+        DFXMLValidador.validaEventoCartaCorrecaoCTe300(cartaCorrecao.toString());
 
         return super.gerarEvento(chaveAcesso, WSCartaCorrecao.VERSAO_LEIAUTE, cartaCorrecao, WSCartaCorrecao.EVENTO_CARTA_DE_CORRECAO, null, sequencialEvento);
     }

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSComprovanteEntrega.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSComprovanteEntrega.java
@@ -5,6 +5,7 @@ import com.fincatto.documentofiscal.cte300.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEventoRetorno;
 import com.fincatto.documentofiscal.cte300.classes.evento.comprovanteentrega.CTeEnviaEventoComprovanteEntrega;
 import com.fincatto.documentofiscal.utils.DFAssinaturaDigital;
+import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
@@ -39,8 +40,10 @@ class WSComprovanteEntrega extends WSRecepcaoEvento {
         return super.efetuaEvento(xmlAssinado, chaveAcesso, WSComprovanteEntrega.VERSAO_LEIAUTE);
     }
 
-    private CTeEvento gerarDadosComprovanteEntrega(final String chaveAcesso, final CTeEnviaEventoComprovanteEntrega comprovanteEntrega, final int sequencialEvento) {
+    private CTeEvento gerarDadosComprovanteEntrega(final String chaveAcesso, final CTeEnviaEventoComprovanteEntrega comprovanteEntrega, final int sequencialEvento) throws Exception {
         comprovanteEntrega.setDescricaoEvento(WSComprovanteEntrega.DESCRICAO_EVENTO);
+
+        DFXMLValidador.validaEventoComprovanteEntregaCTe300(comprovanteEntrega.toString());
 
         return super.gerarEvento(chaveAcesso, WSComprovanteEntrega.VERSAO_LEIAUTE, comprovanteEntrega, WSComprovanteEntrega.EVENTO_COMPROVANTE_DE_ENTREGA, null, sequencialEvento);
     }

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSEpec.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSEpec.java
@@ -5,6 +5,7 @@ import com.fincatto.documentofiscal.cte300.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEventoRetorno;
 import com.fincatto.documentofiscal.cte300.classes.evento.epec.CTeEnviaEventoEpec;
 import com.fincatto.documentofiscal.utils.DFAssinaturaDigital;
+import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
@@ -39,8 +40,10 @@ class WSEpec extends WSRecepcaoEvento {
         return super.efetuaEventoSVC(xmlAssinado, chaveAcesso, WSEpec.VERSAO_LEIAUTE);
     }
 
-    private CTeEvento gerarDadosEpec(final String chaveAcesso, final CTeEnviaEventoEpec eventoEpec) {
+    private CTeEvento gerarDadosEpec(final String chaveAcesso, final CTeEnviaEventoEpec eventoEpec) throws Exception {
         eventoEpec.setDescricaoEvento(WSEpec.DESCRICAO_EVENTO);
+
+        DFXMLValidador.validaEventoEpecCTe300(eventoEpec.toString());
 
         return super.gerarEvento(chaveAcesso, WSEpec.VERSAO_LEIAUTE, eventoEpec, WSEpec.EVENTO_EPEC, null, 1);
     }

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSGtv.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSGtv.java
@@ -5,6 +5,7 @@ import com.fincatto.documentofiscal.cte300.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEventoRetorno;
 import com.fincatto.documentofiscal.cte300.classes.evento.gtv.CTeEnviaEventoGtv;
 import com.fincatto.documentofiscal.utils.DFAssinaturaDigital;
+import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
@@ -39,8 +40,10 @@ class WSGtv extends WSRecepcaoEvento {
         return super.efetuaEventoSVC(xmlAssinado, chaveAcesso, WSGtv.VERSAO_LEIAUTE);
     }
 
-    private CTeEvento gerarDadosGtv(final String chaveAcesso, final CTeEnviaEventoGtv eventoGtv, final int sequencialEvento) {
+    private CTeEvento gerarDadosGtv(final String chaveAcesso, final CTeEnviaEventoGtv eventoGtv, final int sequencialEvento) throws Exception {
         eventoGtv.setDescricaoEvento(WSGtv.DESCRICAO_EVENTO);
+
+        DFXMLValidador.validaEventoGtvCTe300(eventoGtv.toString());
 
         return super.gerarEvento(chaveAcesso, WSGtv.VERSAO_LEIAUTE, eventoGtv, WSGtv.EVENTO_GTV, null, sequencialEvento);
     }

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSPrestacaoEmDesacordo.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSPrestacaoEmDesacordo.java
@@ -5,6 +5,7 @@ import com.fincatto.documentofiscal.cte300.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEventoRetorno;
 import com.fincatto.documentofiscal.cte300.classes.evento.desacordo.CTeEnviaEventoPrestacaoEmDesacordo;
 import com.fincatto.documentofiscal.utils.DFAssinaturaDigital;
+import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
@@ -39,11 +40,13 @@ class WSPrestacaoEmDesacordo extends WSRecepcaoEvento {
         return super.efetuaEvento(xmlAssinado, chaveAcesso, WSPrestacaoEmDesacordo.VERSAO_LEIAUTE);
     }
 
-    private CTeEvento gerarDadosPrestacaoEmDesacordo(final String chaveAcesso, final String motivo, final String cpfOuCnpj) {
+    private CTeEvento gerarDadosPrestacaoEmDesacordo(final String chaveAcesso, final String motivo, final String cpfOuCnpj) throws Exception {
         final CTeEnviaEventoPrestacaoEmDesacordo desacordo = new CTeEnviaEventoPrestacaoEmDesacordo();
         desacordo.setDescricaoEvento(WSPrestacaoEmDesacordo.DESCRICAO_EVENTO);
         desacordo.setIndicadorPrestacaoEmDesacordo(1);
         desacordo.setObservacao(motivo.trim());
+
+        DFXMLValidador.validaEventoPrestacaoEmDesacordoCTe300(desacordo.toString());
 
         return super.gerarEvento(chaveAcesso, WSPrestacaoEmDesacordo.VERSAO_LEIAUTE, desacordo, WSPrestacaoEmDesacordo.EVENTO_SERVICO_EM_DESACORDO, cpfOuCnpj, 1);
     }

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSRecepcaoEvento.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSRecepcaoEvento.java
@@ -8,6 +8,7 @@ import com.fincatto.documentofiscal.cte300.classes.evento.*;
 import com.fincatto.documentofiscal.cte300.parsers.CTChaveParser;
 import com.fincatto.documentofiscal.cte300.webservices.recepcaoevento.RecepcaoEventoStub;
 import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.util.AXIOMUtil;
 
@@ -31,6 +32,8 @@ abstract class WSRecepcaoEvento implements DFLog {
     }
 
     protected OMElement efetuaEvento(final String xmlAssinado, final String chaveAcesso, final BigDecimal versao, final boolean contingencia) throws Exception {
+        DFXMLValidador.validaEventoCTe300(xmlAssinado);
+
         final CTChaveParser ctChaveParser = new CTChaveParser(chaveAcesso);
         final RecepcaoEventoStub.CteCabecMsg cabec = new RecepcaoEventoStub.CteCabecMsg();
         cabec.setCUF(ctChaveParser.getNFUnidadeFederativa().getCodigoIbge());

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSRecepcaoEvento.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSRecepcaoEvento.java
@@ -83,7 +83,7 @@ abstract class WSRecepcaoEvento implements DFLog {
         }
 
         infoEvento.setDataHoraEvento(ZonedDateTime.now(this.config.getTimeZone().toZoneId()));
-        infoEvento.setId(String.format("ID%s%s0%02d", codigoEvento, chaveAcesso, sequencialEvento));
+        infoEvento.setId(String.format("ID%s%s%02d", codigoEvento, chaveAcesso, sequencialEvento));
         infoEvento.setNumeroSequencialEvento(sequencialEvento);
         infoEvento.setOrgao(chaveParser.getNFUnidadeFederativa());
         infoEvento.setCodigoEvento(codigoEvento);

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSRecepcaoLote.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSRecepcaoLote.java
@@ -43,7 +43,7 @@ class WSRecepcaoLote implements DFLog {
     
     private CTeEnvioLoteRetorno comunicaLote(final String loteAssinadoXml) throws Exception {
         //valida o lote assinado, para verificar se o xsd foi satisfeito, antes de comunicar com a sefaz
-        DFXMLValidador.validaLoteCTe(loteAssinadoXml);
+        DFXMLValidador.validaLoteCTe300(loteAssinadoXml);
         
         //envia o lote para a sefaz
         final OMElement omElement = this.cteToOMElement(loteAssinadoXml);

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSRegistroMultimodal.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSRegistroMultimodal.java
@@ -5,6 +5,7 @@ import com.fincatto.documentofiscal.cte300.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEventoRetorno;
 import com.fincatto.documentofiscal.cte300.classes.evento.multimodal.CTeEnviaEventoRegistroMultimodal;
 import com.fincatto.documentofiscal.utils.DFAssinaturaDigital;
+import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
@@ -39,11 +40,13 @@ class WSRegistroMultimodal extends WSRecepcaoEvento {
         return super.efetuaEvento(xmlAssinado, chaveAcesso, WSRegistroMultimodal.VERSAO_LEIAUTE);
     }
 
-    private CTeEvento gerarDadosRegistroMultimodal(final String chaveAcesso, final String informacoesAdicionais, final String numeroDocumento) {
+    private CTeEvento gerarDadosRegistroMultimodal(final String chaveAcesso, final String informacoesAdicionais, final String numeroDocumento) throws Exception {
         final CTeEnviaEventoRegistroMultimodal registroMultimodal = new CTeEnviaEventoRegistroMultimodal();
         registroMultimodal.setDescricaoEvento(WSRegistroMultimodal.DESCRICAO_EVENTO);
         registroMultimodal.setInformacoesAdicionais(informacoesAdicionais.trim());
         registroMultimodal.setNumero(numeroDocumento.trim());
+
+        DFXMLValidador.validaEventoRegistroMultimodalCTe300(registroMultimodal.toString());
 
         return super.gerarEvento(chaveAcesso, WSRegistroMultimodal.VERSAO_LEIAUTE, registroMultimodal, WSRegistroMultimodal.EVENTO_REGISTRO_MULTIMODAL, null, 1);
     }

--- a/src/main/java/com/fincatto/documentofiscal/validadores/DFXMLValidador.java
+++ b/src/main/java/com/fincatto/documentofiscal/validadores/DFXMLValidador.java
@@ -93,12 +93,48 @@ public final class DFXMLValidador {
         return true;
     }
 
-    public static boolean validaLoteCTe(final String arquivoXML) throws Exception {
+    public static boolean validaLoteCTe300(final String arquivoXML) throws Exception {
         return DFXMLValidador.validaCTe(arquivoXML, "enviCTe_v3.00.xsd");
     }
 
     public static boolean validaNotaCte(final String arquivoXML) throws Exception {
         return DFXMLValidador.validaCTe(arquivoXML, "cte_v3.00.xsd");
+    }
+
+    public static boolean validaEventoCTe300(final String arquivoXML) throws Exception {
+        return DFXMLValidador.validaCTe(arquivoXML, "eventoCTe_v3.00.xsd");
+    }
+
+    public static boolean validaEventoCancelamentoCTe300(final String arquivoXML) throws Exception {
+        return DFXMLValidador.validaCTe(arquivoXML, "evCancCTe_v3.00.xsd");
+    }
+
+    public static boolean validaEventoCancelamentoComprovanteEntregaCTe300(final String arquivoXML) throws Exception {
+        return DFXMLValidador.validaCTe(arquivoXML, "evCancCECTe_v3.00.xsd");
+    }
+
+    public static boolean validaEventoCartaCorrecaoCTe300(final String arquivoXML) throws Exception {
+        return DFXMLValidador.validaCTe(arquivoXML, "evCCeCTe_v3.00.xsd");
+    }
+
+    public static boolean validaEventoComprovanteEntregaCTe300(final String arquivoXML) throws Exception {
+        return DFXMLValidador.validaCTe(arquivoXML, "evCECTe_v3.00.xsd");
+    }
+
+    public static boolean validaEventoEpecCTe300(final String arquivoXML) throws Exception {
+        return DFXMLValidador.validaCTe(arquivoXML, "evEPECCTe_v3.00.xsd");
+    }
+
+    public static boolean validaEventoGtvCTe300(final String arquivoXML) throws Exception {
+        return DFXMLValidador.validaCTe(arquivoXML, "evGTV_v3.00.xsd");
+    }
+
+    public static boolean validaEventoPrestacaoEmDesacordoCTe300(final String arquivoXML) throws Exception {
+        return DFXMLValidador.validaCTe(arquivoXML, "evPrestDesacordo_v3.00.xsd");
+    }
+
+    public static boolean validaEventoRegistroMultimodalCTe300(final String arquivoXML) throws Exception {
+        return DFXMLValidador.validaCTe(arquivoXML, "evRegMultimodal_v3.00.xsd");
     }
 
     private static boolean validaDfe(final String xml, final String xsd) throws IOException, SAXException, URISyntaxException {

--- a/src/main/java/com/fincatto/documentofiscal/validadores/DFXMLValidador.java
+++ b/src/main/java/com/fincatto/documentofiscal/validadores/DFXMLValidador.java
@@ -86,7 +86,7 @@ public final class DFXMLValidador {
     }
 
     private static boolean validaCTe(final String xml, final String xsd) throws IOException, SAXException, URISyntaxException {
-        final URL xsdPath = DFXMLValidador.class.getClassLoader().getResource(String.format("schemas/PL_CTe_300a/%s", xsd));
+        final URL xsdPath = DFXMLValidador.class.getClassLoader().getResource(String.format("schemas/PL_CTe_300a_NT2022.001/%s", xsd));
         final SchemaFactory schemaFactory = SchemaFactory.newInstance("http://www.w3.org/2001/XMLSchema");
         final Schema schema = schemaFactory.newSchema(new StreamSource(xsdPath.toURI().toString()));
         schema.newValidator().validate(new StreamSource(new StringReader(xml)));


### PR DESCRIPTION
No meu PR anterior (#902) esqueci de corrigir um erro na geração do atributo "Id" dos eventos e o tratamento pra geração do EPEC também não estava 100%. Fiz essas correções aqui e também tratei para validar o XML gerado pelos eventos contra os schemas do CT-e 3.00 antes do envio.