### PR TITLE
Correções em anotações nas classes do CT-e 3.00 e 4.00 como Namespace, Root e ElementList

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.github.wmixvideo</groupId>
     <artifactId>nfe</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.25-SNAPSHOT</version>
+    <version>4.0.24-SNAPSHOT</version>
     <name>nfe</name>
     <description>Biblioteca de comunicacao de nota fiscal eletronica brasileira</description>
     <url>https://github.com/wmixvideo/nfe</url>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>com.github.wmixvideo</groupId>
     <artifactId>nfe</artifactId>
     <packaging>jar</packaging>
-    <version>4.0.24-SNAPSHOT</version>
+    <version>4.0.25-SNAPSHOT</version>
     <name>nfe</name>
     <description>Biblioteca de comunicacao de nota fiscal eletronica brasileira</description>
     <url>https://github.com/wmixvideo/nfe</url>

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/cartacorrecao/CTeEnviaEventoCartaCorrecao.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/cartacorrecao/CTeEnviaEventoCartaCorrecao.java
@@ -6,13 +6,14 @@ import org.simpleframework.xml.Namespace;
 import org.simpleframework.xml.Root;
 
 import java.util.List;
+import org.simpleframework.xml.ElementList;
 
 @Root(name = "evCCeCTe")
 @Namespace(reference = "http://www.portalfiscal.inf.br/cte")
 public class CTeEnviaEventoCartaCorrecao extends CTeTipoEvento {
     private static final long serialVersionUID = -6818585208080376005L;
 
-    @Element(name = "infCorrecao")
+    @ElementList(name = "infCorrecao", inline = true, required = true)
     private List<CTeInformacaoCartaCorrecao> correcoes;
 
     @Element(name = "xCondUso")

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/cartacorrecao/CTeInformacaoCartaCorrecao.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/evento/cartacorrecao/CTeInformacaoCartaCorrecao.java
@@ -2,7 +2,9 @@ package com.fincatto.documentofiscal.cte300.classes.evento.cartacorrecao;
 
 import com.fincatto.documentofiscal.validadores.DFStringValidador;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Root;
 
+@Root(name = "infCorrecao")
 public class CTeInformacaoCartaCorrecao {
     @Element(name = "grupoAlterado")
     private String grupoAlterado;
@@ -13,7 +15,7 @@ public class CTeInformacaoCartaCorrecao {
     @Element(name = "valorAlterado")
     private String valorAlterado;
 
-    @Element(name = "nroItemAlterado")
+    @Element(name = "nroItemAlterado", required = false)
     private Integer numeroItemAlterado;
 
     public String getGrupoAlterado() {

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/nota/CTeNotaInfoCTeNormalInfoDocumentosInfoNF.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/nota/CTeNotaInfoCTeNormalInfoDocumentosInfoNF.java
@@ -11,6 +11,7 @@ import org.simpleframework.xml.Root;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import org.simpleframework.xml.ElementList;
 
 /**
  * @author Caio
@@ -71,10 +72,10 @@ public class CTeNotaInfoCTeNormalInfoDocumentosInfoNF extends DFBase {
     @Element(name = "dPrev", required = false)
     private LocalDate dataPrevistaEntrega;
 
-    @Element(name = "infUnidCarga", required = false)
+    @ElementList(name = "infUnidCarga", inline = true, required = false)
     private List<CTeNotaInfoCTeNormalInfoDocumentosInfoUnidadeCarga> infoUnidadeCarga;
 
-    @Element(name = "infUnidTransp", required = false)
+    @ElementList(name = "infUnidTransp", inline = true, required = false)
     private List<CTeNotaInfoCTeNormalInfoDocumentosInfoUnidadeTransporte> infoUnidadeTransporte;
 
     public CTeNotaInfoCTeNormalInfoDocumentosInfoNF() {

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/nota/CTeProcessado.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/nota/CTeProcessado.java
@@ -6,11 +6,13 @@ import org.simpleframework.xml.Root;
 
 import com.fincatto.documentofiscal.DFBase;
 import com.fincatto.documentofiscal.cte300.classes.enviolote.consulta.CTeProtocolo;
+import org.simpleframework.xml.Namespace;
 
 /**
  * Created by Eldevan Nery Junior on 09/10/17.
  */
 @Root(name = "cteProc")
+@Namespace(reference = "http://www.portalfiscal.inf.br/cte")
 public class CTeProcessado extends DFBase {
     private static final long serialVersionUID = 7518732714448342954L;
 

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/evento/cartacorrecao/CTeEnviaEventoCartaCorrecao.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/evento/cartacorrecao/CTeEnviaEventoCartaCorrecao.java
@@ -7,13 +7,14 @@ import org.simpleframework.xml.Namespace;
 import org.simpleframework.xml.Root;
 
 import java.util.List;
+import org.simpleframework.xml.ElementList;
 
 @Root(name = "evCCeCTe")
 @Namespace(reference = CTeConfig.NAMESPACE)
 public class CTeEnviaEventoCartaCorrecao extends CTeTipoEvento {
     private static final long serialVersionUID = -6818585208080376005L;
 
-    @Element(name = "infCorrecao")
+    @ElementList(name = "infCorrecao", inline = true, required = true)
     private List<CTeInformacaoCartaCorrecao> correcoes;
 
     @Element(name = "xCondUso")

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/evento/cartacorrecao/CTeInformacaoCartaCorrecao.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/evento/cartacorrecao/CTeInformacaoCartaCorrecao.java
@@ -2,7 +2,9 @@ package com.fincatto.documentofiscal.cte400.classes.evento.cartacorrecao;
 
 import com.fincatto.documentofiscal.validadores.DFStringValidador;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Root;
 
+@Root(name = "infCorrecao")
 public class CTeInformacaoCartaCorrecao {
     @Element(name = "grupoAlterado")
     private String grupoAlterado;
@@ -13,7 +15,7 @@ public class CTeInformacaoCartaCorrecao {
     @Element(name = "valorAlterado")
     private String valorAlterado;
 
-    @Element(name = "nroItemAlterado")
+    @Element(name = "nroItemAlterado", required = false)
     private Integer numeroItemAlterado;
 
     public String getGrupoAlterado() {

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeNotaInfoCTeNormalInfoDocumentosInfoNF.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeNotaInfoCTeNormalInfoDocumentosInfoNF.java
@@ -12,6 +12,7 @@ import org.simpleframework.xml.Root;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import org.simpleframework.xml.ElementList;
 
 /**
  * Informações das NF<br>
@@ -71,10 +72,10 @@ public class CTeNotaInfoCTeNormalInfoDocumentosInfoNF extends DFBase {
     @Element(name = "dPrev", required = false)
     private LocalDate dataPrevistaEntrega;
 
-    @Element(name = "infUnidCarga", required = false)
+    @ElementList(name = "infUnidCarga", inline = true, required = false)
     private List<CTeNotaInfoCTeNormalInfoDocumentosInfoUnidadeCarga> infoUnidadeCarga;
 
-    @Element(name = "infUnidTransp", required = false)
+    @ElementList(name = "infUnidTransp", inline = true, required = false)
     private List<CTeNotaInfoCTeNormalInfoDocumentosInfoUnidadeTransporte> infoUnidadeTransporte;
 
     public String getNumeroRomaneio() {

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeProcessado.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeProcessado.java
@@ -4,12 +4,14 @@ import com.fincatto.documentofiscal.DFBase;
 import com.fincatto.documentofiscal.cte400.classes.envio.CTeProtocolo;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
 import org.simpleframework.xml.Root;
 
 /**
  * Created by Eldevan Nery Junior on 09/10/17.
  */
 @Root(name = "cteProc")
+@Namespace(reference = "http://www.portalfiscal.inf.br/cte")
 public class CTeProcessado extends DFBase {
     private static final long serialVersionUID = -765312048472045116L;
 


### PR DESCRIPTION
Correções em anotações nas classes do CT-e 3.00 e 4.00 como Namespace, Root e ElementList. Os campos do XML do CT-e infUnidCarga e infUnidTransp devem ser anotados com ElementList e não Element.