### PR TITLE
Correções diversas nas classes do CT-e

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/nota/CTeNotaInfoCTeNormalInfoCTeSubstituicao.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/nota/CTeNotaInfoCTeNormalInfoCTeSubstituicao.java
@@ -19,10 +19,10 @@ public class CTeNotaInfoCTeNormalInfoCTeSubstituicao extends DFBase {
     @Element(name = "chCte")
     private String chaveCTe;
     
-    @Element(name = "refCteAnu")
+    @Element(name = "refCteAnu", required = false)
     private String chaveCTeAnulacao;
     
-    @Element(name = "tomaICMS")
+    @Element(name = "tomaICMS", required = false)
     private CTeNotaInfoCTeNormalInfoCTeSubstituicaoTomadorICMS tomadorICMS;
 
     @Element(name = "indAlteraToma", required = false)

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/nota/consulta/CTeNotaConsultaRetorno.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/nota/consulta/CTeNotaConsultaRetorno.java
@@ -104,4 +104,11 @@ public class CTeNotaConsultaRetorno extends DFBase {
         this.protocolo = protocolo;
     }
 
+    public List<CTeProtocoloEvento> getProtocoloEvento() {
+        return protocoloEvento;
+    }
+
+    public void setProtocoloEvento(List<CTeProtocoloEvento> protocoloEvento) {
+        this.protocoloEvento = protocoloEvento;
+    }
 }

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSFacade.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSFacade.java
@@ -421,8 +421,8 @@ public class WSFacade {
      * @return dados do desacordo do CT-e retornado pelo webservice
      * @throws Exception caso nao consiga gerar o xml ou problema de conexao com o sefaz
      */
-    public CTeEventoRetorno prestacaoEmDesacordo(final String chave, final String observacao, final String cpfOuCnpj) throws Exception {
-        return this.wsPrestacaoEmDesacordo.prestacaoEmDesacordo(chave, observacao, cpfOuCnpj);
+    public CTeEventoRetorno prestacaoEmDesacordo(final String chave, final String observacao, final String cpfOuCnpj, final int sequencialEvento) throws Exception {
+        return this.wsPrestacaoEmDesacordo.prestacaoEmDesacordo(chave, observacao, cpfOuCnpj, sequencialEvento);
     }
 
     /**
@@ -446,8 +446,8 @@ public class WSFacade {
      * @return O XML da requisicao de prestação de serviço em desacordo ja assinado
      * @throws Exception caso nao consiga gerar o xml
      */
-    public String getXmlAssinadoPrestacaoEmDesacordo(final String chave, final String observacao, final String cpfOuCnpj) throws Exception {
-        return this.wsPrestacaoEmDesacordo.getXmlAssinado(chave, observacao, cpfOuCnpj);
+    public String getXmlAssinadoPrestacaoEmDesacordo(final String chave, final String observacao, final String cpfOuCnpj, final int sequencialEvento) throws Exception {
+        return this.wsPrestacaoEmDesacordo.getXmlAssinado(chave, observacao, cpfOuCnpj, sequencialEvento);
     }
 
     /**

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSPrestacaoEmDesacordo.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSPrestacaoEmDesacordo.java
@@ -24,17 +24,17 @@ class WSPrestacaoEmDesacordo extends WSRecepcaoEvento {
         return this.config.getPersister().read(CTeEventoRetorno.class, omElementResult.toString());
     }
 
-    CTeEventoRetorno prestacaoEmDesacordo(final String chaveAcesso, final String motivo, final String cpfOuCnpj) throws Exception {
-        final String xmlAssinado = this.getXmlAssinado(chaveAcesso, motivo, cpfOuCnpj);
+    CTeEventoRetorno prestacaoEmDesacordo(final String chaveAcesso, final String motivo, final String cpfOuCnpj, final int sequencialEvento) throws Exception {
+        final String xmlAssinado = this.getXmlAssinado(chaveAcesso, motivo, cpfOuCnpj, sequencialEvento);
         return prestacaoEmDesacordoAssinada(chaveAcesso, xmlAssinado);
     }
 
-    String getXmlAssinado(final String chave, final String observacao, final String cpfOuCnpj) throws Exception {
-        final String xml = this.gerarDadosPrestacaoEmDesacordo(chave, observacao, cpfOuCnpj).toString();
+    String getXmlAssinado(final String chave, final String observacao, final String cpfOuCnpj, final int sequencialEvento) throws Exception {
+        final String xml = this.gerarDadosPrestacaoEmDesacordo(chave, observacao, cpfOuCnpj, sequencialEvento).toString();
         return new DFAssinaturaDigital(this.config).assinarDocumento(xml);
     }
 
-    private CTeEvento gerarDadosPrestacaoEmDesacordo(final String chaveAcesso, final String motivo, final String cpfOuCnpj) throws Exception {
+    private CTeEvento gerarDadosPrestacaoEmDesacordo(final String chaveAcesso, final String motivo, final String cpfOuCnpj, final int sequencialEvento) throws Exception {
         final CTeEnviaEventoPrestacaoEmDesacordo desacordo = new CTeEnviaEventoPrestacaoEmDesacordo();
         desacordo.setDescricaoEvento(WSPrestacaoEmDesacordo.DESCRICAO_EVENTO);
         desacordo.setIndicadorPrestacaoEmDesacordo(1);
@@ -42,6 +42,6 @@ class WSPrestacaoEmDesacordo extends WSRecepcaoEvento {
 
         DFXMLValidador.validaEventoPrestacaoEmDesacordoCTe300(desacordo.toString());
 
-        return super.gerarEvento(chaveAcesso, WSPrestacaoEmDesacordo.VERSAO_LEIAUTE, desacordo, WSPrestacaoEmDesacordo.EVENTO_SERVICO_EM_DESACORDO, cpfOuCnpj, 1);
+        return super.gerarEvento(chaveAcesso, WSPrestacaoEmDesacordo.VERSAO_LEIAUTE, desacordo, WSPrestacaoEmDesacordo.EVENTO_SERVICO_EM_DESACORDO, cpfOuCnpj, sequencialEvento);
     }
 }

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSRecepcaoEvento.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSRecepcaoEvento.java
@@ -85,8 +85,8 @@ abstract class WSRecepcaoEvento implements DFLog {
         }
 
         infoEvento.setDataHoraEvento(ZonedDateTime.now(this.config.getTimeZone().toZoneId()));
-        infoEvento.setId(String.format("ID%s%s%02d", codigoEvento, chaveAcesso, sequencialEvento));
         infoEvento.setNumeroSequencialEvento(sequencialEvento);
+        infoEvento.setId(String.format("ID%s%s%02d", codigoEvento, chaveAcesso, sequencialEvento));
         infoEvento.setOrgao(chaveParser.getNFUnidadeFederativa());
         infoEvento.setCodigoEvento(codigoEvento);
         infoEvento.setDetalheEvento(cteDetalhamentoEventoCancelamento);

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/consulta/CTeNotaConsultaRetorno.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/consulta/CTeNotaConsultaRetorno.java
@@ -94,4 +94,11 @@ public class CTeNotaConsultaRetorno extends DFBase {
         this.protocolo = protocolo;
     }
 
+    public List<CTeProtocoloEvento> getProtocoloEvento() {
+        return protocoloEvento;
+    }
+
+    public void setProtocoloEvento(List<CTeProtocoloEvento> protocoloEvento) {
+        this.protocoloEvento = protocoloEvento;
+    }
 }

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSCancelamentoPrestacaoEmDesacordo.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSCancelamentoPrestacaoEmDesacordo.java
@@ -24,23 +24,23 @@ class WSCancelamentoPrestacaoEmDesacordo extends WSRecepcaoEvento {
         return this.config.getPersister().read(CTeEventoRetorno.class, omElementResult.toString());
     }
 
-    CTeEventoRetorno cancelaPrestacaoEmDesacordo(final String chaveAcesso, final String protocoloDesacordo, final int sequencialEvento) throws Exception {
-        final String xmlAssinado = this.getXmlAssinado(chaveAcesso, protocoloDesacordo, sequencialEvento);
+    CTeEventoRetorno cancelaPrestacaoEmDesacordo(final String chaveAcesso, final String protocoloDesacordo, final String cpfOuCnpj, final int sequencialEvento) throws Exception {
+        final String xmlAssinado = this.getXmlAssinado(chaveAcesso, protocoloDesacordo, cpfOuCnpj, sequencialEvento);
         return cancelaPrestacaoEmDesacordoAssinado(chaveAcesso, xmlAssinado);
     }
 
-    String getXmlAssinado(final String chave, final String protocoloDesacordo, final int sequencialEvento) throws Exception {
-        final String xml = this.gerarDados(chave, protocoloDesacordo, sequencialEvento).toString();
+    String getXmlAssinado(final String chave, final String protocoloDesacordo, final String cpfOuCnpj, final int sequencialEvento) throws Exception {
+        final String xml = this.gerarDados(chave, protocoloDesacordo, cpfOuCnpj, sequencialEvento).toString();
         return new DFAssinaturaDigital(this.config).assinarDocumento(xml);
     }
 
-    private CTeEvento gerarDados(final String chaveAcesso, final String protocoloDesacordo, final int sequencialEvento) throws Exception {
+    private CTeEvento gerarDados(final String chaveAcesso, final String protocoloDesacordo, final String cpfOuCnpj, final int sequencialEvento) throws Exception {
         final CTeEnviaEventoCancelamentoPrestacaoEmDesacordo cancDesacordo = new CTeEnviaEventoCancelamentoPrestacaoEmDesacordo();
         cancDesacordo.setDescricaoEvento(DESCRICAO_EVENTO);
         cancDesacordo.setProtocoloDesacordo(protocoloDesacordo);
 
         DFXMLValidador.validaEventoCancelamentoPrestacaoEmDesacordoCTe400(cancDesacordo.toString());
 
-        return super.gerarEvento(chaveAcesso, VERSAO_LEIAUTE, cancDesacordo, EVENTO_CANCELAMENTO_DESACORDO, null, sequencialEvento);
+        return super.gerarEvento(chaveAcesso, VERSAO_LEIAUTE, cancDesacordo, EVENTO_CANCELAMENTO_DESACORDO, cpfOuCnpj, sequencialEvento);
     }
 }

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSFacade.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSFacade.java
@@ -367,8 +367,8 @@ public class WSFacade {
      * @return dados do desacordo do CT-e retornado pelo webservice
      * @throws Exception caso nao consiga gerar o xml ou problema de conexao com o sefaz
      */
-    public CTeEventoRetorno prestacaoEmDesacordo(final String chave, final String observacao, final String cpfOuCnpj) throws Exception {
-        return this.wsPrestacaoEmDesacordo.prestacaoEmDesacordo(chave, observacao, cpfOuCnpj);
+    public CTeEventoRetorno prestacaoEmDesacordo(final String chave, final String observacao, final String cpfOuCnpj, final int sequencialEvento) throws Exception {
+        return this.wsPrestacaoEmDesacordo.prestacaoEmDesacordo(chave, observacao, cpfOuCnpj, sequencialEvento);
     }
 
     /**
@@ -392,8 +392,8 @@ public class WSFacade {
      * @return O XML da requisicao de prestação de serviço em desacordo ja assinado
      * @throws Exception caso nao consiga gerar o xml
      */
-    public String getXmlAssinadoPrestacaoEmDesacordo(final String chave, final String observacao, final String cpfOuCnpj) throws Exception {
-        return this.wsPrestacaoEmDesacordo.getXmlAssinado(chave, observacao, cpfOuCnpj);
+    public String getXmlAssinadoPrestacaoEmDesacordo(final String chave, final String observacao, final String cpfOuCnpj, final int sequencialEvento) throws Exception {
+        return this.wsPrestacaoEmDesacordo.getXmlAssinado(chave, observacao, cpfOuCnpj, sequencialEvento);
     }
 
     /**

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSFacade.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSFacade.java
@@ -255,6 +255,7 @@ public class WSFacade {
      *
      * @param chave                 chave de acesso do CT-e
      * @param comprovanteEntrega    dados do comprovante de entrega
+     * @param sequencialEvento      sequencial do evento
      * @return dados do comprovante de entrega retornado pelo webservice
      * @throws Exception caso nao consiga gerar o xml ou problema de conexao com o sefaz
      */
@@ -279,6 +280,7 @@ public class WSFacade {
      * Gera o XML assinado do comprovante de entrega sem enviar para a SEFAZ.
      * @param chave                 chave de acesso do CT-e
      * @param comprovanteEntrega    dados do comprovante de entrega
+     * @param sequencialEvento      sequencial do evento
      * @return O XML da requisicao de comprovante de entrega ja assinado
      * @throws Exception caso nao consiga gerar o xml
      */
@@ -361,9 +363,10 @@ public class WSFacade {
     /**
      * Faz o registro de prestação de serviço em desacordo.
      *
-     * @param chave           chave de acesso do CT-e
-     * @param observacao      observação do desacordo
-     * @param cpfOuCnpj       CPF ou CNPJ do autor do evento
+     * @param chave            chave de acesso do CT-e
+     * @param observacao       observação do desacordo
+     * @param cpfOuCnpj        CPF ou CNPJ do autor do evento
+     * @param sequencialEvento sequencial do evento
      * @return dados do desacordo do CT-e retornado pelo webservice
      * @throws Exception caso nao consiga gerar o xml ou problema de conexao com o sefaz
      */
@@ -386,9 +389,10 @@ public class WSFacade {
 
     /**
      * Gera o XML assinado da prestação de serviço em desacordo sem enviar para a SEFAZ.
-     * @param chave           chave de acesso do CT-e
-     * @param observacao      observação do desacordo
-     * @param cpfOuCnpj       CPF ou CNPJ do autor do evento
+     * @param chave            chave de acesso do CT-e
+     * @param observacao       observação do desacordo
+     * @param cpfOuCnpj        CPF ou CNPJ do autor do evento
+     * @param sequencialEvento sequencial do evento
      * @return O XML da requisicao de prestação de serviço em desacordo ja assinado
      * @throws Exception caso nao consiga gerar o xml
      */
@@ -439,12 +443,13 @@ public class WSFacade {
      *
      * @param chave                       chave de acesso do CT-e
      * @param protocoloDesacordo          protocolo do evento de prestação de serviço em desacordo
+     * @param cpfOuCnpj                   CPF ou CNPJ do autor do evento
      * @param sequencialEvento            sequencial do evento
      * @return dados do cancelamento do evento de prestação de serviço em desacordo retornado pelo webservice
      * @throws Exception caso nao consiga gerar o xml ou problema de conexao com o sefaz
      */
-    public CTeEventoRetorno cancelaPrestacaoEmDesacordo(final String chave, final String protocoloDesacordo, final int sequencialEvento) throws Exception {
-        return this.wsCancelamentoPrestacaoEmDesacordo.cancelaPrestacaoEmDesacordo(chave, protocoloDesacordo, sequencialEvento);
+    public CTeEventoRetorno cancelaPrestacaoEmDesacordo(final String chave, final String protocoloDesacordo, final String cpfOuCnpj, final int sequencialEvento) throws Exception {
+        return this.wsCancelamentoPrestacaoEmDesacordo.cancelaPrestacaoEmDesacordo(chave, protocoloDesacordo, cpfOuCnpj, sequencialEvento);
     }
 
     /**
@@ -464,12 +469,13 @@ public class WSFacade {
      * Gera o XML assinado do cancelamento do evento de prestação de serviço em desacordo sem enviar para a SEFAZ.
      * @param chave                       chave de acesso do CT-e
      * @param protocoloDesacordo          protocolo do evento de prestação de serviço em desacordo
+     * @param cpfOuCnpj                   CPF ou CNPJ do autor do evento
      * @param sequencialEvento            sequencial do evento
      * @return O XML da requisicao de cancelamento do evento de prestação de serviço em desacordo ja assinado
      * @throws Exception caso nao consiga gerar o xml
      */
-    public String getXmlAssinadoCancelamentoPrestacaoEmDesacordo(final String chave, final String protocoloDesacordo, final int sequencialEvento) throws Exception {
-        return this.wsCancelamentoPrestacaoEmDesacordo.getXmlAssinado(chave, protocoloDesacordo, sequencialEvento);
+    public String getXmlAssinadoCancelamentoPrestacaoEmDesacordo(final String chave, final String protocoloDesacordo, final String cpfOuCnpj, final int sequencialEvento) throws Exception {
+        return this.wsCancelamentoPrestacaoEmDesacordo.getXmlAssinado(chave, protocoloDesacordo, cpfOuCnpj, sequencialEvento);
     }
 
     /**

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSPrestacaoEmDesacordo.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSPrestacaoEmDesacordo.java
@@ -24,17 +24,17 @@ class WSPrestacaoEmDesacordo extends WSRecepcaoEvento {
         return this.config.getPersister().read(CTeEventoRetorno.class, omElementResult.toString());
     }
 
-    CTeEventoRetorno prestacaoEmDesacordo(final String chaveAcesso, final String motivo, final String cpfOuCnpj) throws Exception {
-        final String xmlAssinado = this.getXmlAssinado(chaveAcesso, motivo, cpfOuCnpj);
+    CTeEventoRetorno prestacaoEmDesacordo(final String chaveAcesso, final String motivo, final String cpfOuCnpj, final int sequencialEvento) throws Exception {
+        final String xmlAssinado = this.getXmlAssinado(chaveAcesso, motivo, cpfOuCnpj, sequencialEvento);
         return prestacaoEmDesacordoAssinada(chaveAcesso, xmlAssinado);
     }
 
-    String getXmlAssinado(final String chave, final String observacao, final String cpfOuCnpj) throws Exception {
-        final String xml = this.gerarDadosPrestacaoEmDesacordo(chave, observacao, cpfOuCnpj).toString();
+    String getXmlAssinado(final String chave, final String observacao, final String cpfOuCnpj, final int sequencialEvento) throws Exception {
+        final String xml = this.gerarDadosPrestacaoEmDesacordo(chave, observacao, cpfOuCnpj, sequencialEvento).toString();
         return new DFAssinaturaDigital(this.config).assinarDocumento(xml);
     }
 
-    private CTeEvento gerarDadosPrestacaoEmDesacordo(final String chaveAcesso, final String motivo, final String cpfOuCnpj) throws Exception {
+    private CTeEvento gerarDadosPrestacaoEmDesacordo(final String chaveAcesso, final String motivo, final String cpfOuCnpj, final int sequencialEvento) throws Exception {
         final CTeEnviaEventoPrestacaoEmDesacordo desacordo = new CTeEnviaEventoPrestacaoEmDesacordo();
         desacordo.setDescricaoEvento(DESCRICAO_EVENTO);
         desacordo.setIndicadorPrestacaoEmDesacordo(1);
@@ -42,6 +42,6 @@ class WSPrestacaoEmDesacordo extends WSRecepcaoEvento {
 
         DFXMLValidador.validaEventoPrestacaoEmDesacordoCTe400(desacordo.toString());
 
-        return super.gerarEvento(chaveAcesso, VERSAO_LEIAUTE, desacordo, EVENTO_SERVICO_EM_DESACORDO, cpfOuCnpj, 1);
+        return super.gerarEvento(chaveAcesso, VERSAO_LEIAUTE, desacordo, EVENTO_SERVICO_EM_DESACORDO, cpfOuCnpj, sequencialEvento);
     }
 }

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSRecepcaoEvento.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSRecepcaoEvento.java
@@ -81,8 +81,8 @@ abstract class WSRecepcaoEvento implements DFLog {
         }
 
         infoEvento.setDataHoraEvento(ZonedDateTime.now(this.config.getTimeZone().toZoneId()));
-        infoEvento.setId(String.format("ID%s%s%03d", codigoEvento, chaveAcesso, sequencialEvento));
         infoEvento.setNumeroSequencialEvento(sequencialEvento);
+        infoEvento.setId(String.format("ID%s%s%03d", codigoEvento, chaveAcesso, sequencialEvento));
         infoEvento.setOrgao(chaveParser.getNFUnidadeFederativa());
         infoEvento.setCodigoEvento(codigoEvento);
         infoEvento.setDetalheEvento(cteDetalhamentoEventoCancelamento);


### PR DESCRIPTION
- Ajustado evento de prestação em desacordo para receber o sequencial do evento porque é permitida a geração de até 20 eventos
- Ajustado cancelamento do evento de prestação em desacordo (existe apenas no 4.00) para receber o CPF/CNPJ do autor do evento pois assim como o evento de desacordo ele é gerado pelo tomador do serviço, então não dá pra extrair essa informação da chave de acesso do CT-e
- Corrigidos atributos opcionais na parte de CT-e de substituição no CT-e 3.00
- Incluído getter/setter que faltava na CTeNotaConsultaRetorno
- Melhorada mensagem de erro gerada quando é informado um sequencial de evento maior que o permitido