### PR TITLE
Adiciona suporte ao CT-e de Outros Serviços

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/CTAutorizador31.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/CTAutorizador31.java
@@ -44,7 +44,12 @@ public enum CTAutorizador31 {
         public String getRecepcaoEvento(final DFAmbiente ambiente) {
             return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homologacao.sefaz.mt.gov.br/ctews2/services/CteRecepcaoEvento?wsdl" : "https://cte.sefaz.mt.gov.br/ctews2/services/CteRecepcaoEvento?wsdl";
         }
-        
+
+        @Override
+        public String getCteRecepcaoOS(DFAmbiente ambiente) {
+            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homologacao.sefaz.mt.gov.br/ctews/services/CteRecepcaoOS" : "https://cte.sefaz.mt.gov.br/ctews/services/CteRecepcaoOS";
+        }
+
         @Override
         public DFUnidadeFederativa[] getUFs() {
             return new DFUnidadeFederativa[]{DFUnidadeFederativa.MT};
@@ -85,6 +90,11 @@ public enum CTAutorizador31 {
         @Override
         public String getRecepcaoEvento(final DFAmbiente ambiente) {
             return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homologacao.cte.ms.gov.br/ws/CteRecepcaoEvento" : "https://producao.cte.ms.gov.br/ws/CteRecepcaoEvento";
+        }
+
+        @Override
+        public String getCteRecepcaoOS(DFAmbiente ambiente) {
+            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homologacao.cte.ms.gov.br/ws/CteRecepcaoOS" : "https://producao.cte.ms.gov.br/ws/CteRecepcaoOS";
         }
     
         @Override
@@ -128,6 +138,11 @@ public enum CTAutorizador31 {
         public String getRecepcaoEvento(final DFAmbiente ambiente) {
             return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://hcte.fazenda.mg.gov.br/cte/services/RecepcaoEvento" : "https://cte.fazenda.mg.gov.br/cte/services/RecepcaoEvento";
         }
+
+        @Override
+        public String getCteRecepcaoOS(DFAmbiente ambiente) {
+            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://hcte.fazenda.mg.gov.br/cte/services/CteRecepcaoOS" : "https://cte.fazenda.mg.gov.br/cte/services/CteRecepcaoOS";
+        }
     
         @Override
         public DFUnidadeFederativa[] getUFs() {
@@ -169,6 +184,11 @@ public enum CTAutorizador31 {
         @Override
         public String getRecepcaoEvento(final DFAmbiente ambiente) {
             return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homologacao.cte.fazenda.pr.gov.br/cte/CteRecepcaoEvento?wsdl" : "https://cte.fazenda.pr.gov.br/cte/CteRecepcaoEvento?wsdl";
+        }
+
+        @Override
+        public String getCteRecepcaoOS(DFAmbiente ambiente) {
+            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homologacao.cte.fazenda.pr.gov.br/cte/CteRecepcaoOS" : "https://cte.fazenda.pr.gov.br/cte/CteRecepcaoOS";
         }
     
         @Override
@@ -212,6 +232,11 @@ public enum CTAutorizador31 {
         public String getRecepcaoEvento(final DFAmbiente ambiente) {
             return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://cte-homologacao.svrs.rs.gov.br/ws/cterecepcaoevento/cterecepcaoevento.asmx" : "https://cte.svrs.rs.gov.br/ws/cterecepcaoevento/cterecepcaoevento.asmx";
         }
+
+        @Override
+        public String getCteRecepcaoOS(DFAmbiente ambiente) {
+            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://cte-homologacao.svrs.rs.gov.br/ws/cterecepcaoos/cterecepcaoos.asmx" : "https://cte.svrs.rs.gov.br/ws/cterecepcaoos/cterecepcaoos.asmx";
+        }
     
         @Override
         public DFUnidadeFederativa[] getUFs() {
@@ -253,6 +278,11 @@ public enum CTAutorizador31 {
         @Override
         public String getRecepcaoEvento(final DFAmbiente ambiente) {
             return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homologacao.nfe.fazenda.sp.gov.br/cteweb/services/cteRecepcaoEvento.asmx" : "https://nfe.fazenda.sp.gov.br/cteweb/services/cteRecepcaoEvento.asmx";
+        }
+
+        @Override
+        public String getCteRecepcaoOS(DFAmbiente ambiente) {
+            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homologacao.nfe.fazenda.sp.gov.br/cteWEB/services/cteRecepcaoOS.asmx" : "https://nfe.fazenda.sp.gov.br/cteWEB/services/cteRecepcaoOS.asmx";
         }
         
         @Override
@@ -296,6 +326,11 @@ public enum CTAutorizador31 {
         public String getRecepcaoEvento(final DFAmbiente ambiente) {
             return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://cte-homologacao.svrs.rs.gov.br/ws/cterecepcaoevento/cterecepcaoevento.asmx" : "https://cte.svrs.rs.gov.br/ws/cterecepcaoevento/cterecepcaoevento.asmx";
         }
+
+        @Override
+        public String getCteRecepcaoOS(DFAmbiente ambiente) {
+            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://cte-homologacao.svrs.rs.gov.br/ws/cterecepcaoos/cterecepcaoos.asmx" : "https://cte.svrs.rs.gov.br/ws/cterecepcaoos/cterecepcaoos.asmx";
+        }
         
         @Override
         public DFUnidadeFederativa[] getUFs() {
@@ -338,6 +373,11 @@ public enum CTAutorizador31 {
         public String getRecepcaoEvento(final DFAmbiente ambiente) {
             return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? null : null;
         }
+
+        @Override
+        public String getCteRecepcaoOS(DFAmbiente ambiente) {
+            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homologacao.nfe.fazenda.sp.gov.br/cteWEB/services/cteRecepcaoOS.asmx" : "https://nfe.fazenda.sp.gov.br/cteWEB/services/cteRecepcaoOS.asmx";
+        }
     
         @Override
         public DFUnidadeFederativa[] getUFs() {
@@ -358,6 +398,8 @@ public enum CTAutorizador31 {
     public abstract String getCteQrCode(final DFAmbiente ambiente);
     
     public abstract String getRecepcaoEvento(final DFAmbiente ambiente);
+
+    public abstract String getCteRecepcaoOS(final DFAmbiente ambiente);
     
     public abstract DFUnidadeFederativa[] getUFs();
     

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/CTResponsavelSeguro.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/CTResponsavelSeguro.java
@@ -1,0 +1,32 @@
+package com.fincatto.documentofiscal.cte300.classes;
+
+public enum CTResponsavelSeguro {
+    EMITENTE("4", "Emitente do CT-e OS"),
+    TOMADOR("5", "Tomador de Serviço");
+
+    private final String codigo;
+    private final String descricao;
+
+    CTResponsavelSeguro(final String codigo, final String descricao) {
+        this.codigo = codigo;
+        this.descricao = descricao;
+    }
+
+    public String getCodigo() {
+        return this.codigo;
+    }
+
+    public static CTResponsavelSeguro valueOfCodigo(final String codigo) {
+        for (final CTResponsavelSeguro valor : CTResponsavelSeguro.values()) {
+            if (valor.getCodigo().equals(codigo)) {
+                return valor;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return codigo + " - " + descricao;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/CTTipoFretamento.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/CTTipoFretamento.java
@@ -1,0 +1,32 @@
+package com.fincatto.documentofiscal.cte300.classes;
+
+public enum CTTipoFretamento {
+    EVENTUAL("1", "Eventual"),
+    CONTINUO("2", "Continuo");
+
+    private final String codigo;
+    private final String descricao;
+
+    CTTipoFretamento(final String codigo, final String descricao) {
+        this.codigo = codigo;
+        this.descricao = descricao;
+    }
+
+    public String getCodigo() {
+        return this.codigo;
+    }
+
+    public static CTTipoFretamento valueOfCodigo(final String codigo) {
+        for (final CTTipoFretamento valor : CTTipoFretamento.values()) {
+            if (valor.getCodigo().equals(codigo)) {
+                return valor;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return codigo + " - " + descricao;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/CTTipoProprietario.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/CTTipoProprietario.java
@@ -1,0 +1,33 @@
+package com.fincatto.documentofiscal.cte300.classes;
+
+public enum CTTipoProprietario {
+    TAC_AGREGADO("0", "TAC – Agregado"),
+    TAC_INDEPENDENTE("1", "TAC – Independente"),
+    OUTROS("2", "Outros");
+
+    private final String codigo;
+    private final String descricao;
+
+    CTTipoProprietario(final String codigo, final String descricao) {
+        this.codigo = codigo;
+        this.descricao = descricao;
+    }
+
+    public String getCodigo() {
+        return this.codigo;
+    }
+
+    public static CTTipoProprietario valueOfCodigo(final String codigo) {
+        for (final CTTipoProprietario valor : CTTipoProprietario.values()) {
+            if (valor.getCodigo().equals(codigo)) {
+                return valor;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return codigo + " - " + descricao;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/CTTipoServicoOS.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/CTTipoServicoOS.java
@@ -1,0 +1,38 @@
+package com.fincatto.documentofiscal.cte300.classes;
+
+public enum CTTipoServicoOS {
+
+    TRANSPORTE_DE_PESSOAS("6", "Transporte de Pessoas"),
+    TRANSPORTE_DE_VALORES("7", "Transporte de Valores"),
+    EXCESSO_DE_BAGAGEM("8", "Excesso de Bagagem");
+
+    private final String codigo;
+    private final String descricao;
+
+    CTTipoServicoOS(final String codigo, final String descricao) {
+        this.codigo = codigo;
+        this.descricao = descricao;
+    }
+
+    public String getCodigo() {
+        return this.codigo;
+    }
+
+    public String getDescricao() {
+        return this.descricao;
+    }
+
+    public static CTTipoServicoOS valueOfCodigo(final String codigo) {
+        for (final CTTipoServicoOS tipo : CTTipoServicoOS.values()) {
+            if (tipo.getCodigo().equals(codigo)) {
+                return tipo;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return codigo + " - " + descricao;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/CTipoComponenteGTVe.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/CTipoComponenteGTVe.java
@@ -1,0 +1,36 @@
+package com.fincatto.documentofiscal.cte300.classes;
+
+public enum CTipoComponenteGTVe {
+    CUSTODIA("1", "Custodia"),
+    EMBARQUE("2", "Embarque"),
+    TEMPO_DE_ESPERA("3", "Tempo de espera"),
+    MALOTE("4", "Malote"),
+    AD_VALOREM("5", "Ad Valorem"),
+    OUTROS("6", "Outros");
+
+    private final String codigo;
+    private final String descricao;
+
+    CTipoComponenteGTVe(final String codigo, final String descricao) {
+        this.codigo = codigo;
+        this.descricao = descricao;
+    }
+
+    public String getCodigo() {
+        return this.codigo;
+    }
+
+    public static CTipoComponenteGTVe valueOfCodigo(final String codigo) {
+        for (final CTipoComponenteGTVe valor : CTipoComponenteGTVe.values()) {
+            if (valor.getCodigo().equals(codigo)) {
+                return valor;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return codigo + " - " + descricao;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/envio/CTeOSEnvioRetorno.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/envio/CTeOSEnvioRetorno.java
@@ -1,0 +1,115 @@
+package com.fincatto.documentofiscal.cte300.classes.envio;
+
+import com.fincatto.documentofiscal.DFAmbiente;
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.DFUnidadeFederativa;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.envio.CTeProtocolo;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "retCTeOS")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSEnvioRetorno extends DFBase {
+    private static final long serialVersionUID = -6459868395256049339L;
+
+    @Element(name = "tpAmb", required = false)
+    private DFAmbiente ambiente;
+
+    @Element(name = "cUF", required = false)
+    private DFUnidadeFederativa uf;
+
+    @Element(name = "verAplic", required = false)
+    private String versaoAplicacao;
+
+    @Element(name = "cStat", required = false)
+    private String status;
+
+    @Element(name = "xMotivo", required = false)
+    private String motivo;
+
+    @Element(name = "protCTe", required = false)
+    private CTeProtocolo protocolo;
+
+    @Attribute(name = "versao", required = false)
+    private String versao;
+
+    public DFAmbiente getAmbiente() {
+        return this.ambiente;
+    }
+
+    /**
+     * Identificação do Ambiente:1 - Produção; 2 - Homologação
+     */
+    public void setAmbiente(final DFAmbiente ambiente) {
+        this.ambiente = ambiente;
+    }
+
+    public DFUnidadeFederativa getUf() {
+        return this.uf;
+    }
+
+    /**
+     * Identificação da UF
+     */
+    public void setUf(final DFUnidadeFederativa uf) {
+        this.uf = uf;
+    }
+
+    public String getVersaoAplicacao() {
+        return this.versaoAplicacao;
+    }
+
+    /**
+     * Versão do Aplicativo que recebeu o Lote.
+     */
+    public void setVersaoAplicacao(final String versaoAplicacao) {
+        this.versaoAplicacao = versaoAplicacao;
+    }
+
+    public String getStatus() {
+        return this.status;
+    }
+
+    /**
+     * Código do status da mensagem enviada.
+     */
+    public void setStatus(final String status) {
+        this.status = status;
+    }
+
+    public String getMotivo() {
+        return this.motivo;
+    }
+
+    /**
+     * Descrição literal do status do serviço solicitado.
+     */
+    public void setMotivo(final String motivo) {
+        this.motivo = motivo;
+    }
+
+    public CTeProtocolo getProtocolo() {
+        return this.protocolo;
+    }
+
+    /**
+     * Dados do protocolo do processamento do CT-e
+     */
+    public void setProtocolo(final CTeProtocolo protocolo) {
+        this.protocolo = protocolo;
+    }
+
+    public String getVersao() {
+        return this.versao;
+    }
+
+    /**
+     * versão da aplicação
+     */
+    public void setVersao(final String versao) {
+        this.versao = versao;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/envio/CTeOSEnvioRetornoDados.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/envio/CTeOSEnvioRetornoDados.java
@@ -1,0 +1,22 @@
+package com.fincatto.documentofiscal.cte300.classes.envio;
+
+import com.fincatto.documentofiscal.cte300.classes.os.CTeOS;
+
+public class CTeOSEnvioRetornoDados {
+
+    private final CTeOSEnvioRetorno retorno;
+    private final CTeOS loteAssinado;
+
+	public CTeOSEnvioRetornoDados(CTeOSEnvioRetorno retorno, CTeOS loteAssinado) {
+		this.retorno = retorno;
+		this.loteAssinado = loteAssinado;
+	}
+
+	public CTeOSEnvioRetorno getRetorno() {
+		return retorno;
+	}
+
+	public CTeOS getLoteAssinado() {
+		return loteAssinado;
+	}
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOS.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOS.java
@@ -1,0 +1,60 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte300.classes.nota.assinatura.CTeSignature;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "CTeOS")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOS extends DFBase {
+    private static final long serialVersionUID = 1005480176062479566L;
+
+    @Element(name = "infCte")
+    private CTeOSInfo info;
+
+    @Element(name="infCTeSupl", required = false)
+    private CTeOSInfoSuplementares infoSuplementares;
+
+    @Element(name = "Signature", required = false)
+    private CTeSignature signature;
+
+    @Attribute(name = "versao")
+    private String versao;
+
+    public CTeOSInfo getInfo() {
+        return info;
+    }
+
+    public void setInfo(final CTeOSInfo info) {
+        this.info = info;
+    }
+
+    public CTeOSInfoSuplementares getInfoSuplementares() {
+        return infoSuplementares;
+    }
+
+    public CTeOS setInfoSuplementares(final CTeOSInfoSuplementares infoSuplementares) {
+        this.infoSuplementares = infoSuplementares;
+        return this;
+    }
+
+    public CTeSignature getSignature() {
+        return this.signature;
+    }
+
+    public void setSignature(final CTeSignature signature) {
+        this.signature = signature;
+    }
+
+    public String getVersao() {
+        return versao;
+    }
+
+    public void setVersao(final String versao) {
+        this.versao = versao;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSEndereco.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSEndereco.java
@@ -1,0 +1,165 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.DFPais;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+
+public class CTeOSEndereco extends DFBase {
+    private static final long serialVersionUID = 1357977819965129753L;
+
+    @Element(name = "xLgr")
+    private String logradouro;
+
+    @Element(name = "nro")
+    private String numero;
+
+    @Element(name = "xCpl", required = false)
+    private String complemento;
+
+    @Element(name = "xBairro")
+    private String bairro;
+
+    @Element(name = "cMun")
+    private String codigoMunicipio;
+
+    @Element(name = "xMun")
+    private String descricaoMunicipio;
+
+    @Element(name = "CEP", required = false)
+    private String cep;
+
+    @Element(name = "UF")
+    private String siglaUF;
+
+    @Element(name = "cPais", required = false)
+    private DFPais codigoPais;
+
+    @Element(name = "xPais", required = false)
+    private String descricaoPais;
+
+    public String getLogradouro() {
+        return this.logradouro;
+    }
+
+    /**
+     * Logradouro
+     */
+    public void setLogradouro(final String logradouro) {
+        DFStringValidador.tamanho2ate60(logradouro, "Logradouro");
+        this.logradouro = logradouro;
+    }
+
+    public String getNumero() {
+        return this.numero;
+    }
+
+    /**
+     * Número
+     */
+    public void setNumero(final String numero) {
+        DFStringValidador.tamanho60(numero, "Número");
+        this.numero = numero;
+    }
+
+    public String getComplemento() {
+        return this.complemento;
+    }
+
+    /**
+     * Complemento
+     */
+    public void setComplemento(final String complemento) {
+        DFStringValidador.tamanho60(complemento, "Complemento");
+        this.complemento = complemento;
+    }
+
+    public String getBairro() {
+        return this.bairro;
+    }
+
+    /**
+     * Bairro
+     */
+    public void setBairro(final String bairro) {
+        DFStringValidador.tamanho2ate60(bairro, "Bairro");
+        this.bairro = bairro;
+    }
+
+    public String getCodigoMunicipio() {
+        return this.codigoMunicipio;
+    }
+
+    /**
+     * Código do município (utilizar a tabela do IBGE)<br>
+     * Informar 9999999 para operações com o exterior.
+     */
+    public void setCodigoMunicipio(final String codigoMunicipio) {
+        DFStringValidador.exatamente7N(codigoMunicipio, "Código do município");
+        this.codigoMunicipio = codigoMunicipio;
+    }
+
+    public String getDescricaoMunicipio() {
+        return this.descricaoMunicipio;
+    }
+
+    /**
+     * Nome do município<br>
+     * Informar EXTERIOR para operações com o exterior.
+     */
+    public void setDescricaoMunicipio(final String descricaoMunicipio) {
+        DFStringValidador.tamanho2ate60(descricaoMunicipio, "Nome do município");
+        this.descricaoMunicipio = descricaoMunicipio;
+    }
+
+    public String getCep() {
+        return this.cep;
+    }
+
+    /**
+     * CEP<br>
+     * Informar os zeros não significativos
+     */
+    public void setCep(final String cep) {
+        DFStringValidador.exatamente8N(cep, "CEP");
+        this.cep = cep;
+    }
+
+    public String getSiglaUF() {
+        return this.siglaUF;
+    }
+
+    /**
+     * Sigla da UF<br>
+     * Informar EX para operações com o exterior.
+     */
+    public void setSiglaUF(final String siglaUf) {
+        DFStringValidador.exatamente2(siglaUf, "Sigla da UF");
+        this.siglaUF = siglaUf;
+    }
+
+    public DFPais getCodigoPais() {
+        return this.codigoPais;
+    }
+
+    /**
+     * Código do país<br>
+     * Utilizar a tabela do BACEN
+     */
+    public void setCodigoPais(final String codigoPais) {
+        DFStringValidador.tamanho4N(codigoPais, "Código do país");
+        this.codigoPais = DFPais.valueOfCodigo(codigoPais);
+    }
+
+    public String getDescricaoPais() {
+        return this.descricaoPais;
+    }
+
+    /**
+     * Nome do país
+     */
+    public void setDescricaoPais(final String descricaoPais) {
+        DFStringValidador.tamanho2ate60(descricaoPais, "Nome do país");
+        this.descricaoPais = descricaoPais;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSEnderecoEmitente.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSEnderecoEmitente.java
@@ -1,0 +1,148 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+
+public class CTeOSEnderecoEmitente extends DFBase {
+    private static final long serialVersionUID = 3229596313843831723L;
+
+    @Element(name = "xLgr")
+    private String logradouro;
+    
+    @Element(name = "nro")
+    private String numero;
+
+    @Element(name = "xCpl", required = false)
+    private String complemento;
+    
+    @Element(name = "xBairro")
+    private String bairro;
+    
+    @Element(name = "cMun")
+    private String codigoMunicipio;
+    
+    @Element(name = "xMun")
+    private String descricaoMunicipio;
+
+    @Element(name = "CEP", required = false)
+    private String cep;
+    
+    @Element(name = "UF")
+    private String siglaUF;
+
+    @Element(name = "fone", required = false)
+    private String telefone;
+
+    public String getLogradouro() {
+        return this.logradouro;
+    }
+
+    /**
+     * Logradouro
+     */
+    public void setLogradouro(final String logradouro) {
+        DFStringValidador.tamanho2ate60(logradouro, "Logradouro no endereço do Emitente");
+        this.logradouro = logradouro;
+    }
+
+    public String getNumero() {
+        return this.numero;
+    }
+
+    /**
+     * Número
+     */
+    public void setNumero(final String numero) {
+        DFStringValidador.tamanho60(numero, "Número no endereço do Emitente");
+        this.numero = numero;
+    }
+
+    public String getComplemento() {
+        return this.complemento;
+    }
+
+    /**
+     * Complemento
+     */
+    public void setComplemento(final String complemento) {
+        DFStringValidador.tamanho60(complemento, "Complemento no endereço do Emitente");
+        this.complemento = complemento;
+    }
+
+    public String getBairro() {
+        return this.bairro;
+    }
+
+    /**
+     * Bairro
+     */
+    public void setBairro(final String bairro) {
+        DFStringValidador.tamanho2ate60(bairro, "Bairro no endereço do Emitente");
+        this.bairro = bairro;
+    }
+
+    public String getCodigoMunicipio() {
+        return this.codigoMunicipio;
+    }
+
+    /**
+     * Código do município (utilizar a tabela do IBGE)<br>
+     * Informar 9999999 para operações com o exterior.
+     */
+    public void setCodigoMunicipio(final String codigoMunicipio) {
+        DFStringValidador.exatamente7N(codigoMunicipio, "Código do município no endereço do Emitente");
+        this.codigoMunicipio = codigoMunicipio;
+    }
+
+    public String getDescricaoMunicipio() {
+        return this.descricaoMunicipio;
+    }
+
+    /**
+     * Nome do município<br>
+     * Informar EXTERIOR para operações com o exterior.
+     */
+    public void setDescricaoMunicipio(final String descricaoMunicipio) {
+        DFStringValidador.tamanho2ate60(descricaoMunicipio, "Nome do município no endereço do Emitente");
+        this.descricaoMunicipio = descricaoMunicipio;
+    }
+
+    public String getCep() {
+        return this.cep;
+    }
+
+    /**
+     * CEP<br>
+     * Informar os zeros não significativos
+     */
+    public void setCep(final String cep) {
+        DFStringValidador.exatamente8N(cep, "CEP no endereço do Emitente");
+        this.cep = cep;
+    }
+
+    public String getSiglaUF() {
+        return this.siglaUF;
+    }
+
+    /**
+     * Sigla da UF<br>
+     * Informar EX para operações com o exterior.
+     */
+    public void setSiglaUF(final String siglaUF) {
+        DFStringValidador.exatamente2(siglaUF, "Sigla da UF no endereço do Emitente");
+        this.siglaUF = siglaUF;
+    }
+
+    public String getTelefone() {
+        return this.telefone;
+    }
+
+    /**
+     * Telefone
+     */
+    public void setTelefone(final String telefone) {
+        DFStringValidador.telefone(telefone);
+        this.telefone = telefone;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfo.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfo.java
@@ -1,0 +1,205 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFListValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.*;
+
+import java.util.List;
+
+@Root(name = "infCte")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfo extends DFBase {
+    public static final String IDENT = "CTe";
+    private static final long serialVersionUID = 1970550899293677744L;
+
+    @Attribute(name = "Id")
+    private String identificador;
+
+    @Attribute(name = "versao")
+    private String versao;
+
+    @Element(name = "ide")
+    private CTeOSInfoIdentificacao identificacao;
+
+    @Element(name = "compl", required = false)
+    private CTeOSInfoDadosComplementares dadosComplementares;
+
+    @Element(name = "emit")
+    private CTeOSInfoEmitente emitente;
+
+    @Element(name = "toma", required = false)
+    private CTeOSInfoIdentificacaoTomador tomador;
+
+    @Element(name = "vPrest")
+    private CTeOSInfoValorPrestacaoServico valorPrestacaoServico;
+
+    @Element(name = "imp")
+    private CTeOSInfoInformacoesRelativasImpostos informacoesRelativasImpostos;
+
+    @Element(name = "infCTeNorm", required = false)
+    private CTeOSInfoCTeNormal cteNormal;
+
+    @Element(name = "infCteComp", required = false)
+    private CTeOSInfoCTeComplementar cteComplementar;
+
+    @Element(name = "infCteAnu", required = false)
+    private CTeOSInfoCTeAnulacao cteAnulacao;
+
+    @ElementList(name = "autXML", inline = true, required = false)
+    private List<CTeOSInfoAutorizacaoDownload> autorizacaoDownload;
+
+    @Element(name="infRespTec", required = false)
+    private CTeOSInfoResponsavelTecnico informacaoResposavelTecnico;
+
+    public String getIdentificador() {
+        return this.identificador;
+    }
+
+    /**
+     * Identificador da tag a ser assinada<br>
+     * Informar a chave de acesso do CT-e e precedida do literal "CTe"
+     */
+    public void setIdentificador(final String identificador) {
+        DFStringValidador.exatamente44N(identificador, "Identificador");
+        this.identificador = CTeOSInfo.IDENT + identificador;
+    }
+
+    /**
+     * Pega a chave de acesso a partir do identificador.
+     * @return Chave de acesso.
+     */
+    public String getChaveAcesso() {
+        return this.identificador.replace(CTeOSInfo.IDENT, "");
+    }
+
+    public CTeOSInfoIdentificacao getIdentificacao() {
+        return this.identificacao;
+    }
+
+    /**
+     * Identificação do CT-e
+     */
+    public void setIdentificacao(final CTeOSInfoIdentificacao identificacao) {
+        this.identificacao = identificacao;
+    }
+
+    public CTeOSInfoDadosComplementares getDadosComplementares() {
+        return this.dadosComplementares;
+    }
+
+    /**
+     * Dados complementares do CT-e para fins operacionais ou comerciais
+     */
+    public void setDadosComplementares(final CTeOSInfoDadosComplementares dadosComplementares) {
+        this.dadosComplementares = dadosComplementares;
+    }
+
+    public CTeOSInfoEmitente getEmitente() {
+        return this.emitente;
+    }
+
+    /**
+     * Identificação do Emitente do CT-e
+     */
+    public void setEmitente(final CTeOSInfoEmitente emitente) {
+        this.emitente = emitente;
+    }
+
+    public CTeOSInfoIdentificacaoTomador getTomador() {
+        return tomador;
+    }
+
+    public void setTomador(final CTeOSInfoIdentificacaoTomador tomador) {
+        this.tomador = tomador;
+    }
+
+    public CTeOSInfoValorPrestacaoServico getValorPrestacaoServico() {
+        return this.valorPrestacaoServico;
+    }
+
+    /**
+     * Valores da Prestação de Serviço
+     */
+    public void setValorPrestacaoServico(final CTeOSInfoValorPrestacaoServico valorPrestacaoServico) {
+        this.valorPrestacaoServico = valorPrestacaoServico;
+    }
+
+    public CTeOSInfoInformacoesRelativasImpostos getInformacoesRelativasImpostos() {
+        return this.informacoesRelativasImpostos;
+    }
+
+    /**
+     * Informações relativas aos Impostos
+     */
+    public void setInformacoesRelativasImpostos(final CTeOSInfoInformacoesRelativasImpostos informacoesRelativasImpostos) {
+        this.informacoesRelativasImpostos = informacoesRelativasImpostos;
+    }
+
+    public CTeOSInfoCTeNormal getCteNormal() {
+        return this.cteNormal;
+    }
+
+    /**
+     * Grupo de informações do CT-e Normal e Substituto
+     */
+    public void setCteNormal(final CTeOSInfoCTeNormal cteNormal) {
+        this.cteNormal = cteNormal;
+    }
+
+    public CTeOSInfoCTeComplementar getCteComplementar() {
+        return this.cteComplementar;
+    }
+
+    /**
+     * Detalhamento do CT-e complementado
+     */
+    public void setCteComplementar(final CTeOSInfoCTeComplementar cteComplementar) {
+        this.cteComplementar = cteComplementar;
+    }
+
+    public CTeOSInfoCTeAnulacao getCteAnulacao() {
+        return this.cteAnulacao;
+    }
+
+    /**
+     * Detalhamento do CT-e do tipo Anulação
+     */
+    public void setCteAnulacao(final CTeOSInfoCTeAnulacao cteAnulacao) {
+        this.cteAnulacao = cteAnulacao;
+    }
+
+    public List<CTeOSInfoAutorizacaoDownload> getAutorizacaoDownload() {
+        return this.autorizacaoDownload;
+    }
+
+    /**
+     * Autorizados para download do XML do DF-e<br>
+     * Informar CNPJ ou CPF. Preencher os zeros não significativos.
+     */
+    public void setAutorizacaoDownload(final List<CTeOSInfoAutorizacaoDownload> autorizacaoDownload) {
+        DFListValidador.tamanho10(autorizacaoDownload, "Autorizados para download do XML do DF-e");
+        this.autorizacaoDownload = autorizacaoDownload;
+    }
+
+    public String getVersao() {
+        return this.versao;
+    }
+
+    /**
+     * Versão do leiaute
+     */
+    public void setVersao(final String versao) {
+        this.versao = versao;
+    }
+
+    public CTeOSInfoResponsavelTecnico getInformacaoResposavelTecnico() {
+        return informacaoResposavelTecnico;
+    }
+
+    public CTeOSInfo setInformacaoResposavelTecnico(final CTeOSInfoResponsavelTecnico informacaoResposavelTecnico) {
+        this.informacaoResposavelTecnico = informacaoResposavelTecnico;
+        return this;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoAutorizacaoDownload.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoAutorizacaoDownload.java
@@ -1,0 +1,46 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "autXML")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoAutorizacaoDownload extends DFBase {
+    private static final long serialVersionUID = -2755368776450778969L;
+
+    @Element(name = "CNPJ", required = false)
+    private String cnpj;
+
+    @Element(name = "CPF", required = false)
+    private String cpf;
+
+    public String getCnpj() {
+        return this.cnpj;
+    }
+
+    /**
+     * CNPJ do autorizado<br>
+     * Informar zeros não significativos
+     */
+    public void setCnpj(final String cnpj) {
+        DFStringValidador.cnpj(cnpj);
+        this.cnpj = cnpj;
+    }
+
+    public String getCpf() {
+        return this.cpf;
+    }
+
+    /**
+     * CPF do autorizado<br>
+     * Informar zeros não significativos
+     */
+    public void setCpf(final String cpf) {
+        DFStringValidador.cpf(cpf);
+        this.cpf = cpf;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeAnulacao.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeAnulacao.java
@@ -1,0 +1,45 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.time.LocalDate;
+
+@Root(name = "infCteAnu")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeAnulacao extends DFBase {
+    private static final long serialVersionUID = 3248640412163502446L;
+
+    @Element(name = "chCte")
+    private String chave;
+    
+    @Element(name = "dEmi")
+    private LocalDate dataEmissao;
+
+    public String getChave() {
+        return this.chave;
+    }
+
+    /**
+     * Chave de acesso do CT-e original a ser anulado e substituído
+     */
+    public void setChave(final String chave) {
+        DFStringValidador.exatamente44N(chave, "Chave de acesso do CT-e original a ser anulado e substituído");
+        this.chave = chave;
+    }
+
+    public LocalDate getDataEmissao() {
+        return this.dataEmissao;
+    }
+
+    /**
+     * Data de emissão da declaração do tomador não contribuinte do ICMS
+     */
+    public void setDataEmissao(final LocalDate dataEmissao) {
+        this.dataEmissao = dataEmissao;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeComplementar.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeComplementar.java
@@ -1,0 +1,33 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "infCteComp")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeComplementar extends DFBase {
+    private static final long serialVersionUID = 8633547499681692469L;
+
+    @Element(name = "chCTe")
+    private String chave;
+
+    public CTeOSInfoCTeComplementar() {
+        this.chave = null;
+    }
+
+    public String getChave() {
+        return this.chave;
+    }
+
+    /**
+     * Chave do CT-e complementado
+     */
+    public void setChave(final String chave) {
+        DFStringValidador.exatamente44N(chave, "Chave do CT-e complementado");
+        this.chave = chave;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormal.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormal.java
@@ -1,0 +1,93 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.util.List;
+
+@Root(name = "infCTeNorm")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormal extends DFBase {
+    private static final long serialVersionUID = -1176357232990148386L;
+
+    @Element(name = "infServico")
+    private CTeOSInfoCTeNormalInfoServico infoCarga;
+
+    @ElementList(name = "infDocRef", inline = true, required = false)
+    private List<CTeOSInfoCTeNormalInfoDocumentos> infoDocumentos;
+
+    @ElementList(name = "seg", inline = true, required = false)
+    private List<CTeOSInfoCTeNormalSeguro> seguros;
+
+    @Element(name = "infModal")
+    private CTeOSInfoCTeNormalInfoModal infoModal;
+
+    @Element(name = "infCteSub", required = false)
+    private CTeOSInfoCTeNormalInfoCTeSubstituicao infoCTeSubstituicao;
+
+    @Element(name = "cobr", required = false)
+    private CTeOSInfoCTeNormalInfoCobranca cobranca;
+
+    @ElementList(name = "infGTVe", inline = true, required = false)
+    private List<CTeOSInfoCTeNormalInfoGTVe> infoGTVe;
+
+    public CTeOSInfoCTeNormalInfoServico getInfoCarga() {
+        return infoCarga;
+    }
+
+    public void setInfoCarga(final CTeOSInfoCTeNormalInfoServico infoCarga) {
+        this.infoCarga = infoCarga;
+    }
+
+    public List<CTeOSInfoCTeNormalInfoDocumentos> getInfoDocumentos() {
+        return infoDocumentos;
+    }
+
+    public void setInfoDocumentos(List<CTeOSInfoCTeNormalInfoDocumentos> infoDocumentos) {
+        this.infoDocumentos = infoDocumentos;
+    }
+
+    public List<CTeOSInfoCTeNormalSeguro> getSeguros() {
+        return seguros;
+    }
+
+    public void setSeguros(List<CTeOSInfoCTeNormalSeguro> seguros) {
+        this.seguros = seguros;
+    }
+
+    public CTeOSInfoCTeNormalInfoModal getInfoModal() {
+        return infoModal;
+    }
+
+    public void setInfoModal(final CTeOSInfoCTeNormalInfoModal infoModal) {
+        this.infoModal = infoModal;
+    }
+
+    public CTeOSInfoCTeNormalInfoCTeSubstituicao getInfoCTeSubstituicao() {
+        return infoCTeSubstituicao;
+    }
+
+    public void setInfoCTeSubstituicao(final CTeOSInfoCTeNormalInfoCTeSubstituicao infoCTeSubstituicao) {
+        this.infoCTeSubstituicao = infoCTeSubstituicao;
+    }
+
+    public CTeOSInfoCTeNormalInfoCobranca getCobranca() {
+        return cobranca;
+    }
+
+    public void setCobranca(final CTeOSInfoCTeNormalInfoCobranca cobranca) {
+        this.cobranca = cobranca;
+    }
+
+    public List<CTeOSInfoCTeNormalInfoGTVe> getInfoGTVe() {
+        return infoGTVe;
+    }
+
+    public void setInfoGTVe(final List<CTeOSInfoCTeNormalInfoGTVe> infoGTVe) {
+        this.infoGTVe = infoGTVe;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoCTeSubstituicao.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoCTeSubstituicao.java
@@ -1,0 +1,58 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "infCteSub")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoCTeSubstituicao extends DFBase {
+    private static final long serialVersionUID = 1065211380518853520L;
+
+    @Element(name = "chCte")
+    private String chaveCTe;
+
+    @Element(name = "refCteAnu", required = false)
+    private String chaveCTeAnulacao;
+
+    @Element(name = "tomaICMS", required = false)
+    private CTeOSInfoCTeNormalInfoCTeSubstituicaoTomadorICMS tomadorICMS;
+
+    public String getChaveCTe() {
+        return this.chaveCTe;
+    }
+
+    /**
+     * Chave de acesso do CT-e a ser substituído (original)
+     */
+    public void setChaveCTe(final String chaveCTe) {
+        DFStringValidador.exatamente44N(chaveCTe, "Chave de acesso do CT-e a ser substituído (original)");
+        this.chaveCTe = chaveCTe;
+    }
+
+    public String getChaveCTeAnulacao() {
+        return this.chaveCTeAnulacao;
+    }
+
+    /**
+     * Chave de acesso do CT-e de Anulação
+     */
+    public void setChaveCTeAnulacao(final String chaveCTeAnulacao) {
+        DFStringValidador.exatamente44N(chaveCTeAnulacao, "Chave de acesso do CT-e de Anulação");
+        this.chaveCTeAnulacao = chaveCTeAnulacao;
+    }
+
+    public CTeOSInfoCTeNormalInfoCTeSubstituicaoTomadorICMS getTomadorICMS() {
+        return this.tomadorICMS;
+    }
+
+    /**
+     * Tomador é contribuinte do ICMS, mas não é emitente de documento fiscal eletrônico
+     */
+    public void setTomadorICMS(final CTeOSInfoCTeNormalInfoCTeSubstituicaoTomadorICMS tomadorICMS) {
+        this.tomadorICMS = tomadorICMS;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoCTeSubstituicaoTomadorICMS.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoCTeSubstituicaoTomadorICMS.java
@@ -1,0 +1,64 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "tomaICMS")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoCTeSubstituicaoTomadorICMS extends DFBase {
+    private static final long serialVersionUID = -1982924377131065804L;
+
+    @Element(name = "refNFe", required = false)
+    private String referenciaNFe;
+
+    @Element(name = "refNF", required = false)
+    private CTeOSInfoCTeNormalInfoCTeSubstituicaoTomadorICMSReferenciaNF referenciaNF;
+
+    @Element(name = "refCte", required = false)
+    private String referenciaCte;
+
+    public CTeOSInfoCTeNormalInfoCTeSubstituicaoTomadorICMS() {
+        this.referenciaNFe = null;
+        this.referenciaNF = null;
+        this.referenciaCte = null;
+    }
+
+    public String getReferenciaNFe() {
+        return this.referenciaNFe;
+    }
+
+    /**
+     * Chave de acesso da NF-e emitida pelo Tomador
+     */
+    public void setReferenciaNFe(final String referenciaNFe) {
+        DFStringValidador.exatamente44N(referenciaNFe, "Chave de acesso da NF-e emitida pelo Tomador");
+        this.referenciaNFe = referenciaNFe;
+    }
+
+    public CTeOSInfoCTeNormalInfoCTeSubstituicaoTomadorICMSReferenciaNF getReferenciaNF() {
+        return this.referenciaNF;
+    }
+
+    /**
+     * Informação da NF ou CT emitido pelo Tomador
+     */
+    public void setReferenciaNF(final CTeOSInfoCTeNormalInfoCTeSubstituicaoTomadorICMSReferenciaNF referenciaNF) {
+        this.referenciaNF = referenciaNF;
+    }
+
+    public String getReferenciaCte() {
+        return this.referenciaCte;
+    }
+
+    /**
+     * Chave de acesso do CT-e emitido pelo Tomador
+     */
+    public void setReferenciaCte(final String referenciaCte) {
+        DFStringValidador.exatamente44N(referenciaCte, "Chave de acesso do CT-e emitido pelo Tomador");
+        this.referenciaCte = referenciaCte;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoCTeSubstituicaoTomadorICMSReferenciaNF.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoCTeSubstituicaoTomadorICMSReferenciaNF.java
@@ -1,0 +1,138 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Root(name = "refNF")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoCTeSubstituicaoTomadorICMSReferenciaNF extends DFBase {
+    private static final long serialVersionUID = -7563695523675903335L;
+
+    @Element(name = "CNPJ", required = false)
+    private String cnpj;
+
+    @Element(name = "CPF", required = false)
+    private String cpf;
+    
+    @Element(name = "mod")
+    private String modelo;
+    
+    @Element(name = "serie")
+    private String serie;
+
+    @Element(name = "subserie", required = false)
+    private String subserie;
+    
+    @Element(name = "nro")
+    private String numeroDocumento;
+    
+    @Element(name = "valor")
+    private String valor;
+    
+    @Element(name = "dEmi")
+    private LocalDate dataEmissao;
+
+    public String getCnpj() {
+        return this.cnpj;
+    }
+
+    /**
+     * CNPJ do Emitente<br>
+     * Informar o CNPJ do emitente do Documento Fiscal
+     */
+    public void setCnpj(final String cnpj) {
+        DFStringValidador.cnpj(cnpj);
+        this.cnpj = cnpj;
+    }
+
+    public String getCpf() {
+        return this.cpf;
+    }
+
+    /**
+     * Número do CPF<br>
+     * Informar o CPF do emitente do documento fiscal
+     */
+    public void setCpf(final String cpf) {
+        DFStringValidador.cpf(cpf);
+        this.cpf = cpf;
+    }
+
+    public String getModelo() {
+        return this.modelo;
+    }
+
+    /**
+     * Modelo do Documento Fiscal
+     */
+    public void setModelo(final String modelo) {
+        DFStringValidador.exatamente2(modelo, "Modelo do Documento Fiscal");
+        this.modelo = modelo;
+    }
+
+    public String getSerie() {
+        return this.serie;
+    }
+
+    /**
+     * Serie do documento fiscal
+     */
+    public void setSerie(final String serie) {
+        DFStringValidador.tamanho3N(serie, "Serie do documento fiscal");
+        this.serie = serie;
+    }
+
+    public String getSubserie() {
+        return this.subserie;
+    }
+
+    /**
+     * Subserie do documento fiscal
+     */
+    public void setSubserie(final String subserie) {
+        DFStringValidador.tamanho3N(this.serie, "Subserie do documento fiscal");
+        this.subserie = subserie;
+    }
+
+    public String getNumeroDocumento() {
+        return this.numeroDocumento;
+    }
+
+    /**
+     * Número do documento fiscal
+     */
+    public void setNumeroDocumento(final String numeroDocumento) {
+        DFStringValidador.tamanho6N(numeroDocumento, "Número do documento fiscal");
+        this.numeroDocumento = numeroDocumento;
+    }
+
+    public String getValor() {
+        return this.valor;
+    }
+
+    /**
+     * Valor do documento fiscal.
+     */
+    public void setValor(final BigDecimal valor) {
+        this.valor = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valor, "Valor do documento fiscal");
+    }
+
+    public LocalDate getDataEmissao() {
+        return this.dataEmissao;
+    }
+
+    /**
+     * Data de emissão do documento fiscal.
+     */
+    public void setDataEmissao(final LocalDate dataEmissao) {
+        this.dataEmissao = dataEmissao;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoCargaInformacoesQuantidadeCarga.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoCargaInformacoesQuantidadeCarga.java
@@ -1,0 +1,29 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte300.classes.CTUnidadeMedida;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "infQ")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoCargaInformacoesQuantidadeCarga extends DFBase {
+    private static final long serialVersionUID = 9113316063559072994L;
+
+    @Element(name = "qCarga")
+    private String quantidade;
+
+    public String getQuantidade() {
+        return this.quantidade;
+    }
+
+    public void setQuantidade(final BigDecimal quantidade) {
+        this.quantidade = DFBigDecimalValidador.tamanho15Com4CasasDecimais(quantidade, "Quantidade");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoCobranca.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoCobranca.java
@@ -1,0 +1,38 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.util.List;
+
+@Root(name = "cobr")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoCobranca extends DFBase {
+    private static final long serialVersionUID = 512711961726591339L;
+
+    @Element(name = "fat", required = false)
+    private CTeOSInfoCTeNormalInfoCobrancaFatura fatura;
+
+    @ElementList(name = "dup", inline = true, required = false)
+    private List<CTeOSInfoCTeNormalInfoCobrancaDuplicata> duplicatas;
+
+    public CTeOSInfoCTeNormalInfoCobrancaFatura getFatura() {
+        return fatura;
+    }
+
+    public void setFatura(final CTeOSInfoCTeNormalInfoCobrancaFatura fatura) {
+        this.fatura = fatura;
+    }
+
+    public List<CTeOSInfoCTeNormalInfoCobrancaDuplicata> getDuplicatas() {
+        return duplicatas;
+    }
+
+    public void setDuplicatas(List<CTeOSInfoCTeNormalInfoCobrancaDuplicata> duplicatas) {
+        this.duplicatas = duplicatas;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoCobrancaDuplicata.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoCobrancaDuplicata.java
@@ -1,0 +1,52 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Root(name = "fat")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoCobrancaDuplicata extends DFBase {
+    private static final long serialVersionUID = 5321172274976502832L;
+
+    @Element(name = "nDup", required = false)
+    private String numeroDuplicata;
+
+    @Element(name = "dVenc", required = false)
+    private LocalDate dataVencimento;
+
+    @Element(name = "vDup", required = false)
+    private String valorDuplicata;
+
+    public String getNumeroDuplicata() {
+        return numeroDuplicata;
+    }
+
+    public void setNumeroDuplicata(final String numeroDuplicata) {
+        DFStringValidador.tamanho60(numeroDuplicata, "Numero da Duplicata");
+        this.numeroDuplicata = numeroDuplicata;
+    }
+
+    public LocalDate getDataVencimento() {
+        return dataVencimento;
+    }
+
+    public void setDataVencimento(final LocalDate dataVencimento) {
+        this.dataVencimento = dataVencimento;
+    }
+
+    public String getValorDuplicata() {
+        return valorDuplicata;
+    }
+
+    public void setValorDuplicata(final BigDecimal valorDuplicata) {
+        this.valorDuplicata = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorDuplicata, "Valor Duplicata");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoCobrancaFatura.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoCobrancaFatura.java
@@ -1,0 +1,62 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "fat")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoCobrancaFatura extends DFBase {
+    private static final long serialVersionUID = 4430617027634028923L;
+
+    @Element(name = "nFat", required = false)
+    private String numeroFatura;
+
+    @Element(name = "vOrig", required = false)
+    private String valorOriginal;
+
+    @Element(name = "vDesc", required = false)
+    private String valorDesconto;
+
+    @Element(name = "vLiq", required = false)
+    private String valorLiquido;
+
+    public String getNumeroFatura() {
+        return numeroFatura;
+    }
+
+    public void setNumeroFatura(final String numeroFatura) {
+        DFStringValidador.tamanho60(numeroFatura, "Numero da Fatura");
+        this.numeroFatura = numeroFatura;
+    }
+
+    public String getValorOriginal() {
+        return valorOriginal;
+    }
+
+    public void setValorOriginal(final BigDecimal valorOriginal) {
+        this.valorOriginal = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorOriginal, "Valor Original");
+    }
+
+    public String getValorDesconto() {
+        return valorDesconto;
+    }
+
+    public void setValorDesconto(final BigDecimal valorDesconto) {
+        this.valorDesconto = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorDesconto, "Valor Desconto");
+    }
+
+    public String getValorLiquido() {
+        return valorLiquido;
+    }
+
+    public void setValorLiquido(final BigDecimal valorLiquido) {
+        this.valorLiquido = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorLiquido, "Valor Liquido");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoDocumentos.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoDocumentos.java
@@ -1,0 +1,88 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Root(name = "infDocRef")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoDocumentos extends DFBase {
+    private static final long serialVersionUID = 8490041070801837687L;
+
+    @Element(name = "nDoc", required = false)
+    private String numeroDocumento;
+
+    @Element(name = "serie", required = false)
+    private String serie;
+
+    @Element(name = "subserie", required = false)
+    private String subserie;
+
+    @Element(name = "dEmi", required = false)
+    private LocalDate dataEmissao;
+
+    @Element(name = "vDoc", required = false)
+    private String valorDocumento;
+
+    @Element(name = "chBPe", required = false)
+    private String chaveBilhetePassagem;
+
+    public String getNumeroDocumento() {
+        return numeroDocumento;
+    }
+
+    public void setNumeroDocumento(final String numeroDocumento) {
+        DFStringValidador.tamanho20(numeroDocumento, "Numero Documento");
+        this.numeroDocumento = numeroDocumento;
+    }
+
+    public String getSerie() {
+        return serie;
+    }
+
+    public void setSerie(final String serie) {
+        DFStringValidador.tamanho3(serie, "Serie");
+        this.serie = serie;
+    }
+
+    public String getSubserie() {
+        return subserie;
+    }
+
+    public void setSubserie(final String subserie) {
+        DFStringValidador.tamanho3(subserie, "Subserie");
+        this.subserie = subserie;
+    }
+
+    public LocalDate getDataEmissao() {
+        return dataEmissao;
+    }
+
+    public void setDataEmissao(final LocalDate dataEmissao) {
+        this.dataEmissao = dataEmissao;
+    }
+
+    public String getValorDocumento() {
+        return valorDocumento;
+    }
+
+    public void setValorDocumento(final BigDecimal valorDocumento) {
+        this.valorDocumento = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorDocumento, "Valor Documento");
+    }
+
+    public String getChaveBilhetePassagem() {
+        return chaveBilhetePassagem;
+    }
+
+    public void setChaveBilhetePassagem(String chaveBilhetePassagem) {
+        DFStringValidador.exatamente44N(chaveBilhetePassagem, "Chave de acesso do Bilhete de Passagem Eletrônico");
+        this.chaveBilhetePassagem = chaveBilhetePassagem;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoGTVe.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoGTVe.java
@@ -1,0 +1,40 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.util.List;
+
+@Root(name = "infGTVe")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoGTVe extends DFBase {
+    private static final long serialVersionUID = -7819895569994558919L;
+
+    @Element(name = "chCTe")
+    private String chaveGTVe;
+
+    @ElementList(name = "Comp", inline = true)
+    private List<CTeOSInfoCTeNormalInfoGTVeComp> comp;
+
+    public String getChaveGTVe() {
+        return chaveGTVe;
+    }
+
+    public void setChaveGTVe(final String chaveGTVe) {
+        DFStringValidador.exatamente44N(chaveGTVe, "Chave de acesso da Guia de Transporte de Valores Eletrônica (GTVe)");
+        this.chaveGTVe = chaveGTVe;
+    }
+
+    public List<CTeOSInfoCTeNormalInfoGTVeComp> getComp() {
+        return comp;
+    }
+
+    public void setComp(final List<CTeOSInfoCTeNormalInfoGTVeComp> comp) {
+        this.comp = comp;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoGTVeComp.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoGTVeComp.java
@@ -1,0 +1,52 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte300.classes.CTipoComponenteGTVe;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "Comp")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoGTVeComp extends DFBase {
+    private static final long serialVersionUID = 3107443189436692983L;
+
+    @Element(name = "tpComp")
+    private CTipoComponenteGTVe tipoComponente;
+
+    @Element(name = "vComp")
+    private String valorComponente;
+
+    @Element(name = "xComp", required = false)
+    private String nomeComponente;
+
+    public CTipoComponenteGTVe getTipoComponente() {
+        return tipoComponente;
+    }
+
+    public void setTipoComponente(final CTipoComponenteGTVe tipoComponente) {
+        this.tipoComponente = tipoComponente;
+    }
+
+    public String getValorComponente() {
+        return valorComponente;
+    }
+
+    public void setValorComponente(final BigDecimal valorComponente) {
+        this.valorComponente = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorComponente, "Valor do componente");
+    }
+
+    public String getNomeComponente() {
+        return nomeComponente;
+    }
+
+    public void setNomeComponente(final String nomeComponente) {
+        DFStringValidador.tamanho15(nomeComponente, "Nome do componente");
+        this.nomeComponente = nomeComponente;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoModal.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoModal.java
@@ -1,0 +1,39 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "infModal")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoModal extends DFBase {
+    private static final long serialVersionUID = 8987158163135069115L;
+
+    @Element(name = "rodoOS", required = false)
+    private CTeOSInfoCTeNormalInfoModalRodoviario rodoviario;
+
+    @Attribute(name = "versaoModal")
+    private String versao;
+
+    public CTeOSInfoCTeNormalInfoModalRodoviario getRodoviario() {
+        return this.rodoviario;
+    }
+
+    public void setRodoviario(final CTeOSInfoCTeNormalInfoModalRodoviario rodoviario) {
+        this.rodoviario = rodoviario;
+    }
+
+    public String getVersao() {
+        return this.versao;
+    }
+
+    /**
+     * Versão do leiaute específico para o Modal
+     */
+    public void setVersao(final String versaoModal) {
+        this.versao = versaoModal;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoModalRodoviario.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoModalRodoviario.java
@@ -1,0 +1,60 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "rodoOS")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoModalRodoviario extends DFBase {
+    private static final long serialVersionUID = -5367579900038295412L;
+
+    @Element(name = "TAF", required = false)
+    private String termoAutorizacaoFretamento;
+
+    @Element(name = "NroRegEstadual", required = false)
+    private String numeroRegistroEstadual;
+
+    @Element(name = "veic", required = false)
+    private CTeOSInfoCTeNormalInfoModalRodoviarioVeiculo veiculo;
+
+    @Element(name = "infFretamento", required = false)
+    private CTeOSInfoCTeNormalInfoModalRodoviarioFretamento fretamento;
+
+    public String getTermoAutorizacaoFretamento() {
+        return termoAutorizacaoFretamento;
+    }
+
+    public void setTermoAutorizacaoFretamento(final String termoAutorizacaoFretamento) {
+        DFStringValidador.tamanho12(termoAutorizacaoFretamento, "Termo de Autorização de Fretamento");
+        this.termoAutorizacaoFretamento = termoAutorizacaoFretamento;
+    }
+
+    public String getNumeroRegistroEstadual() {
+        return numeroRegistroEstadual;
+    }
+
+    public void setNumeroRegistroEstadual(final String numeroRegistroEstadual) {
+        DFStringValidador.tamanho25N(numeroRegistroEstadual, "Número do Registro Estadual");
+        this.numeroRegistroEstadual = numeroRegistroEstadual;
+    }
+
+    public CTeOSInfoCTeNormalInfoModalRodoviarioVeiculo getVeiculo() {
+        return veiculo;
+    }
+
+    public void setVeiculo(final CTeOSInfoCTeNormalInfoModalRodoviarioVeiculo veiculo) {
+        this.veiculo = veiculo;
+    }
+
+    public CTeOSInfoCTeNormalInfoModalRodoviarioFretamento getFretamento() {
+        return fretamento;
+    }
+
+    public void setFretamento(final CTeOSInfoCTeNormalInfoModalRodoviarioFretamento fretamento) {
+        this.fretamento = fretamento;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoModalRodoviarioFretamento.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoModalRodoviarioFretamento.java
@@ -1,0 +1,38 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte300.classes.CTTipoFretamento;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.time.ZonedDateTime;
+
+@Root(name = "infFretamento")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoModalRodoviarioFretamento extends DFBase {
+    private static final long serialVersionUID = 8999239864502092146L;
+
+    @Element(name = "tpFretamento")
+    private CTTipoFretamento tipoFretamento;
+
+    @Element(name = "dhViagem", required = false)
+    private ZonedDateTime dataHoraViagem;
+
+    public CTTipoFretamento getTipoFretamento() {
+        return tipoFretamento;
+    }
+
+    public void setTipoFretamento(final CTTipoFretamento tipoFretamento) {
+        this.tipoFretamento = tipoFretamento;
+    }
+
+    public ZonedDateTime getDataHoraViagem() {
+        return dataHoraViagem;
+    }
+
+    public void setDataHoraViagem(final ZonedDateTime dataHoraViagem) {
+        this.dataHoraViagem = dataHoraViagem;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoModalRodoviarioVeiculo.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoModalRodoviarioVeiculo.java
@@ -1,0 +1,61 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "veic")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoModalRodoviarioVeiculo extends DFBase {
+    private static final long serialVersionUID = 5278574973196952726L;
+
+    @Element(name = "placa")
+    private String placa;
+
+    @Element(name = "RENAVAM", required = false)
+    private String renavam;
+
+    @Element(name = "prop", required = false)
+    private CTeOSInfoCTeNormalInfoModalRodoviarioVeiculoProprietario proprietario;
+
+    @Element(name = "UF")
+    private String uf;
+
+    public String getPlaca() {
+        return placa;
+    }
+
+    public void setPlaca(final String placa) {
+        DFStringValidador.placaDeVeiculo(placa, "Placa do veículo");
+        this.placa = placa;
+    }
+
+    public String getRenavam() {
+        return renavam;
+    }
+
+    public void setRenavam(final String renavam) {
+        this.renavam = DFStringValidador.validaIntervalo(renavam, 9, 11, "Renavam do reboque");
+    }
+
+    public CTeOSInfoCTeNormalInfoModalRodoviarioVeiculoProprietario getProprietario() {
+        return proprietario;
+    }
+
+    public void setProprietario(final CTeOSInfoCTeNormalInfoModalRodoviarioVeiculoProprietario proprietario) {
+        this.proprietario = proprietario;
+    }
+
+    public String getUf() {
+        return uf;
+    }
+
+    public void setUf(final String uf) {
+        DFStringValidador.exatamente2(uf, "UF");
+        this.uf = uf;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoModalRodoviarioVeiculoProprietario.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoModalRodoviarioVeiculoProprietario.java
@@ -1,0 +1,118 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.DFUnidadeFederativa;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte300.classes.CTTipoProprietario;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "prop")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoModalRodoviarioVeiculoProprietario extends DFBase {
+    private static final long serialVersionUID = -7624273019279765397L;
+
+    @Element(name = "CPF", required = false)
+    private String cpf;
+
+    @Element(name = "CNPJ", required = false)
+    private String cnpj;
+
+    @Element(name = "TAF", required = false)
+    private String termoAutorizacaoFretamento;
+
+    @Element(name = "NroRegEstadual", required = false)
+    private String numeroRegistroEstadual;
+
+    @Element(name = "xNome")
+    private String razaoSocial;
+
+    @Element(name = "IE")
+    private String inscricaoEstadual;
+
+    @Element(name = "UF")
+    private String unidadeFederativa;
+
+    @Element(name = "tpProp", required = false)
+    private CTTipoProprietario tipoProprietario;
+
+    public String getCpf() {
+        return cpf;
+    }
+
+    public void setCpf(final String cpf) {
+        if (this.cnpj != null) {
+            throw new IllegalStateException("Nao deve setar CPF se CNPJ esteja setado em proprietario do Veículo ");
+        }
+        this.cpf = DFStringValidador.cpf(cpf, "proprietario do Veículo");
+        this.cpf = cpf;
+    }
+
+    public String getCnpj() {
+        return cnpj;
+    }
+
+    public void setCnpj(final String cnpj) {
+        if (this.cpf != null) {
+            throw new IllegalStateException("Nao deve setar CNPJ se CPF esteja setado em proprietario do Veículo");
+        }
+        this.cnpj = DFStringValidador.cnpj(cnpj, "proprietario do Veículo");
+    }
+
+    public String getRazaoSocial() {
+        return razaoSocial;
+    }
+
+    public void setRazaoSocial(final String razaoSocial) {
+        this.razaoSocial = razaoSocial;
+    }
+
+    public String getInscricaoEstadual() {
+        return inscricaoEstadual;
+    }
+
+    public void setInscricaoEstadual(final String inscricaoEstadual) {
+        DFStringValidador.inscricaoEstadual(inscricaoEstadual);
+        this.inscricaoEstadual = inscricaoEstadual;
+    }
+
+    public String getUnidadeFederativa() {
+        return unidadeFederativa;
+    }
+
+    public void setUnidadeFederativa(final String unidadeFederativa) {
+        this.unidadeFederativa = unidadeFederativa;
+    }
+
+    public void setUnidadeFederativa(DFUnidadeFederativa unidadeFederativa) {
+        this.unidadeFederativa = unidadeFederativa.getCodigo();
+    }
+
+    public String getTermoAutorizacaoFretamento() {
+        return termoAutorizacaoFretamento;
+    }
+
+    public void setTermoAutorizacaoFretamento(final String termoAutorizacaoFretamento) {
+        DFStringValidador.tamanho12(termoAutorizacaoFretamento, "Termo de Autorização de Fretamento");
+        this.termoAutorizacaoFretamento = termoAutorizacaoFretamento;
+    }
+
+    public String getNumeroRegistroEstadual() {
+        return numeroRegistroEstadual;
+    }
+
+    public void setNumeroRegistroEstadual(final String numeroRegistroEstadual) {
+        DFStringValidador.tamanho25N(numeroRegistroEstadual, "Número do Registro Estadual");
+        this.numeroRegistroEstadual = numeroRegistroEstadual;
+    }
+
+    public CTTipoProprietario getTipoProprietario() {
+        return tipoProprietario;
+    }
+
+    public void setTipoProprietario(final CTTipoProprietario tipoProprietario) {
+        this.tipoProprietario = tipoProprietario;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoServico.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalInfoServico.java
@@ -1,0 +1,40 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.util.List;
+
+@Root(name = "infServico")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoServico extends DFBase {
+    private static final long serialVersionUID = -6918550471184804059L;
+
+    @Element(name = "xDescServ")
+    private String descricaoServico;
+
+    @ElementList(name = "infQ", inline = true, required = false)
+    private List<CTeOSInfoCTeNormalInfoCargaInformacoesQuantidadeCarga> informacoesQuantidadeCarga;
+
+    public String getDescricaoServico() {
+        return descricaoServico;
+    }
+
+    public void setDescricaoServico(final String descricaoServico) {
+        DFStringValidador.tamanho30(descricaoServico, "Descricao Servico");
+        this.descricaoServico = descricaoServico;
+    }
+
+    public List<CTeOSInfoCTeNormalInfoCargaInformacoesQuantidadeCarga> getInformacoesQuantidadeCarga() {
+        return informacoesQuantidadeCarga;
+    }
+
+    public void setInformacoesQuantidadeCarga(List<CTeOSInfoCTeNormalInfoCargaInformacoesQuantidadeCarga> informacoesQuantidadeCarga) {
+        this.informacoesQuantidadeCarga = informacoesQuantidadeCarga;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalSeguro.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoCTeNormalSeguro.java
@@ -1,0 +1,51 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte300.classes.CTResponsavelSeguro;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "seg")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalSeguro extends DFBase {
+    private static final long serialVersionUID = -7791328283494118369L;
+
+    @Element(name = "respSeg")
+    private CTResponsavelSeguro responsavelSeguro;
+
+    @Element(name = "xSeg", required = false)
+    private String nomeSeguradora;
+
+    @Element(name = "nApol", required = false)
+    private String numeroApolice;
+
+    public CTResponsavelSeguro getResponsavelSeguro() {
+        return responsavelSeguro;
+    }
+
+    public void setResponsavelSeguro(final CTResponsavelSeguro responsavelSeguro) {
+        this.responsavelSeguro = responsavelSeguro;
+    }
+
+    public String getNomeSeguradora() {
+        return nomeSeguradora;
+    }
+
+    public void setNomeSeguradora(final String nomeSeguradora) {
+        DFStringValidador.tamanho30(nomeSeguradora, "Nome da seguradora");
+        this.nomeSeguradora = nomeSeguradora;
+    }
+
+    public String getNumeroApolice() {
+        return numeroApolice;
+    }
+
+    public void setNumeroApolice(final String numeroApolice) {
+        DFStringValidador.tamanho20(numeroApolice, "Número da apólice");
+        this.numeroApolice = numeroApolice;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoDadosComplementares.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoDadosComplementares.java
@@ -1,0 +1,110 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFListValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.util.List;
+
+@Root(name = "compl")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoDadosComplementares extends DFBase {
+    private static final long serialVersionUID = -8686019717867243514L;
+
+    @Element(name = "xCaracAd", required = false)
+    private String caracteristicasTransporte;
+
+    @Element(name = "xCaracSer", required = false)
+    private String caracteristicasServico;
+
+    @Element(name = "xEmi", required = false)
+    private String funcionarioEmissor;
+
+    @Element(name = "xObs", required = false)
+    private String observacaoGeral;
+
+    @ElementList(name = "ObsCont", inline = true, required = false)
+    private List<CTeOSInfoDadosComplementaresObservacaoContribuinte> observacaoContribuinte;
+
+    @ElementList(name = "ObsFisco", inline = true, required = false)
+    private List<CTeOSInfoDadosComplementaresObservacaoFisco> observacaoFisco;
+
+    public String getCaracteristicasTransporte() {
+        return this.caracteristicasTransporte;
+    }
+
+    /**
+     * Característica adicional do transporte<br>
+     * Texto livre: REENTREGA; DEVOLUÇÃO; REFATURAMENTO; etc
+     */
+    public void setCaracteristicasTransporte(final String caracteristicasTransporte) {
+        DFStringValidador.tamanho15(caracteristicasTransporte, "Característica adicional do transporte");
+        this.caracteristicasTransporte = caracteristicasTransporte;
+    }
+
+    public String getCaracteristicasServico() {
+        return this.caracteristicasServico;
+    }
+
+    /**
+     * Característica adicional do serviço<br>
+     * Texto livre: ENTREGA EXPRESSA; LOGÍSTICA REVERSA; CONVENCIONAL; EMERGENCIAL; etc
+     */
+    public void setCaracteristicasServico(final String caracteristicasServico) {
+        DFStringValidador.tamanho30(caracteristicasServico, "Característica adicional do serviço");
+        this.caracteristicasServico = caracteristicasServico;
+    }
+
+    public String getFuncionarioEmissor() {
+        return this.funcionarioEmissor;
+    }
+
+    /**
+     * Funcionário emissor do CTe
+     */
+    public void setFuncionarioEmissor(final String funcionarioEmissor) {
+        DFStringValidador.tamanho20(funcionarioEmissor, "Funcionário emissor do CTe");
+        this.funcionarioEmissor = funcionarioEmissor;
+    }
+
+    public String getObservacaoGeral() {
+        return this.observacaoGeral;
+    }
+
+    /**
+     * Observações Gerais
+     */
+    public void setObservacaoGeral(final String observacaoGeral) {
+        DFStringValidador.tamanho2000(observacaoGeral, "Observações Gerais");
+        this.observacaoGeral = observacaoGeral;
+    }
+
+    public List<CTeOSInfoDadosComplementaresObservacaoContribuinte> getObservacaoContribuinte() {
+        return this.observacaoContribuinte;
+    }
+
+    /**
+     * Campo de uso livre do contribuinte
+     */
+    public void setObservacaoContribuinte(final List<CTeOSInfoDadosComplementaresObservacaoContribuinte> observacaoContribuinte) {
+        DFListValidador.tamanho10(observacaoContribuinte, "Observação de interesse do contribuinte");
+        this.observacaoContribuinte = observacaoContribuinte;
+    }
+
+    public List<CTeOSInfoDadosComplementaresObservacaoFisco> getObservacaoFisco() {
+        return this.observacaoFisco;
+    }
+
+    /**
+     * Campo de uso livre do contribuinte
+     */
+    public void setObservacaoFisco(final List<CTeOSInfoDadosComplementaresObservacaoFisco> observacaoFisco) {
+        DFListValidador.tamanho10(observacaoFisco, "Observação de interesse do fisco");
+        this.observacaoFisco = observacaoFisco;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoDadosComplementaresObservacaoContribuinte.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoDadosComplementaresObservacaoContribuinte.java
@@ -1,0 +1,45 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "ObsCont")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoDadosComplementaresObservacaoContribuinte extends DFBase {
+    private static final long serialVersionUID = 3363633720721437281L;
+
+    @Attribute(name = "xCampo")
+    private String campo;
+
+    @Element(name = "xTexto")
+    private String texto;
+
+    public String getCampo() {
+        return this.campo;
+    }
+
+    /**
+     * Identificação do campo
+     */
+    public void setCampo(final String campo) {
+        DFStringValidador.tamanho20(campo, "Identificação do campo");
+        this.campo = campo;
+    }
+
+    public String getTexto() {
+        return this.texto;
+    }
+
+    /**
+     * Identificação do texto
+     */
+    public void setTexto(final String texto) {
+        DFStringValidador.tamanho160(texto, "Identificação do texto");
+        this.texto = texto;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoDadosComplementaresObservacaoFisco.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoDadosComplementaresObservacaoFisco.java
@@ -1,0 +1,45 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "ObsFisco")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoDadosComplementaresObservacaoFisco extends DFBase {
+    private static final long serialVersionUID = -2703860850692444439L;
+
+    @Attribute(name = "xCampo")
+    private String campo;
+
+    @Element(name = "xTexto")
+    private String texto;
+
+    public String getCampo() {
+        return this.campo;
+    }
+
+    /**
+     * Identificação do campo
+     */
+    public void setCampo(final String campo) {
+        DFStringValidador.tamanho20(campo, "Identificação do campo");
+        this.campo = campo;
+    }
+
+    public String getTexto() {
+        return this.texto;
+    }
+
+    /**
+     * Identificação do texto
+     */
+    public void setTexto(final String texto) {
+        DFStringValidador.tamanho60(texto, "Identificação do texto");
+        this.texto = texto;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoEmitente.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoEmitente.java
@@ -1,0 +1,117 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte300.classes.CTTipoRegimeTributario;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "emit")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoEmitente extends DFBase {
+    private static final long serialVersionUID = 3236506485275091047L;
+
+    @Element(name = "CNPJ")
+    private String cnpj;
+
+    @Element(name = "IE")
+    private String inscricaoEstadual;
+
+    @Element(name = "IEST", required = false)
+    private String inscricaoEstadualST;
+
+    @Element(name = "xNome")
+    private String razaoSocial;
+
+    @Element(name = "xFant", required = false)
+    private String nomeFantasia;
+
+    @Element(name = "enderEmit")
+    private CTeOSEnderecoEmitente endereco;
+
+    @Element(name = "CRT", required = false)
+    private CTTipoRegimeTributario tipoRegimeTributario;
+
+    public String getCnpj() {
+        return this.cnpj;
+    }
+
+    /**
+     * CNPJ do emitente<br>
+     * Informar zeros não significativos
+     */
+    public void setCnpj(final String cnpj) {
+        DFStringValidador.cnpj(cnpj);
+        this.cnpj = cnpj;
+    }
+
+    public String getInscricaoEstadual() {
+        return this.inscricaoEstadual;
+    }
+
+    /**
+     * Inscrição Estadual do Emitente
+     */
+    public void setInscricaoEstadual(final String inscricaoEstadual) {
+        DFStringValidador.inscricaoEstadualSemIsencao(inscricaoEstadual);
+        this.inscricaoEstadual = inscricaoEstadual;
+    }
+
+    public String getInscricaoEstadualST() {
+        return this.inscricaoEstadualST;
+    }
+
+    /**
+     * Inscrição Estadual do Substituto Tributário
+     */
+    public void setInscricaoEstadualST(final String inscricaoEstadualST) {
+        DFStringValidador.tamanho14N(inscricaoEstadualST, "Inscrição Estadual do Substituto Tributário");
+        this.inscricaoEstadualST = inscricaoEstadualST;
+    }
+
+    public String getRazaoSocial() {
+        return this.razaoSocial;
+    }
+
+    /**
+     * Razão social ou Nome do emitente
+     */
+    public void setRazaoSocial(final String xNome) {
+        DFStringValidador.tamanho2ate60(xNome, "Razão social ou Nome do emitente");
+        this.razaoSocial = xNome;
+    }
+
+    public String getNomeFantasia() {
+        return this.nomeFantasia;
+    }
+
+    /**
+     * Nome fantasia
+     */
+    public void setNomeFantasia(final String xFant) {
+        DFStringValidador.tamanho2ate60(xFant, "Nome fantasia");
+        this.nomeFantasia = xFant;
+    }
+
+    public CTeOSEnderecoEmitente getEnderEmit() {
+        return this.endereco;
+    }
+
+    /**
+     * Endereço do emitente
+     */
+    public void setEnderEmit(final CTeOSEnderecoEmitente enderEmit) {
+        this.endereco = enderEmit;
+    }
+
+    public CTTipoRegimeTributario getTipoRegimeTributario() {
+        return tipoRegimeTributario;
+    }
+
+    public CTeOSInfoEmitente setTipoRegimeTributario(final CTTipoRegimeTributario tipoRegimeTributario) {
+        this.tipoRegimeTributario = tipoRegimeTributario;
+        return this;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoIdentificacao.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoIdentificacao.java
@@ -1,0 +1,509 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFAmbiente;
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.DFModelo;
+import com.fincatto.documentofiscal.DFUnidadeFederativa;
+import com.fincatto.documentofiscal.cte.CTTipoEmissao;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte300.classes.*;
+import com.fincatto.documentofiscal.validadores.DFIntegerValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+@Root(name = "ide")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoIdentificacao extends DFBase {
+    private static final long serialVersionUID = -8453848058358735289L;
+
+    @Element(name = "cUF")
+    private DFUnidadeFederativa codigoUF;
+
+    @Element(name = "cCT")
+    private String codigoNumerico;
+
+    @Element(name = "CFOP")
+    private String cfop;
+
+    @Element(name = "natOp")
+    private String naturezaOperacao;
+
+    @Element(name = "mod")
+    private DFModelo modelo;
+
+    @Element(name = "serie")
+    private Integer serie;
+
+    @Element(name = "nCT")
+    private Integer numero;
+
+    @Element(name = "dhEmi")
+    private ZonedDateTime dataEmissao;
+
+    @Element(name = "tpImp")
+    private CTTipoImpressao tipoImpressao;
+
+    @Element(name = "tpEmis")
+    private CTTipoEmissao tipoEmissao;
+
+    @Element(name = "cDV")
+    private Integer digitoVerificador;
+
+    @Element(name = "tpAmb")
+    private DFAmbiente ambiente;
+
+    @Element(name = "tpCTe")
+    private CTFinalidade finalidade;
+
+    @Element(name = "procEmi")
+    private CTProcessoEmissao processoEmissao;
+
+    @Element(name = "verProc")
+    private String versaoProcessoEmissao;
+
+    @Element(name = "cMunEnv")
+    private String codigoMunicipioEnvio;
+
+    @Element(name = "xMunEnv")
+    private String descricaoMunicipioEnvio;
+
+    @Element(name = "UFEnv")
+    private String siglaUFEnvio;
+
+    @Element(name = "modal")
+    private CTModal modalidadeFrete;
+
+    @Element(name = "tpServ")
+    private CTTipoServicoOS tipoServico;
+
+    @Element(name = "indIEToma")
+    private CTIndicadorTomador indIEToma;
+
+    @Element(name = "cMunIni")
+    private String codigoMunicipioInicio;
+
+    @Element(name = "xMunIni")
+    private String descricaoMunicipioInicio;
+
+    @Element(name = "UFIni")
+    private String siglaUfInicio;
+
+    @Element(name = "cMunFim")
+    private String codigoMunicipioFim;
+
+    @Element(name = "xMunFim")
+    private String descricaoMunicipioFim;
+
+    @Element(name = "UFFim")
+    private String siglaUfFim;
+
+    @ElementList(entry = "infPercurso", inline = true, required = false)
+    private List<CTeOSInfoIdentificacaoUfPercurso> identificacaoUfPercursos;
+
+    @Element(name = "dhCont", required = false)
+    private LocalDateTime dataContingencia;
+
+    @Element(name = "xJust", required = false)
+    private String justificativa;
+
+    public DFUnidadeFederativa getCodigoUF() {
+        return this.codigoUF;
+    }
+    
+    /**
+     * Codigo da UF do emitente do CT-e.
+     */
+    public void setCodigoUF(final DFUnidadeFederativa codigoUF) {
+        this.codigoUF = codigoUF;
+    }
+    
+    public String getCodigoNumerico() {
+        return this.codigoNumerico;
+    }
+    
+    /**
+     * Codigo numerico que compoe a Chave de Acesso.<br>
+     * Numero aleatorio gerado pelo emitente para cada CT-e, com o objetivo de evitar acessos indevidos ao documento.
+     */
+    public void setCodigoNumerico(final String codigoNumerico) {
+        DFStringValidador.exatamente8N(codigoNumerico, "Codigo Numerico");
+        this.codigoNumerico = codigoNumerico;
+    }
+    
+    public String getCfop() {
+        return this.cfop;
+    }
+    
+    /**
+     * Codigo Fiscal de Operacoes e Prestacoes
+     */
+    public void setCfop(final String cfop) {
+        DFStringValidador.exatamente4N(cfop, "CFOP");
+        this.cfop = cfop;
+    }
+    
+    public String getNaturezaOperacao() {
+        return this.naturezaOperacao;
+    }
+    
+    /**
+     * Natureza da Operacao
+     */
+    public void setNaturezaOperacao(final String naturezaOperacao) {
+        DFStringValidador.tamanho2ate60(naturezaOperacao, "Natureza da Operacao");
+        this.naturezaOperacao = naturezaOperacao;
+    }
+    
+    public DFModelo getModelo() {
+        return this.modelo;
+    }
+    
+    /**
+     * Modelo do documento fiscal<br>
+     * Utilizar o codigo 57 para identificacao do CT-e, emitido em substituicao aos modelos de conhecimentos em papel.
+     */
+    public void setModelo(final DFModelo modelo) {
+        this.modelo = modelo;
+    }
+    
+    public Integer getSerie() {
+        return this.serie;
+    }
+    
+    /**
+     * Serie do CT-e<br>
+     * Preencher com "0" no caso de serie unica
+     */
+    public void setSerie(final Integer serie) {
+        DFIntegerValidador.tamanho3(serie, "Serie");
+        this.serie = serie;
+    }
+    
+    public Integer getNumero() {
+        return this.numero;
+    }
+    
+    /**
+     * Numero do CT-e
+     */
+    public void setNumero(final Integer numero) {
+        DFIntegerValidador.tamanho9(numero, "Numero");
+        this.numero = numero;
+    }
+    
+    public ZonedDateTime getDataEmissao() {
+        return this.dataEmissao;
+    }
+    
+    /**
+     * Data e hora de emissao do CT-e<br>
+     * Formato AAAA-MM-DDTHH:MM:DD TZD
+     */
+    public void setDataEmissao(final ZonedDateTime dataEmissao) {
+        this.dataEmissao = dataEmissao;
+    }
+    
+    public CTTipoImpressao getTipoImpressao() {
+        return this.tipoImpressao;
+    }
+    
+    /**
+     * Formato de impressao do DACTE<br>
+     * Preencher com: 1 - Retrato; 2 - Paisagem.
+     */
+    public void setTipoImpressao(final CTTipoImpressao tipoImpressao) {
+        this.tipoImpressao = tipoImpressao;
+    }
+    
+    public CTTipoEmissao getTipoEmissao() {
+        return this.tipoEmissao;
+    }
+    
+    /**
+     * Forma de emissao do CT-e<br>
+     * Preencher com:<br>
+     * 1 - Normal;<br>
+     * 4 - EPEC pela SVC; 5 - Contingencia FSDA;<br>
+     * 7 - Autorizacao pela SVC-RS;<br>
+     * 8 - Autorizacao pela SVC-SP;<br>
+     */
+    public void setTipoEmissao(final CTTipoEmissao tipoEmissao) {
+        this.tipoEmissao = tipoEmissao;
+    }
+    
+    public Integer getDigitoVerificador() {
+        return this.digitoVerificador;
+    }
+    
+    /**
+     * Digito Verificador da chave de acesso do CT-e<br>
+     * Informar o digito de controle da chave de acesso do CT-e, que deve ser calculado com a aplicacao do algoritmo modulo 11 (base 2,9) da chave de acesso.
+     */
+    public void setDigitoVerificador(final Integer digitoVerificador) {
+        DFIntegerValidador.exatamente1(digitoVerificador, "DV");
+        this.digitoVerificador = digitoVerificador;
+    }
+    
+    public DFAmbiente getAmbiente() {
+        return this.ambiente;
+    }
+    
+    /**
+     * Tipo do Ambiente<br>
+     * Preencher com:<br>
+     * 1 - Producao;<br>
+     * 2 - Homologacao
+     */
+    public void setAmbiente(final DFAmbiente ambiente) {
+        this.ambiente = ambiente;
+    }
+    
+    public CTFinalidade getFinalidade() {
+        return this.finalidade;
+    }
+    
+    /**
+     * Tipo do CT-e<br>
+     * Preencher com:<br>
+     * 0 - CT-e Normal;<br>
+     * 1 - CT-e de Complemento de Valores;<br>
+     * 2 - CT-e de Anulacao;<br>
+     * 3 - CT-e Substituto
+     */
+    public void setFinalidade(final CTFinalidade finalidade) {
+        this.finalidade = finalidade;
+    }
+    
+    public CTProcessoEmissao getProcessoEmissao() {
+        return this.processoEmissao;
+    }
+    
+    /**
+     * Identificador do processo de emissao do CT-e<br>
+     * Preencher com:<br>
+     * 0 - emissao de CT-e com aplicativo do contribuinte;<br>
+     * 3- emissao CT-e pelo contribuinte com aplicativo fornecido pelo Fisco.
+     */
+    public void setProcessoEmissao(final CTProcessoEmissao processoEmissao) {
+        this.processoEmissao = processoEmissao;
+    }
+    
+    public String getVersaoProcessoEmissao() {
+        return this.versaoProcessoEmissao;
+    }
+    
+    /**
+     * Versao do processo de emissao<br>
+     * Iinformar a versao do aplicativo emissor de CT-e.
+     */
+    public void setVersaoProcessoEmissao(final String versaoProcessoEmissao) {
+        DFStringValidador.tamanho20(versaoProcessoEmissao, "Versao Aplicativo Emissor");
+        this.versaoProcessoEmissao = versaoProcessoEmissao;
+    }
+    
+    public String getCodigoMunicipioEnvio() {
+        return this.codigoMunicipioEnvio;
+    }
+    
+    /**
+     * Codigo do Municipio de envio do CT-e (de onde o documento foi transmitido)<br>
+     * Utilizar a tabela do IBGE. Informar 9999999 para as operacoes com o exterior.
+     */
+    public void setCodigoMunicipioEnvio(final String codigoMunicipioEnvio) {
+        DFStringValidador.exatamente7N(codigoMunicipioEnvio, "Codigo do Municipio de envio do CT-e");
+        this.codigoMunicipioEnvio = codigoMunicipioEnvio;
+    }
+    
+    public String getDescricaoMunicipioEnvio() {
+        return this.descricaoMunicipioEnvio;
+    }
+    
+    /**
+     * Nome do Municipio de envio do CT-e (de onde o documento foi transmitido)<br>
+     * Informar PAIS/Municipio para as operacoes com o exterior.
+     */
+    public void setDescricaoMunicipioEnvio(final String descricaoMunicipioEnvio) {
+        DFStringValidador.tamanho2ate60(descricaoMunicipioEnvio, "Nome do Municipio de envio do CT-e");
+        this.descricaoMunicipioEnvio = descricaoMunicipioEnvio;
+    }
+    
+    public String getSiglaUFEnvio() {
+        return this.siglaUFEnvio;
+    }
+    
+    /**
+     * Sigla da UF de envio do CT-e (de onde o documento foi transmitido)<br>
+     * Informar 'EX' para operacoes com o exterior.
+     */
+    public void setSiglaUFEnvio(final String siglaUFEnvio) {
+        DFStringValidador.exatamente2(siglaUFEnvio, "Sigla da UF de envio do CT-e");
+        this.siglaUFEnvio = siglaUFEnvio;
+    }
+    
+    public CTModal getModalidadeFrete() {
+        return this.modalidadeFrete;
+    }
+    
+    /**
+     * Modal<br>
+     * Preencher com:<br>
+     * 01 - Rodoviario;<br>
+     * 02 - Aereo;<br>
+     * 03 - Aquaviario;<br>
+     * 04 - Ferroviario;<br>
+     * 05 - Dutoviario;<br>
+     * 06 - Multimodal;
+     */
+    public void setModalidadeFrete(final CTModal modalidadeFrete) {
+        this.modalidadeFrete = modalidadeFrete;
+    }
+    
+    public CTTipoServicoOS getTipoServico() {
+        return this.tipoServico;
+    }
+    
+    /**
+     * Tipo do Servico<br>
+     * Preencher com:<br>
+     * 0 - Normal;<br>
+     * 1 - Subcontratacao;<br>
+     * 2 - Redespacho;<br>
+     * 3 - Redespacho Intermediario;<br>
+     * 4 - Servico Vinculado a Multimodal
+     */
+    public void setTipoServico(final CTTipoServicoOS tipoServico) {
+        this.tipoServico = tipoServico;
+    }
+    
+    public String getCodigoMunicipioInicio() {
+        return this.codigoMunicipioInicio;
+    }
+    
+    /**
+     * Codigo do Municipio de inicio da prestacao<br>
+     * Utilizar a tabela do IBGE. Informar 9999999 para operacoes com o exterior.
+     */
+    public void setCodigoMunicipioInicio(final String codigoMunicipioInicio) {
+        DFStringValidador.exatamente7N(codigoMunicipioInicio, "Codigo do Municipio de inicio da prestacao");
+        this.codigoMunicipioInicio = codigoMunicipioInicio;
+    }
+    
+    public String getDescricaoMunicipioInicio() {
+        return this.descricaoMunicipioInicio;
+    }
+    
+    /**
+     * Nome do Municipio do inicio da prestacao<br>
+     * Informar 'EXTERIOR' para operacoes com o exterior.
+     */
+    public void setDescricaoMunicipioInicio(final String descricaoMunicipioInicio) {
+        DFStringValidador.tamanho2ate60(descricaoMunicipioInicio, "Nome do Municipio do inicio da prestacao");
+        this.descricaoMunicipioInicio = descricaoMunicipioInicio;
+    }
+    
+    public String getSiglaUfInicio() {
+        return this.siglaUfInicio;
+    }
+    
+    /**
+     * UF do inicio da prestacao<br>
+     * Informar 'EX' para operacoes com o exterior.
+     */
+    public void setSiglaUfInicio(final String siglaUfInicio) {
+        DFStringValidador.exatamente2(siglaUfInicio, "UF do inicio da prestacao");
+        this.siglaUfInicio = siglaUfInicio;
+    }
+    
+    public String getCodigoMunicipioFim() {
+        return this.codigoMunicipioFim;
+    }
+    
+    /**
+     * Codigo do Municipio de termino da prestacao<br>
+     * Utilizar a tabela do IBGE. Informar 9999999 para operacoes com o exterior.
+     */
+    public void setCodigoMunicipioFim(final String codigoMunicipioFim) {
+        DFStringValidador.exatamente7N(codigoMunicipioFim, "Codigo do Municipio de termino da prestacao");
+        this.codigoMunicipioFim = codigoMunicipioFim;
+    }
+    
+    public String getDescricaoMunicipioFim() {
+        return this.descricaoMunicipioFim;
+    }
+    
+    /**
+     * Nome do Municipio do termino da prestacao<br>
+     * Informar 'EXTERIOR' para operacoes com o exterior.
+     */
+    public void setDescricaoMunicipioFim(final String descricaoMunicipioFim) {
+        DFStringValidador.tamanho2ate60(descricaoMunicipioFim, "Nome do Municipio do termino da prestacao");
+        this.descricaoMunicipioFim = descricaoMunicipioFim;
+    }
+    
+    public String getSiglaUfFim() {
+        return this.siglaUfFim;
+    }
+    
+    /**
+     * UF do termino da prestacao<br>
+     * Informar 'EX' para operacoes com o exterior.
+     */
+    public void setSiglaUfFim(final String siglaUfFim) {
+        DFStringValidador.exatamente2(siglaUfFim, "UF do termino da prestacao");
+        this.siglaUfFim = siglaUfFim;
+    }
+    
+    public CTIndicadorTomador getIndIEToma() {
+        return this.indIEToma;
+    }
+    
+    /**
+     * Indicador do papel do tomador na prestacao do servico:<br>
+     * 1 – Contribuinte ICMS;<br>
+     * 2 – Contribuinte isento de inscricao;<br>
+     * 9 – Nao Contribuinte<br>
+     * Aplica-se ao tomador que for indicado no toma3 ou toma4
+     */
+    public void setIndIEToma(final CTIndicadorTomador indIEToma) {
+        this.indIEToma = indIEToma;
+    }
+    
+    public LocalDateTime getDataContingencia() {
+        return this.dataContingencia;
+    }
+    
+    /**
+     * Data e Hora da entrada em contingencia<br>
+     * Informar a data e hora no formato AAAA-MM-DDTHH:MM:SS
+     */
+    public void setDataContingencia(final LocalDateTime dataContingencia) {
+        this.dataContingencia = dataContingencia;
+    }
+    
+    public String getJustificativa() {
+        return this.justificativa;
+    }
+    
+    /**
+     * Justificativa da entrada em contingencia
+     */
+    public void setJustificativa(final String justificativa) {
+        DFStringValidador.tamanho15a256(justificativa, "Justificativa da entrada em contingencia");
+        this.justificativa = justificativa;
+    }
+
+    public List<CTeOSInfoIdentificacaoUfPercurso> getIdentificacaoUfPercursos() {
+        return identificacaoUfPercursos;
+    }
+
+    public void setIdentificacaoUfPercursos(List<CTeOSInfoIdentificacaoUfPercurso> identificacaoUfPercursos) {
+        this.identificacaoUfPercursos = identificacaoUfPercursos;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoIdentificacaoTomador.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoIdentificacaoTomador.java
@@ -1,0 +1,137 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "toma")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoIdentificacaoTomador extends DFBase {
+    private static final long serialVersionUID = -7014772748798643095L;
+
+    @Element(name = "CNPJ", required = false)
+    private String cnpj;
+
+    @Element(name = "CPF", required = false)
+    private String cpf;
+
+    @Element(name = "IE", required = false)
+    private String inscricaoEstadual;
+
+    @Element(name = "xNome")
+    private String razaoSocial;
+
+    @Element(name = "xFant", required = false)
+    private String nomeFantasia;
+
+    @Element(name = "fone", required = false)
+    private String telefone;
+
+    @Element(name = "enderToma")
+    private CTeOSEndereco enderTomadorServico;
+
+    @Element(name = "email", required = false)
+    private String email;
+
+    public String getCnpj() {
+        return this.cnpj;
+    }
+
+    /**
+     * Número do CNPJ<br>
+     * Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros. Informar os zeros não significativos.
+     */
+    public void setCnpj(final String cnpj) {
+        DFStringValidador.cnpj(cnpj);
+        this.cnpj = cnpj;
+    }
+
+    public String getCpf() {
+        return this.cpf;
+    }
+
+    /**
+     * Número do CPF<br>
+     * Informar os zeros não significativos.
+     */
+    public void setCpf(final String cpf) {
+        DFStringValidador.cpf(cpf);
+        this.cpf = cpf;
+    }
+
+    public String getInscricaoEstadual() {
+        return this.inscricaoEstadual;
+    }
+
+    /**
+     * Inscrição Estadual<br>
+     * Informar a IE do tomador ou ISENTO se tomador é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o tomador não seja contribuinte do ICMS não informar o conteúdo.
+     */
+    public void setInscricaoEstadual(final String inscricaoEstadual) {
+        DFStringValidador.inscricaoEstadual(inscricaoEstadual);
+        this.inscricaoEstadual = inscricaoEstadual;
+    }
+
+    public String getRazaoSocial() {
+        return this.razaoSocial;
+    }
+
+    /**
+     * Razão Social ou Nome
+     */
+    public void setRazaoSocial(final String razaoSocial) {
+        DFStringValidador.tamanho2ate60(razaoSocial, "Razão Social ou Nome");
+        this.razaoSocial = razaoSocial;
+    }
+
+    public String getNomeFantasia() {
+        return this.nomeFantasia;
+    }
+
+    /**
+     * Nome Fantasia
+     */
+    public void setNomeFantasia(final String nomeFantasia) {
+        DFStringValidador.tamanho2ate60(nomeFantasia, "Nome Fantasia");
+        this.nomeFantasia = nomeFantasia;
+    }
+
+    public String getTelefone() {
+        return this.telefone;
+    }
+
+    /**
+     * Telefone
+     */
+    public void setTelefone(final String telefone) {
+        DFStringValidador.telefone(telefone);
+        this.telefone = telefone;
+    }
+
+    public CTeOSEndereco getEnderTomadorServico() {
+        return this.enderTomadorServico;
+    }
+
+    /**
+     * Dados do endereço
+     */
+    public void setEnderTomadorServico(final CTeOSEndereco enderTomadorServico) {
+        this.enderTomadorServico = enderTomadorServico;
+    }
+
+    public String getEmail() {
+        return this.email;
+    }
+
+    /**
+     * Endereço de email
+     */
+    public void setEmail(final String email) {
+        DFStringValidador.tamanho60(email, "Endereço de email");
+        DFStringValidador.email(email);
+        this.email = email;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoIdentificacaoUfPercurso.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoIdentificacaoUfPercurso.java
@@ -1,0 +1,37 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.DFUnidadeFederativa;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+
+@Root(name = "infPercurso")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoIdentificacaoUfPercurso extends DFBase {
+    private static final long serialVersionUID = -8756073376187638453L;
+
+    @Element(name = "UFPer")
+    private String ufPercurso;
+
+    public CTeOSInfoIdentificacaoUfPercurso() {
+    }
+
+    public CTeOSInfoIdentificacaoUfPercurso(final DFUnidadeFederativa ufPercurso) {
+        this.ufPercurso = ufPercurso.getCodigo();
+    }
+
+    public String getUfPercurso() {
+        return this.ufPercurso;
+    }
+
+    public void setUfPercurso(final String ufPercurso) {
+        this.ufPercurso = ufPercurso;
+    }
+
+    public void setUfPercurso(final DFUnidadeFederativa ufPercurso) {
+        this.ufPercurso = ufPercurso.getCodigo();
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostos.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostos.java
@@ -1,0 +1,87 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "imp")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostos extends DFBase {
+    private static final long serialVersionUID = -8373764548950257942L;
+
+    @Element(name = "ICMS")
+    private CTeOSInfoInformacoesRelativasImpostosICMS icms;
+
+    @Element(name = "vTotTrib", required = false)
+    private String valorTotalTributos;
+
+    @Element(name = "infAdFisco", required = false)
+    private String informacoesAdicionaisFisco;
+
+    @Element(name = "ICMSUFFim", required = false)
+    private CTeOSInfoInformacoesRelativasImpostosICMSPartilha icmsPartilha;
+
+    @Element(name = "infTribFed", required = false)
+    private CTeOSInfoInformacoesRelativasImpostosTributosFederais tributosFederais;
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS getIcms() {
+        return this.icms;
+    }
+
+    /**
+     * Informações relativas ao ICMS
+     */
+    public void setIcms(final CTeOSInfoInformacoesRelativasImpostosICMS icms) {
+        this.icms = icms;
+    }
+
+    public String getValorTotalTributos() {
+        return this.valorTotalTributos;
+    }
+
+    /**
+     * Valor Total dos Tributos
+     */
+    public void setValorTotalTributos(final BigDecimal valorTotalTributos) {
+        this.valorTotalTributos = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorTotalTributos, "Valor Total dos Tributos");
+    }
+
+    public String getInformacoesAdicionaisFisco() {
+        return this.informacoesAdicionaisFisco;
+    }
+
+    /**
+     * Informações adicionais de interesse do Fisco<br>
+     * Norma referenciada, informações complementares, etc
+     */
+    public void setInformacoesAdicionaisFisco(final String informacoesAdicionaisFisco) {
+        DFStringValidador.tamanho2000(informacoesAdicionaisFisco, "Informações adicionais de interesse do Fisco");
+        this.informacoesAdicionaisFisco = informacoesAdicionaisFisco;
+    }
+
+    public CTeOSInfoInformacoesRelativasImpostosICMSPartilha getIcmsPartilha() {
+        return this.icmsPartilha;
+    }
+
+    /**
+     * Informações do ICMS de partilha com a UF de término do serviço de transporte na operação interestadual<br>
+     * Grupo a ser informado nas prestações interestaduais para consumidor final, não contribuinte do ICMS
+     */
+    public void setIcmsPartilha(final CTeOSInfoInformacoesRelativasImpostosICMSPartilha icmsPartilha) {
+        this.icmsPartilha = icmsPartilha;
+    }
+
+    public CTeOSInfoInformacoesRelativasImpostosTributosFederais getTributosFederais() {
+        return tributosFederais;
+    }
+
+    public void setTributosFederais(final CTeOSInfoInformacoesRelativasImpostosTributosFederais tributosFederais) {
+        this.tributosFederais = tributosFederais;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS.java
@@ -1,0 +1,120 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "ICMS")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostosICMS extends DFBase {
+
+    @Element(name = "ICMS00", required = false)
+    private CTeOSInfoInformacoesRelativasImpostosICMS00 icms00;
+
+    @Element(name = "ICMS20", required = false)
+    private CTeOSInfoInformacoesRelativasImpostosICMS20 icms20;
+
+    @Element(name = "ICMS45", required = false)
+    private CTeOSInfoInformacoesRelativasImpostosICMS45 icms45;
+
+    @Element(name = "ICMS60", required = false)
+    private CTeOSInfoInformacoesRelativasImpostosICMS60 icms60;
+
+    @Element(name = "ICMS90", required = false)
+    private CTeOSInfoInformacoesRelativasImpostosICMS90 icms90;
+
+    @Element(name = "ICMSOutraUF", required = false)
+    private CTeOSInfoInformacoesRelativasImpostosICMSOutraUF icmsOutraUF;
+
+    @Element(name = "ICMSSN", required = false)
+    private CTeOSInfoInformacoesRelativasImpostosICMSSN icmssn;
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS() {
+        this.icms00 = null;
+        this.icms20 = null;
+        this.icms45 = null;
+        this.icms60 = null;
+        this.icms90 = null;
+        this.icmsOutraUF = null;
+        this.icmssn = null;
+    }
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS00 getIcms00() {
+        return this.icms00;
+    }
+
+    /**
+     * Prestação sujeito à tributação normal do ICMS
+     */
+    public void setIcms00(final CTeOSInfoInformacoesRelativasImpostosICMS00 icms00) {
+        this.icms00 = icms00;
+    }
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS20 getIcms20() {
+        return this.icms20;
+    }
+
+    /**
+     * Prestação sujeito à tributação com redução de BC do ICMS<
+     */
+    public void setIcms20(final CTeOSInfoInformacoesRelativasImpostosICMS20 icms20) {
+        this.icms20 = icms20;
+    }
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS45 getIcms45() {
+        return this.icms45;
+    }
+
+    /**
+     * ICMS Isento, não Tributado ou diferido
+     */
+    public void setIcms45(final CTeOSInfoInformacoesRelativasImpostosICMS45 icms45) {
+        this.icms45 = icms45;
+    }
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS60 getIcms60() {
+        return this.icms60;
+    }
+
+    /**
+     * Tributação pelo ICMS60 - ICMS cobrado por substituição tributária.Responsabilidade do recolhimento do ICMS atribuído ao tomador ou 3º por ST
+     */
+    public void setIcms60(final CTeOSInfoInformacoesRelativasImpostosICMS60 icms60) {
+        this.icms60 = icms60;
+    }
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS90 getIcms90() {
+        return this.icms90;
+    }
+
+    /**
+     * ICMS Outros
+     */
+    public void setIcms90(final CTeOSInfoInformacoesRelativasImpostosICMS90 icms90) {
+        this.icms90 = icms90;
+    }
+
+    public CTeOSInfoInformacoesRelativasImpostosICMSOutraUF getIcmsOutraUF() {
+        return this.icmsOutraUF;
+    }
+
+    /**
+     * ICMS devido à UF de origem da prestação, quando diferente da UF do emitente
+     */
+    public void setIcmsOutraUF(final CTeOSInfoInformacoesRelativasImpostosICMSOutraUF icmsOutraUF) {
+        this.icmsOutraUF = icmsOutraUF;
+    }
+
+    public CTeOSInfoInformacoesRelativasImpostosICMSSN getIcmssn() {
+        return this.icmssn;
+    }
+
+    /**
+     * Simples Nacional
+     */
+    public void setIcmssn(final CTeOSInfoInformacoesRelativasImpostosICMSSN icmssn) {
+        this.icmssn = icmssn;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS00.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS00.java
@@ -1,0 +1,80 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte300.classes.CTCodigoSituacaoTributariaICMS;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "ICMS00")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostosICMS00 extends DFBase {
+    
+    @Element(name = "CST")
+    private CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria;
+    
+    @Element(name = "vBC")
+    private String baseCalculoICMS;
+    
+    @Element(name = "pICMS")
+    private String aliquotaICMS;
+    
+    @Element(name = "vICMS")
+    private String valorICMS;
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS00() {
+        this.codigoSituacaoTributaria = null;
+        this.baseCalculoICMS = null;
+        this.aliquotaICMS = null;
+        this.valorICMS = null;
+    }
+
+    public CTCodigoSituacaoTributariaICMS getCodigoSituacaoTributaria() {
+        return this.codigoSituacaoTributaria;
+    }
+
+    /**
+     * classificação Tributária do Serviço<br>
+     * 00 - tributação normal ICMS
+     */
+    public void setCodigoSituacaoTributaria(final CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria) {
+        this.codigoSituacaoTributaria = codigoSituacaoTributaria;
+    }
+
+    public String getBaseCalculoICMS() {
+        return this.baseCalculoICMS;
+    }
+
+    /**
+     * Valor da BC do ICMS
+     */
+    public void setBaseCalculoICMS(final BigDecimal baseCalculoICMS) {
+        this.baseCalculoICMS = DFBigDecimalValidador.tamanho15Com2CasasDecimais(baseCalculoICMS, "Valor da BC do ICMS");
+    }
+
+    public String getAliquotaICMS() {
+        return this.aliquotaICMS;
+    }
+
+    /**
+     * Alíquota do ICMS
+     */
+    public void setAliquotaICMS(final BigDecimal aliquotaICMS) {
+        this.aliquotaICMS = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaICMS, "Alíquota do ICMS");
+    }
+
+    public String getValorICMS() {
+        return this.valorICMS;
+    }
+
+    /**
+     * Valor do ICMS
+     */
+    public void setValorICMS(final BigDecimal valorICMS) {
+        this.valorICMS = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorICMS, "Valor do ICMS");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS20.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS20.java
@@ -1,0 +1,95 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte300.classes.CTCodigoSituacaoTributariaICMS;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "ICMS20")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostosICMS20 extends DFBase {
+    
+    @Element(name = "CST")
+    private CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria;
+    
+    @Element(name = "pRedBC")
+    private String aliquotaReducaoBaseCalculoICMS;
+    
+    @Element(name = "vBC")
+    private String baseCalculoICMS;
+    
+    @Element(name = "pICMS")
+    private String aliquotaICMS;
+    
+    @Element(name = "vICMS")
+    private String valorICMS;
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS20() {
+        this.codigoSituacaoTributaria = null;
+        this.aliquotaReducaoBaseCalculoICMS = null;
+        this.baseCalculoICMS = null;
+        this.aliquotaICMS = null;
+        this.valorICMS = null;
+    }
+
+    public CTCodigoSituacaoTributariaICMS getCodigoSituacaoTributaria() {
+        return this.codigoSituacaoTributaria;
+    }
+
+    /**
+     * Classificação Tributária do serviço<br>
+     * 20 - tributação com BC reduzida do ICMS
+     */
+    public void setCodigoSituacaoTributaria(final CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria) {
+        this.codigoSituacaoTributaria = codigoSituacaoTributaria;
+    }
+
+    public String getAliquotaReducaoBaseCalculoICMS() {
+        return this.aliquotaReducaoBaseCalculoICMS;
+    }
+
+    /**
+     * Percentual de redução da BC
+     */
+    public void setAliquotaReducaoBaseCalculoICMS(final BigDecimal aliquotaReducaoBaseCalculoICMS) {
+        this.aliquotaReducaoBaseCalculoICMS = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaReducaoBaseCalculoICMS, "Percentual de redução da BC");
+    }
+
+    public String getBaseCalculoICMS() {
+        return this.baseCalculoICMS;
+    }
+
+    /**
+     * Valor da BC do ICMS
+     */
+    public void setBaseCalculoICMS(final BigDecimal baseCalculoICMS) {
+        this.baseCalculoICMS = DFBigDecimalValidador.tamanho15Com2CasasDecimais(baseCalculoICMS, "Valor da BC do ICMS");
+    }
+
+    public String getAliquotaICMS() {
+        return this.aliquotaICMS;
+    }
+
+    /**
+     * Alíquota do ICMS
+     */
+    public void setAliquotaICMS(final BigDecimal aliquotaICMS) {
+        this.aliquotaICMS = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaICMS, "Alíquota do ICMS");
+    }
+
+    public String getValorICMS() {
+        return this.valorICMS;
+    }
+
+    /**
+     * Valor do ICMS
+     */
+    public void setValorICMS(final BigDecimal valorICMS) {
+        this.valorICMS = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorICMS, "Valor do ICMS");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS45.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS45.java
@@ -1,0 +1,35 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte300.classes.CTCodigoSituacaoTributariaICMS;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "ICMS45")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostosICMS45 extends DFBase {
+    
+    @Element(name = "CST")
+    private CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria;
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS45() {
+        this.codigoSituacaoTributaria = null;
+    }
+
+    public CTCodigoSituacaoTributariaICMS getCodigoSituacaoTributaria() {
+        return this.codigoSituacaoTributaria;
+    }
+
+    /**
+     * Classificação Tributária do Serviço<br>
+     * Preencher com:<br>
+     * 40 - ICMS isenção;<br>
+     * 41 - ICMS não tributada;<br>
+     * 51 - ICMS diferido
+     */
+    public void setCodigoSituacaoTributaria(final CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria) {
+        this.codigoSituacaoTributaria = codigoSituacaoTributaria;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS60.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS60.java
@@ -1,0 +1,99 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte300.classes.CTCodigoSituacaoTributariaICMS;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "ICMS60")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostosICMS60 extends DFBase {
+    
+    @Element(name = "CST")
+    private CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria;
+    
+    @Element(name = "vBCSTRet")
+    private String baseCalculoICMSSTRetido;
+    
+    @Element(name = "vICMSSTRet")
+    private String valorICMSSTRetido;
+    
+    @Element(name = "pICMSSTRet")
+    private String aliquotaICMSSTRetido;
+
+    @Element(name = "vCred", required = false)
+    private String valorCredito;
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS60() {
+        this.codigoSituacaoTributaria = null;
+        this.baseCalculoICMSSTRetido = null;
+        this.valorICMSSTRetido = null;
+        this.aliquotaICMSSTRetido = null;
+        this.valorCredito = null;
+    }
+
+    public CTCodigoSituacaoTributariaICMS getCodigoSituacaoTributaria() {
+        return this.codigoSituacaoTributaria;
+    }
+
+    /**
+     * Classificação Tributária do Serviço<br>
+     * 60 - ICMS cobrado por substituição tributária
+     */
+    public void setCodigoSituacaoTributaria(final CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria) {
+        this.codigoSituacaoTributaria = codigoSituacaoTributaria;
+    }
+
+    public String getBaseCalculoICMSSTRetido() {
+        return this.baseCalculoICMSSTRetido;
+    }
+
+    /**
+     * Valor da BC do ICMS ST retido<br>
+     * Valor do frete sobre o qual será calculado o ICMS a ser substituído na Prestação.
+     */
+    public void setBaseCalculoICMSSTRetido(final BigDecimal baseCalculoICMSSTRetido) {
+        this.baseCalculoICMSSTRetido = DFBigDecimalValidador.tamanho15Com2CasasDecimais(baseCalculoICMSSTRetido, "Valor da BC do ICMS ST retido");
+    }
+
+    public String getValorICMSSTRetido() {
+        return this.valorICMSSTRetido;
+    }
+
+    /**
+     * Valor do ICMS ST retido<br>
+     * Resultado da multiplicação do “vBCSTRet” x “pICMSSTRet” – que será valor do ICMS a ser retido pelo Substituto. Podendo o valor do ICMS a ser retido efetivamente, sofrer ajustes conforme a opção tributaria do transportador substituído.
+     */
+    public void setValorICMSSTRetido(final BigDecimal valorICMSSTRetido) {
+        this.valorICMSSTRetido = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorICMSSTRetido, "Valor do ICMS ST retido");
+    }
+
+    public String getAliquotaICMSSTRetido() {
+        return this.aliquotaICMSSTRetido;
+    }
+
+    /**
+     * Alíquota do ICMS<br>
+     * Percentual de Alíquota incidente na prestação de serviço de transporte.
+     */
+    public void setAliquotaICMSSTRetido(final BigDecimal aliquotaICMSSTRetido) {
+        this.aliquotaICMSSTRetido = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaICMSSTRetido, "Alíquota do ICMS");
+    }
+
+    public String getValorCredito() {
+        return this.valorCredito;
+    }
+
+    /**
+     * Valor do Crédito outorgado/Presumido<br>
+     * Preencher somente quando o transportador substituído, for optante pelo crédito outorgado previsto no Convênio 106/96 e corresponde ao percentual de 20% do valor do ICMS ST retido.
+     */
+    public void setValorCredito(final BigDecimal valorCredito) {
+        this.valorCredito = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorCredito, "Valor do Crédito outorgado/Presumido");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS90.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS90.java
@@ -1,0 +1,110 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte300.classes.CTCodigoSituacaoTributariaICMS;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "ICMS90")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostosICMS90 extends DFBase {
+    
+    @Element(name = "CST")
+    private CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria;
+
+    @Element(name = "pRedBC", required = false)
+    private String aliquotaReducaoBaseCalculo;
+    
+    @Element(name = "vBC")
+    private String baseCalculoICMS;
+    
+    @Element(name = "pICMS")
+    private String aliquotaICMS;
+    
+    @Element(name = "vICMS")
+    private String valorICMS;
+
+    @Element(name = "vCred", required = false)
+    private String valorCredito;
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS90() {
+        this.codigoSituacaoTributaria = null;
+        this.aliquotaReducaoBaseCalculo = null;
+        this.baseCalculoICMS = null;
+        this.aliquotaICMS = null;
+        this.valorICMS = null;
+        this.valorCredito = null;
+    }
+
+    public CTCodigoSituacaoTributariaICMS getCodigoSituacaoTributaria() {
+        return this.codigoSituacaoTributaria;
+    }
+
+    /**
+     * Classificação Tributária do Serviço<br>
+     * 90 - ICMS outros
+     */
+    public void setCodigoSituacaoTributaria(final CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria) {
+        this.codigoSituacaoTributaria = codigoSituacaoTributaria;
+    }
+
+    public String getAliquotaReducaoBaseCalculo() {
+        return this.aliquotaReducaoBaseCalculo;
+    }
+
+    /**
+     * Percentual de redução da BC
+     */
+    public void setAliquotaReducaoBaseCalculo(final BigDecimal aliquotaReducaoBaseCalculo) {
+        this.aliquotaReducaoBaseCalculo = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaReducaoBaseCalculo, "Percentual de redução da BC");
+    }
+
+    public String getBaseCalculoICMS() {
+        return this.baseCalculoICMS;
+    }
+
+    /**
+     * Valor da BC do ICMS
+     */
+    public void setBaseCalculoICMS(final BigDecimal baseCalculoICMS) {
+        this.baseCalculoICMS = DFBigDecimalValidador.tamanho15Com2CasasDecimais(baseCalculoICMS, "Valor da BC do ICMS");
+    }
+
+    public String getAliquotaICMS() {
+        return this.aliquotaICMS;
+    }
+
+    /**
+     * Alíquota do ICMS
+     */
+    public void setAliquotaICMS(final BigDecimal aliquotaICMS) {
+        this.aliquotaICMS = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaICMS, "Alíquota do ICMS");
+    }
+
+    public String getValorICMS() {
+        return this.valorICMS;
+    }
+
+    /**
+     * Valor do ICMS
+     */
+    public void setValorICMS(final BigDecimal valorICMS) {
+        this.valorICMS = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorICMS, "Valor do ICMS");
+    }
+
+    public String getValorCredito() {
+        return this.valorCredito;
+    }
+
+    /**
+     * Valor do Crédito Outorgado/Presumido
+     */
+    public void setValorCredito(final BigDecimal valorCredito) {
+        this.valorCredito = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorCredito, "Valor do Crédito Outorgado/Presumido");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostosICMSOutraUF.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostosICMSOutraUF.java
@@ -1,0 +1,95 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte300.classes.CTCodigoSituacaoTributariaICMS;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "ICMSOutraUF")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostosICMSOutraUF extends DFBase {
+    
+    @Element(name = "CST")
+    private CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria;
+
+    @Element(name = "pRedBCOutraUF", required = false)
+    private String aliquotaReducaoBaseCalculoICMSOutraUF;
+    
+    @Element(name = "vBCOutraUF")
+    private String baseCalculoICMSOutraUF;
+    
+    @Element(name = "pICMSOutraUF")
+    private String aliquotaICMSOutraUF;
+    
+    @Element(name = "vICMSOutraUF")
+    private String valorICMSOutraUF;
+
+    public CTeOSInfoInformacoesRelativasImpostosICMSOutraUF() {
+        this.codigoSituacaoTributaria = null;
+        this.aliquotaReducaoBaseCalculoICMSOutraUF = null;
+        this.baseCalculoICMSOutraUF = null;
+        this.aliquotaICMSOutraUF = null;
+        this.valorICMSOutraUF = null;
+    }
+
+    public CTCodigoSituacaoTributariaICMS getCodigoSituacaoTributaria() {
+        return this.codigoSituacaoTributaria;
+    }
+
+    /**
+     * Classificação Tributária do Serviço<br>
+     * 90 - ICMS Outra UF
+     */
+    public void setCodigoSituacaoTributaria(final CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria) {
+        this.codigoSituacaoTributaria = codigoSituacaoTributaria;
+    }
+
+    public String getAliquotaReducaoBaseCalculoICMSOutraUF() {
+        return this.aliquotaReducaoBaseCalculoICMSOutraUF;
+    }
+
+    /**
+     * Percentual de redução da BC
+     */
+    public void setAliquotaReducaoBaseCalculoICMSOutraUF(final BigDecimal aliquotaReducaoBaseCalculoICMSOutraUF) {
+        this.aliquotaReducaoBaseCalculoICMSOutraUF = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaReducaoBaseCalculoICMSOutraUF, "Percentual de redução da BC");
+    }
+
+    public String getBaseCalculoICMSOutraUF() {
+        return this.baseCalculoICMSOutraUF;
+    }
+
+    /**
+     * Valor da BC do ICMS
+     */
+    public void setBaseCalculoICMSOutraUF(final BigDecimal baseCalculoICMSOutraUF) {
+        this.baseCalculoICMSOutraUF = DFBigDecimalValidador.tamanho15Com2CasasDecimais(baseCalculoICMSOutraUF, "Valor da BC do ICMS");
+    }
+
+    public String getAliquotaICMSOutraUF() {
+        return this.aliquotaICMSOutraUF;
+    }
+
+    /**
+     * Alíquota do ICMS
+     */
+    public void setAliquotaICMSOutraUF(final BigDecimal aliquotaICMSOutraUF) {
+        this.aliquotaICMSOutraUF = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaICMSOutraUF, "Alíquota do ICMS");
+    }
+
+    public String getValorICMSOutraUF() {
+        return this.valorICMSOutraUF;
+    }
+
+    /**
+     * Valor do ICMS devido outra UF
+     */
+    public void setValorICMSOutraUF(final BigDecimal valorICMSOutraUF) {
+        this.valorICMSOutraUF = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorICMSOutraUF, "Valor do ICMS devido outra UF");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostosICMSPartilha.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostosICMSPartilha.java
@@ -1,0 +1,145 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "ICMSUFFim")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostosICMSPartilha extends DFBase {
+    
+    @Element(name = "vBCUFFim")
+    private String bcICMS;
+    
+    @Element(name = "pFCPUFFim")
+    private String aliquotaFCP;
+    
+    @Element(name = "pICMSUFFim")
+    private String aliquotaInterna;
+    
+    @Element(name = "pICMSInter")
+    private String aliquotaInterestadual;
+    
+    @Element(name = "pICMSInterPart", required = false)
+    private String aliquotaPartilha;
+
+    @Element(name = "vFCPUFFim")
+    private String valorFCP;
+    
+    @Element(name = "vICMSUFFim")
+    private String valorUfDestino;
+    
+    @Element(name = "vICMSUFIni")
+    private String valorUf;
+
+    public CTeOSInfoInformacoesRelativasImpostosICMSPartilha() {
+        this.bcICMS = null;
+        this.aliquotaFCP = null;
+        this.aliquotaInterna = null;
+        this.aliquotaInterestadual = null;
+        this.aliquotaPartilha = null;
+        this.valorFCP = null;
+        this.valorUfDestino = null;
+        this.valorUf = null;
+    }
+
+    public String getBcICMS() {
+        return this.bcICMS;
+    }
+
+    /**
+     * Valor da BC do ICMS na UF de término da prestação do serviço de transporte
+     */
+    public void setBcICMS(final BigDecimal bcICMS) {
+        this.bcICMS = DFBigDecimalValidador.tamanho15Com2CasasDecimais(bcICMS, "Valor da BC do ICMS na UF de término da prestação do serviço de transporte");
+    }
+
+    public String getAliquotaFCP() {
+        return this.aliquotaFCP;
+    }
+
+    /**
+     * Percentual do ICMS relativo ao Fundo de Combate à pobreza (FCP) na UF de término da prestação do serviço de transporte<br>
+     * Alíquota adotada nas operações internas na UF do destinatário
+     */
+    public void setAliquotaFCP(final BigDecimal aliquotaFCP) {
+        this.aliquotaFCP = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaFCP, "Percentual do ICMS relativo ao Fundo de Combate à pobreza (FCP)");
+    }
+
+    public String getAliquotaInterna() {
+        return this.aliquotaInterna;
+    }
+
+    /**
+     * Alíquota interna da UF de término da prestação do serviço de transporte<br>
+     * Alíquota adotada nas operações internas na UF do destinatário
+     */
+    public void setAliquotaInterna(final BigDecimal aliquotaInterna) {
+        this.aliquotaInterna = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaInterna, "Alíquota interna da UF de término da prestação do serviço de transporte");
+    }
+
+    public String getAliquotaInterestadual() {
+        return this.aliquotaInterestadual;
+    }
+
+    /**
+     * Alíquota interestadual das UF envolvidas
+     */
+    public void setAliquotaInterestadual(final BigDecimal aliquotaInterestadual) {
+        this.aliquotaInterestadual = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaInterestadual, "Alíquota interestadual das UF envolvidas");
+    }
+
+    public String getAliquotaPartilha() {
+        return this.aliquotaPartilha;
+    }
+
+    /**
+     * Percentual provisório de partilha entre os estados<br>
+     * Percentual de partilha para a UF do destinatário:<br>
+     * - 40% em 2016;<br>
+     * - 60% em 2017;<br>
+     * - 80% em 2018;<br>
+     * - 100% a partir de 2019.
+     */
+    public void setAliquotaPartilha(final BigDecimal aliquotaPartilha) {
+        this.aliquotaPartilha = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaPartilha, "Percentual provisório de partilha entre os estados");
+    }
+
+    public String getValorFCP() {
+        return this.valorFCP;
+    }
+
+    /**
+     * Valor do ICMS relativo ao Fundo de Combate á Pobreza (FCP) da UF de término da prestação
+     */
+    public void setValorFCP(final BigDecimal valorFCP) {
+        this.valorFCP = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorFCP, "Valor do ICMS relativo ao Fundo de Combate á Pobreza (FCP)");
+    }
+
+    public String getValorUfDestino() {
+        return this.valorUfDestino;
+    }
+
+    /**
+     * Valor do ICMS de partilha para a UF de término da prestação do serviço de transporte
+     */
+    public void setValorUfDestino(final BigDecimal valorUfDestino) {
+        this.valorUfDestino = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorUfDestino, "Valor do ICMS de partilha para a UF de término da prestação do serviço de transporte");
+    }
+
+    public String getValorUf() {
+        return this.valorUf;
+    }
+
+    /**
+     * Valor do ICMS de partilha para a UF de início da prestação do serviço de transporte
+     */
+    public void setValorUf(final BigDecimal valorUf) {
+        this.valorUf = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorUf, "Valor do ICMS de partilha para a UF de início da prestação do serviço de transporte");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostosICMSSN.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostosICMSSN.java
@@ -1,0 +1,47 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte300.classes.CTCodigoSituacaoTributariaICMS;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "ICMSSN")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostosICMSSN extends DFBase {
+    
+    @Element(name = "CST")
+    private CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria;
+    
+    @Element(name = "indSN")
+    private String indicadorSN;
+
+    public CTeOSInfoInformacoesRelativasImpostosICMSSN() {
+        this.codigoSituacaoTributaria = null;
+        this.indicadorSN = null;
+    }
+
+    public CTCodigoSituacaoTributariaICMS getCodigoSituacaoTributaria() {
+        return this.codigoSituacaoTributaria;
+    }
+
+    /**
+     * Classificação Tributária do Serviço<br>
+     * 90 - ICMS Simples Nacional
+     */
+    public void setCodigoSituacaoTributaria(final CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria) {
+        this.codigoSituacaoTributaria = codigoSituacaoTributaria;
+    }
+
+    public String getIndicadorSN() {
+        return this.indicadorSN;
+    }
+
+    /**
+     * Indica se o contribuinte é Simples Nacional 1=Sim
+     */
+    public void setIndicadorSN(final String indicadorSN) {
+        this.indicadorSN = indicadorSN;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostosTributosFederais.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoInformacoesRelativasImpostosTributosFederais.java
@@ -1,0 +1,71 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "infTribFed")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostosTributosFederais extends DFBase {
+    private static final long serialVersionUID = -5969100532189710320L;
+
+    @Element(name = "vPIS", required = false)
+    private String valorPIS;
+
+    @Element(name = "vCOFINS", required = false)
+    private String valorCOFINS;
+
+    @Element(name = "vIR", required = false)
+    private String valorIR;
+
+    @Element(name = "vINSS", required = false)
+    private String valorINSS;
+
+    @Element(name = "vCSLL", required = false)
+    private String valorCSLL;
+
+    public String getValorPIS() {
+        return valorPIS;
+    }
+
+    public void setValorPIS(final BigDecimal valorPIS) {
+        this.valorPIS = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorPIS, "Valor PIS");
+    }
+
+    public String getValorCOFINS() {
+        return valorCOFINS;
+    }
+
+    public void setValorCOFINS(final BigDecimal valorCOFINS) {
+        this.valorCOFINS = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorCOFINS, "Valor COFINS");
+    }
+
+    public String getValorIR() {
+        return valorIR;
+    }
+
+    public void setValorIR(final BigDecimal valorIR) {
+        this.valorIR = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorIR, "Valor IR");
+    }
+
+    public String getValorINSS() {
+        return valorINSS;
+    }
+
+    public void setValorINSS(final BigDecimal valorINSS) {
+        this.valorINSS = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorINSS, "Valor INSS");
+    }
+
+    public String getValorCSLL() {
+        return valorCSLL;
+    }
+
+    public void setValorCSLL(final BigDecimal valorCSLL) {
+        this.valorCSLL = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorCSLL, "Valor CSLL");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoResponsavelTecnico.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoResponsavelTecnico.java
@@ -1,0 +1,91 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "infRespTec")
+@Namespace(reference = "http://www.portalfiscal.inf.br/cte")
+public class CTeOSInfoResponsavelTecnico extends DFBase {
+    private static final long serialVersionUID = 2049320360410243067L;
+
+    @Element(name = "CNPJ")
+    private String cnpj;
+
+    @Element(name = "xContato")
+    private String contatoNome;
+
+    @Element(name = "email")
+    private String email;
+
+    @Element(name = "fone")
+    private String telefone;
+
+    @Element(name = "idCSRT", required = false)
+    private String idCSRT;
+
+    @Element(name = "hashCSRT", required = false)
+    private String hashCSRT;
+
+    public String getCnpj() {
+        return cnpj;
+    }
+
+    public CTeOSInfoResponsavelTecnico setCnpj(String cnpj) {
+        DFStringValidador.cnpj(cnpj);
+        this.cnpj = cnpj;
+        return this;
+    }
+
+    public String getContatoNome() {
+        return contatoNome;
+    }
+
+    public CTeOSInfoResponsavelTecnico setContatoNome(String contatoNome) {
+        DFStringValidador.tamanho2ate60(contatoNome, "Responsavel tecnico");
+        this.contatoNome = contatoNome;
+        return this;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public CTeOSInfoResponsavelTecnico setEmail(String email) {
+        DFStringValidador.email(email, "Responsavel tecnico ");
+        DFStringValidador.validaIntervalo(email, 6, 60, "Responsavel tecnico");
+        this.email = email;
+        return this;
+    }
+
+    public String getTelefone() {
+        return telefone;
+    }
+
+    public CTeOSInfoResponsavelTecnico setTelefone(String telefone) {
+        DFStringValidador.telefone(telefone, "Responsavel tecnico");
+        this.telefone = telefone;
+        return this;
+    }
+
+    public String getIdCSRT() {
+        return idCSRT;
+    }
+
+    public void setIdCSRT(String idCSRT) {
+        DFStringValidador.exatamente2N(idCSRT, "Responsavel tecnico");
+        this.idCSRT = idCSRT;
+    }
+
+    public String getHashCSRT() {
+        return hashCSRT;
+    }
+
+    public void setHashCSRT(String hashCSRT) {
+        DFStringValidador.isBase64(hashCSRT, "HASH CSRT em Responsavel tecnico");
+        this.hashCSRT = hashCSRT;
+    }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoSuplementares.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoSuplementares.java
@@ -1,0 +1,25 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "infCTeSupl")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoSuplementares extends DFBase {
+    private static final long serialVersionUID = 5643192963806193737L;
+
+    @Element(name = "qrCodCTe")
+    private String qrCode;
+
+    public String getQrCode() {
+        return qrCode;
+    }
+
+    public CTeOSInfoSuplementares setQrCode(String qrCode) {
+        this.qrCode = qrCode;
+        return this;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoValorPrestacaoServico.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoValorPrestacaoServico.java
@@ -1,0 +1,61 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Root(name = "vPrest")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoValorPrestacaoServico extends DFBase {
+    private static final long serialVersionUID = -5913703822180633261L;
+    
+    @Element(name = "vTPrest")
+    private String valorTotalPrestacaoServico;
+    
+    @Element(name = "vRec")
+    private String valorReceber;
+
+    @ElementList(name = "Comp", inline = true, required = false)
+    private List<CTeOSInfoValorPrestacaoServicoComponentesValorPrestacao> componentesValorPrestacao;
+
+    public String getValorTotalPrestacaoServico() {
+        return this.valorTotalPrestacaoServico;
+    }
+
+    /**
+     * Valor Total da Prestação do Serviço<br>
+     * Pode conter zeros quando o CT-e for de complemento de ICMS
+     */
+    public void setValorTotalPrestacaoServico(final BigDecimal valorTotalPrestacaoServico) {
+        this.valorTotalPrestacaoServico = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorTotalPrestacaoServico, "Valor Total da Prestação do Serviço");
+    }
+
+    public String getValorReceber() {
+        return this.valorReceber;
+    }
+
+    /**
+     * Valor a Receber
+     */
+    public void setValorReceber(final BigDecimal valorReceber) {
+        this.valorReceber = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorReceber, "Valor a Receber");
+    }
+
+    public List<CTeOSInfoValorPrestacaoServicoComponentesValorPrestacao> getComponentesValorPrestacao() {
+        return this.componentesValorPrestacao;
+    }
+
+    /**
+     * Componentes do Valor da Prestação
+     */
+    public void setComponentesValorPrestacao(final List<CTeOSInfoValorPrestacaoServicoComponentesValorPrestacao> componentesValorPrestacao) {
+        this.componentesValorPrestacao = componentesValorPrestacao;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoValorPrestacaoServicoComponentesValorPrestacao.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSInfoValorPrestacaoServicoComponentesValorPrestacao.java
@@ -1,0 +1,47 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "Comp")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoValorPrestacaoServicoComponentesValorPrestacao extends DFBase {
+    private static final long serialVersionUID = 8206239265618792602L;
+
+    @Element(name = "xNome")
+    private String nomeComponente;
+
+    @Element(name = "vComp")
+    private String valorComponente;
+
+    public String getNomeComponente() {
+        return this.nomeComponente;
+    }
+
+    /**
+     * Nome do componente<br>
+     * Exemplos: FRETE PESO, FRETE VALOR, SEC/CAT, ADEME, AGENDAMENTO, etc
+     */
+    public void setNomeComponente(final String nomeComponente) {
+        DFStringValidador.tamanho15(nomeComponente, "Nome do componente");
+        this.nomeComponente = nomeComponente;
+    }
+
+    public String getValorComponente() {
+        return this.valorComponente;
+    }
+
+    /**
+     * Valor do componente
+     */
+    public void setValorComponente(final BigDecimal valorComponente) {
+        this.valorComponente = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorComponente, "Valor do componente");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSProcessado.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/os/CTeOSProcessado.java
@@ -1,0 +1,62 @@
+package com.fincatto.documentofiscal.cte300.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte300.classes.enviolote.consulta.CTeProtocolo;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "cteOSProc")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSProcessado extends DFBase {
+    private static final long serialVersionUID = 137030186528448628L;
+
+    /**
+     * Tipo IP versão 4
+     */
+    @Attribute(name = "ipTransmissor", required = false)
+    private String ipTransmissor;
+
+    @Attribute(name = "versao")
+    private String versao;
+
+    @Element(name = "CTeOS")
+    private CTeOS cte;
+
+    @Element(name = "protCTe")
+    private CTeProtocolo protocolo;
+
+    public String getIpTransmissor() {
+        return this.ipTransmissor;
+    }
+
+    public void setIpTransmissor(final String ipTransmissor) {
+        this.ipTransmissor = ipTransmissor;
+    }
+
+    public String getVersao() {
+        return this.versao;
+    }
+
+    public void setVersao(final String versao) {
+        this.versao = versao;
+    }
+
+    public CTeOS getCte() {
+        return this.cte;
+    }
+
+    public void setCte(final CTeOS cte) {
+        this.cte = cte;
+    }
+
+    public CTeProtocolo getProtocolo() {
+        return this.protocolo;
+    }
+
+    public void setProtocolo(final CTeProtocolo protocolo) {
+        this.protocolo = protocolo;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/transformes/CTResponsavelSeguroTransformer.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/transformes/CTResponsavelSeguroTransformer.java
@@ -1,0 +1,18 @@
+package com.fincatto.documentofiscal.cte300.transformes;
+
+import com.fincatto.documentofiscal.cte300.classes.CTResponsavelSeguro;
+import org.simpleframework.xml.transform.Transform;
+
+public class CTResponsavelSeguroTransformer implements Transform<CTResponsavelSeguro> {
+
+    @Override
+    public CTResponsavelSeguro read(final String codigo) {
+        return CTResponsavelSeguro.valueOfCodigo(codigo);
+    }
+
+    @Override
+    public String write(final CTResponsavelSeguro tipo) {
+        return tipo.getCodigo();
+    }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/transformes/CTTipoFretamentoTransformer.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/transformes/CTTipoFretamentoTransformer.java
@@ -1,0 +1,18 @@
+package com.fincatto.documentofiscal.cte300.transformes;
+
+import com.fincatto.documentofiscal.cte300.classes.CTTipoFretamento;
+import org.simpleframework.xml.transform.Transform;
+
+public class CTTipoFretamentoTransformer implements Transform<CTTipoFretamento> {
+
+    @Override
+    public CTTipoFretamento read(final String codigo) {
+        return CTTipoFretamento.valueOfCodigo(codigo);
+    }
+
+    @Override
+    public String write(final CTTipoFretamento tipo) {
+        return tipo.getCodigo();
+    }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/transformes/CTTipoProprietarioTransformer.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/transformes/CTTipoProprietarioTransformer.java
@@ -1,0 +1,18 @@
+package com.fincatto.documentofiscal.cte300.transformes;
+
+import com.fincatto.documentofiscal.cte300.classes.CTTipoProprietario;
+import org.simpleframework.xml.transform.Transform;
+
+public class CTTipoProprietarioTransformer implements Transform<CTTipoProprietario> {
+
+    @Override
+    public CTTipoProprietario read(final String codigo) {
+        return CTTipoProprietario.valueOfCodigo(codigo);
+    }
+
+    @Override
+    public String write(final CTTipoProprietario tipo) {
+        return tipo.getCodigo();
+    }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/transformes/CTTipoServicoOSTransformer.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/transformes/CTTipoServicoOSTransformer.java
@@ -1,0 +1,18 @@
+package com.fincatto.documentofiscal.cte300.transformes;
+
+import com.fincatto.documentofiscal.cte300.classes.CTTipoServicoOS;
+import org.simpleframework.xml.transform.Transform;
+
+public class CTTipoServicoOSTransformer implements Transform<CTTipoServicoOS> {
+
+    @Override
+    public CTTipoServicoOS read(final String codigo) {
+        return CTTipoServicoOS.valueOfCodigo(codigo);
+    }
+
+    @Override
+    public String write(final CTTipoServicoOS tipo) {
+        return tipo.getCodigo();
+    }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/transformes/CTipoComponenteGTVeTransformer.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/transformes/CTipoComponenteGTVeTransformer.java
@@ -1,0 +1,18 @@
+package com.fincatto.documentofiscal.cte300.transformes;
+
+import com.fincatto.documentofiscal.cte300.classes.CTipoComponenteGTVe;
+import org.simpleframework.xml.transform.Transform;
+
+public class CTipoComponenteGTVeTransformer implements Transform<CTipoComponenteGTVe> {
+
+    @Override
+    public CTipoComponenteGTVe read(final String codigo) {
+        return CTipoComponenteGTVe.valueOfCodigo(codigo);
+    }
+
+    @Override
+    public String write(final CTipoComponenteGTVe tipo) {
+        return tipo.getCodigo();
+    }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSCancelamento.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSCancelamento.java
@@ -1,5 +1,6 @@
 package com.fincatto.documentofiscal.cte300.webservices;
 
+import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeDetalhamentoEvento;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEvento;
@@ -10,14 +11,16 @@ import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 class WSCancelamento extends WSRecepcaoEvento {
     private static final String DESCRICAO_EVENTO = "Cancelamento";
     private static final BigDecimal VERSAO_LEIAUTE = new BigDecimal("3.00");
     private static final String EVENTO_CANCELAMENTO = "110111";
+    private static final List<DFModelo> modelosPermitidos = List.of(DFModelo.CTE, DFModelo.CTeOS);
     
     WSCancelamento(final CTeConfig config) {
-        super(config);
+        super(config, modelosPermitidos);
     }
     
     CTeEventoRetorno cancelaNotaAssinada(final String chaveAcesso, final String eventoAssinadoXml) throws Exception {

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSCancelamentoComprovanteEntrega.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSCancelamentoComprovanteEntrega.java
@@ -1,5 +1,6 @@
 package com.fincatto.documentofiscal.cte300.webservices;
 
+import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEventoRetorno;
@@ -9,14 +10,16 @@ import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 class WSCancelamentoComprovanteEntrega extends WSRecepcaoEvento {
     private static final String DESCRICAO_EVENTO = "Cancelamento do Comprovante de Entrega do CT-e";
     private static final BigDecimal VERSAO_LEIAUTE = new BigDecimal("3.00");
     private static final String EVENTO_COMPROVANTE_DE_ENTREGA = "110181";
+    private static final List<DFModelo> modelosPermitidos = List.of(DFModelo.CTE);
 
     WSCancelamentoComprovanteEntrega(final CTeConfig config) {
-        super(config);
+        super(config, modelosPermitidos);
     }
 
     CTeEventoRetorno cancelaComprovanteEntregaAssinado(final String chaveAcesso, final String eventoAssinadoXml) throws Exception {

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSCartaCorrecao.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSCartaCorrecao.java
@@ -1,5 +1,6 @@
 package com.fincatto.documentofiscal.cte300.webservices;
 
+import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEventoRetorno;
@@ -16,9 +17,10 @@ class WSCartaCorrecao extends WSRecepcaoEvento {
     private static final String DESCRICAO_EVENTO = "Carta de Correcao";
     private static final BigDecimal VERSAO_LEIAUTE = new BigDecimal("3.00");
     private static final String EVENTO_CARTA_DE_CORRECAO = "110110";
+    private static final List<DFModelo> modelosPermitidos = List.of(DFModelo.CTE, DFModelo.CTeOS);
 
     WSCartaCorrecao(final CTeConfig config) {
-        super(config);
+        super(config, modelosPermitidos);
     }
 
     CTeEventoRetorno corrigeNotaAssinada(final String chaveAcesso, final String eventoAssinadoXml) throws Exception {

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSComprovanteEntrega.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSComprovanteEntrega.java
@@ -1,5 +1,6 @@
 package com.fincatto.documentofiscal.cte300.webservices;
 
+import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEventoRetorno;
@@ -9,14 +10,16 @@ import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 class WSComprovanteEntrega extends WSRecepcaoEvento {
     private static final String DESCRICAO_EVENTO = "Comprovante de Entrega do CT-e";
     private static final BigDecimal VERSAO_LEIAUTE = new BigDecimal("3.00");
     private static final String EVENTO_COMPROVANTE_DE_ENTREGA = "110180";
+    private static final List<DFModelo> modelosPermitidos = List.of(DFModelo.CTE);
 
     WSComprovanteEntrega(final CTeConfig config) {
-        super(config);
+        super(config, modelosPermitidos);
     }
 
     CTeEventoRetorno comprovanteEntregaAssinado(final String chaveAcesso, final String eventoAssinadoXml) throws Exception {

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSEpec.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSEpec.java
@@ -1,5 +1,6 @@
 package com.fincatto.documentofiscal.cte300.webservices;
 
+import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEventoRetorno;
@@ -9,14 +10,16 @@ import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 class WSEpec extends WSRecepcaoEvento {
     private static final String DESCRICAO_EVENTO = "EPEC";
     private static final BigDecimal VERSAO_LEIAUTE = new BigDecimal("3.00");
     private static final String EVENTO_EPEC = "110113";
+    private static final List<DFModelo> modelosPermitidos = List.of(DFModelo.CTE);
 
     WSEpec(final CTeConfig config) {
-        super(config);
+        super(config, modelosPermitidos);
     }
     
     CTeEventoRetorno enviaEpecAssinado(final String chaveAcesso, final String eventoAssinadoXml) throws Exception {

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSFacade.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSFacade.java
@@ -6,6 +6,7 @@ import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte.classes.distribuicao.CTDistribuicaoIntRetorno;
 import com.fincatto.documentofiscal.cte.webservices.distribuicao.WSDistribuicaoCTe;
 import com.fincatto.documentofiscal.cte300.classes.consultastatusservico.CTeConsStatServRet;
+import com.fincatto.documentofiscal.cte300.classes.envio.CTeOSEnvioRetornoDados;
 import com.fincatto.documentofiscal.cte300.classes.enviolote.CTeEnvioLote;
 import com.fincatto.documentofiscal.cte300.classes.enviolote.CTeEnvioLoteRetornoDados;
 import com.fincatto.documentofiscal.cte300.classes.enviolote.consulta.CTeConsultaRecLoteRet;
@@ -16,6 +17,7 @@ import com.fincatto.documentofiscal.cte300.classes.evento.epec.CTeEnviaEventoEpe
 import com.fincatto.documentofiscal.cte300.classes.evento.gtv.CTeEnviaEventoGtv;
 import com.fincatto.documentofiscal.cte300.classes.evento.inutilizacao.CTeRetornoEventoInutilizacao;
 import com.fincatto.documentofiscal.cte300.classes.nota.consulta.CTeNotaConsultaRetorno;
+import com.fincatto.documentofiscal.cte300.classes.os.CTeOS;
 import com.fincatto.documentofiscal.utils.DFSocketFactory;
 import org.apache.commons.httpclient.protocol.Protocol;
 
@@ -43,6 +45,7 @@ public class WSFacade {
     private final WSCancelamentoComprovanteEntrega wsCancelamentoComprovanteEntrega;
     private final WSEpec wsEpec;
     private final WSGtv wsGtv;
+    private final WSRecepcaoCTeOS wsRecepcaoCTeOS;
 
     public WSFacade(final CTeConfig config) throws IOException, KeyManagementException, UnrecoverableKeyException, KeyStoreException, NoSuchAlgorithmException, CertificateException {
         Protocol.registerProtocol("https", new Protocol("https", new DFSocketFactory(config), 443));
@@ -60,6 +63,7 @@ public class WSFacade {
         this.wsCancelamentoComprovanteEntrega = new WSCancelamentoComprovanteEntrega(config);
         this.wsEpec = new WSEpec(config);
         this.wsGtv = new WSGtv(config);
+        this.wsRecepcaoCTeOS = new WSRecepcaoCTeOS(config);
     }
 
     /**
@@ -486,6 +490,17 @@ public class WSFacade {
      */
     public String getXmlAssinadoRegistroMultimodal(final String chave, final String informacoesAdicionais, final String numeroDocumento) throws Exception {
         return this.wsRegistroMultimodal.getXmlAssinado(chave, informacoesAdicionais, numeroDocumento);
+    }
+
+    /**
+     * Faz o envio do CT-e de Outros Serviços para a SEFAZ.
+     *
+     * @param cteOS a ser eviado para a SEFAZ
+     * @return dados do retorno do envio do CT-e OS e o xml assinado
+     * @throws Exception caso nao consiga gerar o xml ou problema de conexao com o sefaz
+     * */
+    public CTeOSEnvioRetornoDados envioRecepcaoLote(CTeOS cteOS) throws Exception {
+        return this.wsRecepcaoCTeOS.envioRecepcao(cteOS);
     }
 
 }

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSGtv.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSGtv.java
@@ -1,5 +1,6 @@
 package com.fincatto.documentofiscal.cte300.webservices;
 
+import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEventoRetorno;
@@ -9,14 +10,16 @@ import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 class WSGtv extends WSRecepcaoEvento {
     private static final String DESCRICAO_EVENTO = "Informacoes da GTV";
     private static final BigDecimal VERSAO_LEIAUTE = new BigDecimal("3.00");
     private static final String EVENTO_GTV = "110170";
+    private static final List<DFModelo> modelosPermitidos = List.of(DFModelo.CTeOS);
 
     WSGtv(final CTeConfig config) {
-        super(config);
+        super(config, modelosPermitidos);
     }
     
     CTeEventoRetorno enviaGtvAssinada(final String chaveAcesso, final String eventoAssinadoXml) throws Exception {

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSPrestacaoEmDesacordo.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSPrestacaoEmDesacordo.java
@@ -1,5 +1,6 @@
 package com.fincatto.documentofiscal.cte300.webservices;
 
+import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEventoRetorno;
@@ -9,14 +10,16 @@ import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 class WSPrestacaoEmDesacordo extends WSRecepcaoEvento {
     private static final String DESCRICAO_EVENTO = "Prestacao do Servico em Desacordo";
     private static final BigDecimal VERSAO_LEIAUTE = new BigDecimal("3.00");
     private static final String EVENTO_SERVICO_EM_DESACORDO = "610110";
+    private static final List<DFModelo> modelosPermitidos = List.of(DFModelo.CTE, DFModelo.CTeOS);
 
     WSPrestacaoEmDesacordo(final CTeConfig config) {
-        super(config);
+        super(config, modelosPermitidos);
     }
 
     CTeEventoRetorno prestacaoEmDesacordoAssinada(final String chaveAcesso, final String eventoAssinadoXml) throws Exception {

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSRecepcaoCTeOS.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSRecepcaoCTeOS.java
@@ -1,0 +1,67 @@
+package com.fincatto.documentofiscal.cte300.webservices;
+
+import com.fincatto.documentofiscal.DFLog;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte300.classes.CTAutorizador31;
+import com.fincatto.documentofiscal.cte300.classes.envio.CTeOSEnvioRetorno;
+import com.fincatto.documentofiscal.cte300.classes.envio.CTeOSEnvioRetornoDados;
+import com.fincatto.documentofiscal.cte300.classes.os.CTeOS;
+import com.fincatto.documentofiscal.cte300.webservices.recepcaoOS.CteRecepcaoOSStub;
+import com.fincatto.documentofiscal.cte300.webservices.recepcaoOS.CteRecepcaoOSStub.CteCabecMsg;
+import com.fincatto.documentofiscal.cte300.webservices.recepcaoOS.CteRecepcaoOSStub.CteCabecMsgE;
+import com.fincatto.documentofiscal.cte300.webservices.recepcaoOS.CteRecepcaoOSStub.CteDadosMsg;
+import com.fincatto.documentofiscal.cte300.webservices.recepcaoOS.CteRecepcaoOSStub.CteRecepcaoOSResult;
+import com.fincatto.documentofiscal.utils.DFAssinaturaDigital;
+import com.fincatto.documentofiscal.validadores.DFXMLValidador;
+import org.apache.axiom.om.OMElement;
+import org.apache.axiom.om.util.AXIOMUtil;
+
+class WSRecepcaoCTeOS implements DFLog {
+
+    private final CTeConfig config;
+
+    WSRecepcaoCTeOS(final CTeConfig config) {
+        this.config = config;
+    }
+    
+    public CTeOSEnvioRetornoDados envioRecepcao(CTeOS cteOS) throws Exception {
+        //assina o lote
+        final String documentoAssinado = new DFAssinaturaDigital(this.config).assinarDocumento(cteOS.toString(), "infCte");
+        final CTeOS loteAssinado = this.config.getPersister().read(CTeOS.class, documentoAssinado);
+        
+        //comunica o lote
+        final CTeOSEnvioRetorno retorno = comunicaLote(documentoAssinado);
+        return new CTeOSEnvioRetornoDados(retorno, loteAssinado);
+    }
+    
+    private CTeOSEnvioRetorno comunicaLote(final String loteAssinadoXml) throws Exception {
+        DFXMLValidador.validaCTeOS300(loteAssinadoXml);
+
+        final OMElement omElement = AXIOMUtil.stringToOM(loteAssinadoXml);
+        
+        final CteDadosMsg dados = new CteDadosMsg();
+        dados.setExtraElement(omElement);
+        
+        final CteCabecMsgE cabecalhoSOAP = this.getCabecalhoSOAP();
+        this.getLogger().debug(omElement.toString());
+        
+        final CTAutorizador31 autorizador = CTAutorizador31.valueOfTipoEmissao(this.config.getTipoEmissao(), this.config.getCUF());
+        final String endpoint = autorizador.getCteRecepcaoOS(this.config.getAmbiente());
+        if (endpoint == null) {
+            throw new IllegalArgumentException("Nao foi possivel encontrar URL para Recepcao OS, autorizador " + autorizador.name() + ", UF " + this.config.getCUF().name());
+        }
+        final CteRecepcaoOSResult autorizacaoLoteResult = new CteRecepcaoOSStub(endpoint, config).cteRecepcaoOS(dados, cabecalhoSOAP);
+        final CTeOSEnvioRetorno retorno = this.config.getPersister().read(CTeOSEnvioRetorno.class, autorizacaoLoteResult.getExtraElement().toString());
+        this.getLogger().debug(retorno.toString());
+        return retorno;
+    }
+    
+    private CteCabecMsgE getCabecalhoSOAP() {
+        final CteCabecMsg cabecalho = new CteCabecMsg();
+        cabecalho.setCUF(this.config.getCUF().getCodigoIbge());
+        cabecalho.setVersaoDados("3.00");
+        final CteCabecMsgE cabecalhoSOAP = new CteCabecMsgE();
+        cabecalhoSOAP.setCteCabecMsg(cabecalho);
+        return cabecalhoSOAP;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSRecepcaoEvento.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSRecepcaoEvento.java
@@ -1,9 +1,13 @@
 package com.fincatto.documentofiscal.cte300.webservices;
 
 import com.fincatto.documentofiscal.DFLog;
+import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte300.classes.CTAutorizador31;
-import com.fincatto.documentofiscal.cte300.classes.evento.*;
+import com.fincatto.documentofiscal.cte300.classes.evento.CTeDetalhamentoEvento;
+import com.fincatto.documentofiscal.cte300.classes.evento.CTeEvento;
+import com.fincatto.documentofiscal.cte300.classes.evento.CTeInfoEvento;
+import com.fincatto.documentofiscal.cte300.classes.evento.CTeTipoEvento;
 import com.fincatto.documentofiscal.cte300.parsers.CTChaveParser;
 import com.fincatto.documentofiscal.cte300.webservices.recepcaoevento.RecepcaoEventoStub;
 import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
@@ -13,13 +17,16 @@ import org.apache.axiom.om.util.AXIOMUtil;
 
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
+import java.util.List;
 
 abstract class WSRecepcaoEvento implements DFLog {
 
     protected final CTeConfig config;
+    private final List<DFModelo> modelosPermitidos;
 
-    WSRecepcaoEvento(CTeConfig config) {
+    WSRecepcaoEvento(CTeConfig config, List<DFModelo> modelosPermitidos) {
         this.config = config;
+        this.modelosPermitidos = modelosPermitidos;
     }
 
     protected OMElement efetuaEvento(final String xmlAssinado, final String chaveAcesso, final BigDecimal versao) throws Exception {
@@ -31,9 +38,13 @@ abstract class WSRecepcaoEvento implements DFLog {
     }
 
     protected OMElement efetuaEvento(final String xmlAssinado, final String chaveAcesso, final BigDecimal versao, final boolean contingencia) throws Exception {
+        final CTChaveParser ctChaveParser = new CTChaveParser(chaveAcesso);
+        if (!modelosPermitidos.contains(ctChaveParser.getModelo())) {
+            throw new IllegalArgumentException("CT-e do modelo \"" + ctChaveParser.getModelo().toString() + "\" não é permitido nesse evento.");
+        }
+
         DFXMLValidador.validaEventoCTe300(xmlAssinado);
 
-        final CTChaveParser ctChaveParser = new CTChaveParser(chaveAcesso);
         final RecepcaoEventoStub.CteCabecMsg cabec = new RecepcaoEventoStub.CteCabecMsg();
         cabec.setCUF(ctChaveParser.getNFUnidadeFederativa().getCodigoIbge());
         cabec.setVersaoDados(DFBigDecimalValidador.tamanho5Com2CasasDecimais(versao, "Versao do Evento"));

--- a/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSRegistroMultimodal.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/webservices/WSRegistroMultimodal.java
@@ -1,5 +1,6 @@
 package com.fincatto.documentofiscal.cte300.webservices;
 
+import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte300.classes.evento.CTeEventoRetorno;
@@ -9,14 +10,16 @@ import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 class WSRegistroMultimodal extends WSRecepcaoEvento {
     private static final String DESCRICAO_EVENTO = "Registro Multimodal";
     private static final BigDecimal VERSAO_LEIAUTE = new BigDecimal("3.00");
     private static final String EVENTO_REGISTRO_MULTIMODAL = "110160";
+    private static final List<DFModelo> modelosPermitidos = List.of(DFModelo.CTE);
 
     WSRegistroMultimodal(final CTeConfig config) {
-        super(config);
+        super(config, modelosPermitidos);
     }
 
     CTeEventoRetorno registroMultimodalAssinado(final String chaveAcesso, final String eventoAssinadoXml) throws Exception {

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/CTResponsavelSeguro.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/CTResponsavelSeguro.java
@@ -1,0 +1,32 @@
+package com.fincatto.documentofiscal.cte400.classes;
+
+public enum CTResponsavelSeguro {
+    EMITENTE("4", "Emitente do CT-e OS"),
+    TOMADOR("5", "Tomador de Serviço");
+
+    private final String codigo;
+    private final String descricao;
+
+    CTResponsavelSeguro(final String codigo, final String descricao) {
+        this.codigo = codigo;
+        this.descricao = descricao;
+    }
+
+    public String getCodigo() {
+        return this.codigo;
+    }
+
+    public static CTResponsavelSeguro valueOfCodigo(final String codigo) {
+        for (final CTResponsavelSeguro valor : CTResponsavelSeguro.values()) {
+            if (valor.getCodigo().equals(codigo)) {
+                return valor;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return codigo + " - " + descricao;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/CTTipoFretamento.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/CTTipoFretamento.java
@@ -1,0 +1,32 @@
+package com.fincatto.documentofiscal.cte400.classes;
+
+public enum CTTipoFretamento {
+    EVENTUAL("1", "Eventual"),
+    CONTINUO("2", "Continuo");
+
+    private final String codigo;
+    private final String descricao;
+
+    CTTipoFretamento(final String codigo, final String descricao) {
+        this.codigo = codigo;
+        this.descricao = descricao;
+    }
+
+    public String getCodigo() {
+        return this.codigo;
+    }
+
+    public static CTTipoFretamento valueOfCodigo(final String codigo) {
+        for (final CTTipoFretamento valor : CTTipoFretamento.values()) {
+            if (valor.getCodigo().equals(codigo)) {
+                return valor;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return codigo + " - " + descricao;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/CTTipoProprietario.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/CTTipoProprietario.java
@@ -1,0 +1,33 @@
+package com.fincatto.documentofiscal.cte400.classes;
+
+public enum CTTipoProprietario {
+    TAC_AGREGADO("0", "TAC – Agregado"),
+    TAC_INDEPENDENTE("1", "TAC – Independente"),
+    OUTROS("2", "Outros");
+
+    private final String codigo;
+    private final String descricao;
+
+    CTTipoProprietario(final String codigo, final String descricao) {
+        this.codigo = codigo;
+        this.descricao = descricao;
+    }
+
+    public String getCodigo() {
+        return this.codigo;
+    }
+
+    public static CTTipoProprietario valueOfCodigo(final String codigo) {
+        for (final CTTipoProprietario valor : CTTipoProprietario.values()) {
+            if (valor.getCodigo().equals(codigo)) {
+                return valor;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return codigo + " - " + descricao;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/CTTipoServicoOS.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/CTTipoServicoOS.java
@@ -1,0 +1,38 @@
+package com.fincatto.documentofiscal.cte400.classes;
+
+public enum CTTipoServicoOS {
+
+    TRANSPORTE_DE_PESSOAS("6", "Transporte de Pessoas"),
+    TRANSPORTE_DE_VALORES("7", "Transporte de Valores"),
+    EXCESSO_DE_BAGAGEM("8", "Excesso de Bagagem");
+
+    private final String codigo;
+    private final String descricao;
+
+    CTTipoServicoOS(final String codigo, final String descricao) {
+        this.codigo = codigo;
+        this.descricao = descricao;
+    }
+
+    public String getCodigo() {
+        return this.codigo;
+    }
+
+    public String getDescricao() {
+        return this.descricao;
+    }
+
+    public static CTTipoServicoOS valueOfCodigo(final String codigo) {
+        for (final CTTipoServicoOS tipo : CTTipoServicoOS.values()) {
+            if (tipo.getCodigo().equals(codigo)) {
+                return tipo;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return codigo + " - " + descricao;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/CTipoComponenteGTVe.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/CTipoComponenteGTVe.java
@@ -1,0 +1,36 @@
+package com.fincatto.documentofiscal.cte400.classes;
+
+public enum CTipoComponenteGTVe {
+    CUSTODIA("1", "Custodia"),
+    EMBARQUE("2", "Embarque"),
+    TEMPO_DE_ESPERA("3", "Tempo de espera"),
+    MALOTE("4", "Malote"),
+    AD_VALOREM("5", "Ad Valorem"),
+    OUTROS("6", "Outros");
+
+    private final String codigo;
+    private final String descricao;
+
+    CTipoComponenteGTVe(final String codigo, final String descricao) {
+        this.codigo = codigo;
+        this.descricao = descricao;
+    }
+
+    public String getCodigo() {
+        return this.codigo;
+    }
+
+    public static CTipoComponenteGTVe valueOfCodigo(final String codigo) {
+        for (final CTipoComponenteGTVe valor : CTipoComponenteGTVe.values()) {
+            if (valor.getCodigo().equals(codigo)) {
+                return valor;
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return codigo + " - " + descricao;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/envio/CTeOSEnvioRetorno.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/envio/CTeOSEnvioRetorno.java
@@ -1,0 +1,114 @@
+package com.fincatto.documentofiscal.cte400.classes.envio;
+
+import com.fincatto.documentofiscal.DFAmbiente;
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.DFUnidadeFederativa;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "retCTeOS")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSEnvioRetorno extends DFBase {
+    private static final long serialVersionUID = -6459868395256049339L;
+
+    @Element(name = "tpAmb", required = false)
+    private DFAmbiente ambiente;
+
+    @Element(name = "cUF", required = false)
+    private DFUnidadeFederativa uf;
+
+    @Element(name = "verAplic", required = false)
+    private String versaoAplicacao;
+
+    @Element(name = "cStat", required = false)
+    private String status;
+
+    @Element(name = "xMotivo", required = false)
+    private String motivo;
+
+    @Element(name = "protCTe", required = false)
+    private CTeProtocolo protocolo;
+
+    @Attribute(name = "versao", required = false)
+    private String versao;
+
+    public DFAmbiente getAmbiente() {
+        return this.ambiente;
+    }
+
+    /**
+     * Identificação do Ambiente:1 - Produção; 2 - Homologação
+     */
+    public void setAmbiente(final DFAmbiente ambiente) {
+        this.ambiente = ambiente;
+    }
+
+    public DFUnidadeFederativa getUf() {
+        return this.uf;
+    }
+
+    /**
+     * Identificação da UF
+     */
+    public void setUf(final DFUnidadeFederativa uf) {
+        this.uf = uf;
+    }
+
+    public String getVersaoAplicacao() {
+        return this.versaoAplicacao;
+    }
+
+    /**
+     * Versão do Aplicativo que recebeu o Lote.
+     */
+    public void setVersaoAplicacao(final String versaoAplicacao) {
+        this.versaoAplicacao = versaoAplicacao;
+    }
+
+    public String getStatus() {
+        return this.status;
+    }
+
+    /**
+     * Código do status da mensagem enviada.
+     */
+    public void setStatus(final String status) {
+        this.status = status;
+    }
+
+    public String getMotivo() {
+        return this.motivo;
+    }
+
+    /**
+     * Descrição literal do status do serviço solicitado.
+     */
+    public void setMotivo(final String motivo) {
+        this.motivo = motivo;
+    }
+
+    public CTeProtocolo getProtocolo() {
+        return this.protocolo;
+    }
+
+    /**
+     * Dados do protocolo do processamento do CT-e
+     */
+    public void setProtocolo(final CTeProtocolo protocolo) {
+        this.protocolo = protocolo;
+    }
+
+    public String getVersao() {
+        return this.versao;
+    }
+
+    /**
+     * versão da aplicação
+     */
+    public void setVersao(final String versao) {
+        this.versao = versao;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/envio/CTeOSEnvioRetornoDados.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/envio/CTeOSEnvioRetornoDados.java
@@ -1,0 +1,22 @@
+package com.fincatto.documentofiscal.cte400.classes.envio;
+
+import com.fincatto.documentofiscal.cte400.classes.os.CTeOS;
+
+public class CTeOSEnvioRetornoDados {
+
+    private final CTeOSEnvioRetorno retorno;
+    private final CTeOS loteAssinado;
+
+	public CTeOSEnvioRetornoDados(CTeOSEnvioRetorno retorno, CTeOS loteAssinado) {
+		this.retorno = retorno;
+		this.loteAssinado = loteAssinado;
+	}
+
+	public CTeOSEnvioRetorno getRetorno() {
+		return retorno;
+	}
+
+	public CTeOS getLoteAssinado() {
+		return loteAssinado;
+	}
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOS.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOS.java
@@ -1,0 +1,60 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.nota.assinatura.CTeSignature;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "CTeOS")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOS extends DFBase {
+    private static final long serialVersionUID = 1005480176062479566L;
+
+    @Element(name = "infCte")
+    private CTeOSInfo info;
+
+    @Element(name="infCTeSupl", required = false)
+    private CTeOSInfoSuplementares infoSuplementares;
+
+    @Element(name = "Signature", required = false)
+    private CTeSignature signature;
+
+    @Attribute(name = "versao")
+    private String versao;
+
+    public CTeOSInfo getInfo() {
+        return info;
+    }
+
+    public void setInfo(final CTeOSInfo info) {
+        this.info = info;
+    }
+
+    public CTeOSInfoSuplementares getInfoSuplementares() {
+        return infoSuplementares;
+    }
+
+    public CTeOS setInfoSuplementares(final CTeOSInfoSuplementares infoSuplementares) {
+        this.infoSuplementares = infoSuplementares;
+        return this;
+    }
+
+    public CTeSignature getSignature() {
+        return this.signature;
+    }
+
+    public void setSignature(final CTeSignature signature) {
+        this.signature = signature;
+    }
+
+    public String getVersao() {
+        return versao;
+    }
+
+    public void setVersao(final String versao) {
+        this.versao = versao;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSEndereco.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSEndereco.java
@@ -1,0 +1,165 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.DFPais;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+
+public class CTeOSEndereco extends DFBase {
+    private static final long serialVersionUID = 1357977819965129753L;
+
+    @Element(name = "xLgr")
+    private String logradouro;
+
+    @Element(name = "nro")
+    private String numero;
+
+    @Element(name = "xCpl", required = false)
+    private String complemento;
+
+    @Element(name = "xBairro")
+    private String bairro;
+
+    @Element(name = "cMun")
+    private String codigoMunicipio;
+
+    @Element(name = "xMun")
+    private String descricaoMunicipio;
+
+    @Element(name = "CEP", required = false)
+    private String cep;
+
+    @Element(name = "UF")
+    private String siglaUF;
+
+    @Element(name = "cPais", required = false)
+    private DFPais codigoPais;
+
+    @Element(name = "xPais", required = false)
+    private String descricaoPais;
+
+    public String getLogradouro() {
+        return this.logradouro;
+    }
+
+    /**
+     * Logradouro
+     */
+    public void setLogradouro(final String logradouro) {
+        DFStringValidador.tamanho2ate60(logradouro, "Logradouro");
+        this.logradouro = logradouro;
+    }
+
+    public String getNumero() {
+        return this.numero;
+    }
+
+    /**
+     * Número
+     */
+    public void setNumero(final String numero) {
+        DFStringValidador.tamanho60(numero, "Número");
+        this.numero = numero;
+    }
+
+    public String getComplemento() {
+        return this.complemento;
+    }
+
+    /**
+     * Complemento
+     */
+    public void setComplemento(final String complemento) {
+        DFStringValidador.tamanho60(complemento, "Complemento");
+        this.complemento = complemento;
+    }
+
+    public String getBairro() {
+        return this.bairro;
+    }
+
+    /**
+     * Bairro
+     */
+    public void setBairro(final String bairro) {
+        DFStringValidador.tamanho2ate60(bairro, "Bairro");
+        this.bairro = bairro;
+    }
+
+    public String getCodigoMunicipio() {
+        return this.codigoMunicipio;
+    }
+
+    /**
+     * Código do município (utilizar a tabela do IBGE)<br>
+     * Informar 9999999 para operações com o exterior.
+     */
+    public void setCodigoMunicipio(final String codigoMunicipio) {
+        DFStringValidador.exatamente7N(codigoMunicipio, "Código do município");
+        this.codigoMunicipio = codigoMunicipio;
+    }
+
+    public String getDescricaoMunicipio() {
+        return this.descricaoMunicipio;
+    }
+
+    /**
+     * Nome do município<br>
+     * Informar EXTERIOR para operações com o exterior.
+     */
+    public void setDescricaoMunicipio(final String descricaoMunicipio) {
+        DFStringValidador.tamanho2ate60(descricaoMunicipio, "Nome do município");
+        this.descricaoMunicipio = descricaoMunicipio;
+    }
+
+    public String getCep() {
+        return this.cep;
+    }
+
+    /**
+     * CEP<br>
+     * Informar os zeros não significativos
+     */
+    public void setCep(final String cep) {
+        DFStringValidador.exatamente8N(cep, "CEP");
+        this.cep = cep;
+    }
+
+    public String getSiglaUF() {
+        return this.siglaUF;
+    }
+
+    /**
+     * Sigla da UF<br>
+     * Informar EX para operações com o exterior.
+     */
+    public void setSiglaUF(final String siglaUf) {
+        DFStringValidador.exatamente2(siglaUf, "Sigla da UF");
+        this.siglaUF = siglaUf;
+    }
+
+    public DFPais getCodigoPais() {
+        return this.codigoPais;
+    }
+
+    /**
+     * Código do país<br>
+     * Utilizar a tabela do BACEN
+     */
+    public void setCodigoPais(final String codigoPais) {
+        DFStringValidador.tamanho4N(codigoPais, "Código do país");
+        this.codigoPais = DFPais.valueOfCodigo(codigoPais);
+    }
+
+    public String getDescricaoPais() {
+        return this.descricaoPais;
+    }
+
+    /**
+     * Nome do país
+     */
+    public void setDescricaoPais(final String descricaoPais) {
+        DFStringValidador.tamanho2ate60(descricaoPais, "Nome do país");
+        this.descricaoPais = descricaoPais;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSEnderecoEmitente.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSEnderecoEmitente.java
@@ -1,0 +1,148 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+
+public class CTeOSEnderecoEmitente extends DFBase {
+    private static final long serialVersionUID = 3229596313843831723L;
+
+    @Element(name = "xLgr")
+    private String logradouro;
+    
+    @Element(name = "nro")
+    private String numero;
+
+    @Element(name = "xCpl", required = false)
+    private String complemento;
+    
+    @Element(name = "xBairro")
+    private String bairro;
+    
+    @Element(name = "cMun")
+    private String codigoMunicipio;
+    
+    @Element(name = "xMun")
+    private String descricaoMunicipio;
+
+    @Element(name = "CEP", required = false)
+    private String cep;
+    
+    @Element(name = "UF")
+    private String siglaUF;
+
+    @Element(name = "fone", required = false)
+    private String telefone;
+
+    public String getLogradouro() {
+        return this.logradouro;
+    }
+
+    /**
+     * Logradouro
+     */
+    public void setLogradouro(final String logradouro) {
+        DFStringValidador.tamanho2ate60(logradouro, "Logradouro no endereço do Emitente");
+        this.logradouro = logradouro;
+    }
+
+    public String getNumero() {
+        return this.numero;
+    }
+
+    /**
+     * Número
+     */
+    public void setNumero(final String numero) {
+        DFStringValidador.tamanho60(numero, "Número no endereço do Emitente");
+        this.numero = numero;
+    }
+
+    public String getComplemento() {
+        return this.complemento;
+    }
+
+    /**
+     * Complemento
+     */
+    public void setComplemento(final String complemento) {
+        DFStringValidador.tamanho60(complemento, "Complemento no endereço do Emitente");
+        this.complemento = complemento;
+    }
+
+    public String getBairro() {
+        return this.bairro;
+    }
+
+    /**
+     * Bairro
+     */
+    public void setBairro(final String bairro) {
+        DFStringValidador.tamanho2ate60(bairro, "Bairro no endereço do Emitente");
+        this.bairro = bairro;
+    }
+
+    public String getCodigoMunicipio() {
+        return this.codigoMunicipio;
+    }
+
+    /**
+     * Código do município (utilizar a tabela do IBGE)<br>
+     * Informar 9999999 para operações com o exterior.
+     */
+    public void setCodigoMunicipio(final String codigoMunicipio) {
+        DFStringValidador.exatamente7N(codigoMunicipio, "Código do município no endereço do Emitente");
+        this.codigoMunicipio = codigoMunicipio;
+    }
+
+    public String getDescricaoMunicipio() {
+        return this.descricaoMunicipio;
+    }
+
+    /**
+     * Nome do município<br>
+     * Informar EXTERIOR para operações com o exterior.
+     */
+    public void setDescricaoMunicipio(final String descricaoMunicipio) {
+        DFStringValidador.tamanho2ate60(descricaoMunicipio, "Nome do município no endereço do Emitente");
+        this.descricaoMunicipio = descricaoMunicipio;
+    }
+
+    public String getCep() {
+        return this.cep;
+    }
+
+    /**
+     * CEP<br>
+     * Informar os zeros não significativos
+     */
+    public void setCep(final String cep) {
+        DFStringValidador.exatamente8N(cep, "CEP no endereço do Emitente");
+        this.cep = cep;
+    }
+
+    public String getSiglaUF() {
+        return this.siglaUF;
+    }
+
+    /**
+     * Sigla da UF<br>
+     * Informar EX para operações com o exterior.
+     */
+    public void setSiglaUF(final String siglaUF) {
+        DFStringValidador.exatamente2(siglaUF, "Sigla da UF no endereço do Emitente");
+        this.siglaUF = siglaUF;
+    }
+
+    public String getTelefone() {
+        return this.telefone;
+    }
+
+    /**
+     * Telefone
+     */
+    public void setTelefone(final String telefone) {
+        DFStringValidador.telefone(telefone);
+        this.telefone = telefone;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfo.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfo.java
@@ -1,0 +1,191 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFListValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.*;
+
+import java.util.List;
+
+@Root(name = "infCte")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfo extends DFBase {
+    public static final String IDENT = "CTe";
+    private static final long serialVersionUID = 1970550899293677744L;
+
+    @Attribute(name = "Id")
+    private String identificador;
+
+    @Attribute(name = "versao")
+    private String versao;
+
+    @Element(name = "ide")
+    private CTeOSInfoIdentificacao identificacao;
+
+    @Element(name = "compl", required = false)
+    private CTeOSInfoDadosComplementares dadosComplementares;
+
+    @Element(name = "emit")
+    private CTeOSInfoEmitente emitente;
+
+    @Element(name = "toma", required = false)
+    private CTeOSInfoIdentificacaoTomador tomador;
+
+    @Element(name = "vPrest")
+    private CTeOSInfoValorPrestacaoServico valorPrestacaoServico;
+
+    @Element(name = "imp")
+    private CTeOSInfoInformacoesRelativasImpostos informacoesRelativasImpostos;
+
+    @Element(name = "infCTeNorm", required = false)
+    private CTeOSInfoCTeNormal cteNormal;
+
+    @ElementList(name = "infCteComp", inline = true, required = false)
+    private List<CTeOSInfoCTeComplementar> cteComplementar;
+
+    @ElementList(name = "autXML", inline = true, required = false)
+    private List<CTeOSInfoAutorizacaoDownload> autorizacaoDownload;
+
+    @Element(name="infRespTec", required = false)
+    private CTeOSInfoResponsavelTecnico informacaoResposavelTecnico;
+
+    public String getIdentificador() {
+        return this.identificador;
+    }
+
+    /**
+     * Identificador da tag a ser assinada<br>
+     * Informar a chave de acesso do CT-e e precedida do literal "CTe"
+     */
+    public void setIdentificador(final String identificador) {
+        DFStringValidador.exatamente44N(identificador, "Identificador");
+        this.identificador = CTeOSInfo.IDENT + identificador;
+    }
+
+    /**
+     * Pega a chave de acesso a partir do identificador.
+     * @return Chave de acesso.
+     */
+    public String getChaveAcesso() {
+        return this.identificador.replace(CTeOSInfo.IDENT, "");
+    }
+
+    public CTeOSInfoIdentificacao getIdentificacao() {
+        return this.identificacao;
+    }
+
+    /**
+     * Identificação do CT-e
+     */
+    public void setIdentificacao(final CTeOSInfoIdentificacao identificacao) {
+        this.identificacao = identificacao;
+    }
+
+    public CTeOSInfoDadosComplementares getDadosComplementares() {
+        return this.dadosComplementares;
+    }
+
+    /**
+     * Dados complementares do CT-e para fins operacionais ou comerciais
+     */
+    public void setDadosComplementares(final CTeOSInfoDadosComplementares dadosComplementares) {
+        this.dadosComplementares = dadosComplementares;
+    }
+
+    public CTeOSInfoEmitente getEmitente() {
+        return this.emitente;
+    }
+
+    /**
+     * Identificação do Emitente do CT-e
+     */
+    public void setEmitente(final CTeOSInfoEmitente emitente) {
+        this.emitente = emitente;
+    }
+
+    public CTeOSInfoIdentificacaoTomador getTomador() {
+        return tomador;
+    }
+
+    public void setTomador(final CTeOSInfoIdentificacaoTomador tomador) {
+        this.tomador = tomador;
+    }
+
+    public CTeOSInfoValorPrestacaoServico getValorPrestacaoServico() {
+        return this.valorPrestacaoServico;
+    }
+
+    /**
+     * Valores da Prestação de Serviço
+     */
+    public void setValorPrestacaoServico(final CTeOSInfoValorPrestacaoServico valorPrestacaoServico) {
+        this.valorPrestacaoServico = valorPrestacaoServico;
+    }
+
+    public CTeOSInfoInformacoesRelativasImpostos getInformacoesRelativasImpostos() {
+        return this.informacoesRelativasImpostos;
+    }
+
+    /**
+     * Informações relativas aos Impostos
+     */
+    public void setInformacoesRelativasImpostos(final CTeOSInfoInformacoesRelativasImpostos informacoesRelativasImpostos) {
+        this.informacoesRelativasImpostos = informacoesRelativasImpostos;
+    }
+
+    public CTeOSInfoCTeNormal getCteNormal() {
+        return this.cteNormal;
+    }
+
+    /**
+     * Grupo de informações do CT-e Normal e Substituto
+     */
+    public void setCteNormal(final CTeOSInfoCTeNormal cteNormal) {
+        this.cteNormal = cteNormal;
+    }
+
+    public List<CTeOSInfoCTeComplementar> getCteComplementar() {
+        return this.cteComplementar;
+    }
+
+    /**
+     * Detalhamento do CT-e complementado
+     */
+    public void setCteComplementar(final List<CTeOSInfoCTeComplementar> cteComplementar) {
+        this.cteComplementar = cteComplementar;
+    }
+
+    public List<CTeOSInfoAutorizacaoDownload> getAutorizacaoDownload() {
+        return this.autorizacaoDownload;
+    }
+
+    /**
+     * Autorizados para download do XML do DF-e<br>
+     * Informar CNPJ ou CPF. Preencher os zeros não significativos.
+     */
+    public void setAutorizacaoDownload(final List<CTeOSInfoAutorizacaoDownload> autorizacaoDownload) {
+        DFListValidador.tamanho10(autorizacaoDownload, "Autorizados para download do XML do DF-e");
+        this.autorizacaoDownload = autorizacaoDownload;
+    }
+
+    public String getVersao() {
+        return this.versao;
+    }
+
+    /**
+     * Versão do leiaute
+     */
+    public void setVersao(final String versao) {
+        this.versao = versao;
+    }
+
+    public CTeOSInfoResponsavelTecnico getInformacaoResposavelTecnico() {
+        return informacaoResposavelTecnico;
+    }
+
+    public CTeOSInfo setInformacaoResposavelTecnico(final CTeOSInfoResponsavelTecnico informacaoResposavelTecnico) {
+        this.informacaoResposavelTecnico = informacaoResposavelTecnico;
+        return this;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoAutorizacaoDownload.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoAutorizacaoDownload.java
@@ -1,0 +1,46 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "autXML")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoAutorizacaoDownload extends DFBase {
+    private static final long serialVersionUID = -2755368776450778969L;
+
+    @Element(name = "CNPJ", required = false)
+    private String cnpj;
+
+    @Element(name = "CPF", required = false)
+    private String cpf;
+
+    public String getCnpj() {
+        return this.cnpj;
+    }
+
+    /**
+     * CNPJ do autorizado<br>
+     * Informar zeros não significativos
+     */
+    public void setCnpj(final String cnpj) {
+        DFStringValidador.cnpj(cnpj);
+        this.cnpj = cnpj;
+    }
+
+    public String getCpf() {
+        return this.cpf;
+    }
+
+    /**
+     * CPF do autorizado<br>
+     * Informar zeros não significativos
+     */
+    public void setCpf(final String cpf) {
+        DFStringValidador.cpf(cpf);
+        this.cpf = cpf;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeComplementar.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeComplementar.java
@@ -1,0 +1,33 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "infCteComp")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeComplementar extends DFBase {
+    private static final long serialVersionUID = 8633547499681692469L;
+
+    @Element(name = "chCTe")
+    private String chave;
+
+    public CTeOSInfoCTeComplementar() {
+        this.chave = null;
+    }
+
+    public String getChave() {
+        return this.chave;
+    }
+
+    /**
+     * Chave do CT-e complementado
+     */
+    public void setChave(final String chave) {
+        DFStringValidador.exatamente44N(chave, "Chave do CT-e complementado");
+        this.chave = chave;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormal.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormal.java
@@ -1,0 +1,93 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.util.List;
+
+@Root(name = "infCTeNorm")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormal extends DFBase {
+    private static final long serialVersionUID = -2211331295487410228L;
+
+    @Element(name = "infServico")
+    private CTeOSInfoCTeNormalInfoServico infoCarga;
+
+    @ElementList(name = "infDocRef", inline = true, required = false)
+    private List<CTeOSInfoCTeNormalInfoDocumentos> infoDocumentos;
+
+    @ElementList(name = "seg", inline = true, required = false)
+    private List<CTeOSInfoCTeNormalSeguro> seguros;
+
+    @Element(name = "infModal")
+    private CTeOSInfoCTeNormalInfoModal infoModal;
+
+    @Element(name = "infCteSub", required = false)
+    private CTeOSInfoCTeNormalInfoCTeSubstituicao infoCTeSubstituicao;
+
+    @Element(name = "cobr", required = false)
+    private CTeOSInfoCTeNormalInfoCobranca cobranca;
+
+    @ElementList(name = "infGTVe", inline = true, required = false)
+    private List<CTeOSInfoCTeNormalInfoGTVe> infoGTVe;
+
+    public CTeOSInfoCTeNormalInfoServico getInfoCarga() {
+        return infoCarga;
+    }
+
+    public void setInfoCarga(final CTeOSInfoCTeNormalInfoServico infoCarga) {
+        this.infoCarga = infoCarga;
+    }
+
+    public List<CTeOSInfoCTeNormalInfoDocumentos> getInfoDocumentos() {
+        return infoDocumentos;
+    }
+
+    public void setInfoDocumentos(List<CTeOSInfoCTeNormalInfoDocumentos> infoDocumentos) {
+        this.infoDocumentos = infoDocumentos;
+    }
+
+    public List<CTeOSInfoCTeNormalSeguro> getSeguros() {
+        return seguros;
+    }
+
+    public void setSeguros(List<CTeOSInfoCTeNormalSeguro> seguros) {
+        this.seguros = seguros;
+    }
+
+    public CTeOSInfoCTeNormalInfoModal getInfoModal() {
+        return infoModal;
+    }
+
+    public void setInfoModal(final CTeOSInfoCTeNormalInfoModal infoModal) {
+        this.infoModal = infoModal;
+    }
+
+    public CTeOSInfoCTeNormalInfoCTeSubstituicao getInfoCTeSubstituicao() {
+        return infoCTeSubstituicao;
+    }
+
+    public void setInfoCTeSubstituicao(final CTeOSInfoCTeNormalInfoCTeSubstituicao infoCTeSubstituicao) {
+        this.infoCTeSubstituicao = infoCTeSubstituicao;
+    }
+
+    public CTeOSInfoCTeNormalInfoCobranca getCobranca() {
+        return cobranca;
+    }
+
+    public void setCobranca(final CTeOSInfoCTeNormalInfoCobranca cobranca) {
+        this.cobranca = cobranca;
+    }
+
+    public List<CTeOSInfoCTeNormalInfoGTVe> getInfoGTVe() {
+        return infoGTVe;
+    }
+
+    public void setInfoGTVe(final List<CTeOSInfoCTeNormalInfoGTVe> infoGTVe) {
+        this.infoGTVe = infoGTVe;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoCTeSubstituicao.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoCTeSubstituicao.java
@@ -1,0 +1,29 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "infCteSub")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoCTeSubstituicao extends DFBase {
+    private static final long serialVersionUID = -5828896779480738537L;
+
+    @Element(name = "chCte")
+    private String chaveCTe;
+
+    public String getChaveCTe() {
+        return this.chaveCTe;
+    }
+
+    /**
+     * Chave de acesso do CT-e a ser substituído (original)
+     */
+    public void setChaveCTe(final String chaveCTe) {
+        DFStringValidador.exatamente44N(chaveCTe, "Chave de acesso do CT-e a ser substituído (original)");
+        this.chaveCTe = chaveCTe;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoCargaInformacoesQuantidadeCarga.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoCargaInformacoesQuantidadeCarga.java
@@ -1,0 +1,27 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "infQ")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoCargaInformacoesQuantidadeCarga extends DFBase {
+    private static final long serialVersionUID = 9113316063559072994L;
+
+    @Element(name = "qCarga")
+    private String quantidade;
+
+    public String getQuantidade() {
+        return this.quantidade;
+    }
+
+    public void setQuantidade(final BigDecimal quantidade) {
+        this.quantidade = DFBigDecimalValidador.tamanho15Com4CasasDecimais(quantidade, "Quantidade");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoCobranca.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoCobranca.java
@@ -1,0 +1,38 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.util.List;
+
+@Root(name = "cobr")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoCobranca extends DFBase {
+    private static final long serialVersionUID = 512711961726591339L;
+
+    @Element(name = "fat", required = false)
+    private CTeOSInfoCTeNormalInfoCobrancaFatura fatura;
+
+    @ElementList(name = "dup", inline = true, required = false)
+    private List<CTeOSInfoCTeNormalInfoCobrancaDuplicata> duplicatas;
+
+    public CTeOSInfoCTeNormalInfoCobrancaFatura getFatura() {
+        return fatura;
+    }
+
+    public void setFatura(final CTeOSInfoCTeNormalInfoCobrancaFatura fatura) {
+        this.fatura = fatura;
+    }
+
+    public List<CTeOSInfoCTeNormalInfoCobrancaDuplicata> getDuplicatas() {
+        return duplicatas;
+    }
+
+    public void setDuplicatas(List<CTeOSInfoCTeNormalInfoCobrancaDuplicata> duplicatas) {
+        this.duplicatas = duplicatas;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoCobrancaDuplicata.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoCobrancaDuplicata.java
@@ -1,0 +1,52 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Root(name = "fat")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoCobrancaDuplicata extends DFBase {
+    private static final long serialVersionUID = 5321172274976502832L;
+
+    @Element(name = "nDup", required = false)
+    private String numeroDuplicata;
+
+    @Element(name = "dVenc", required = false)
+    private LocalDate dataVencimento;
+
+    @Element(name = "vDup", required = false)
+    private String valorDuplicata;
+
+    public String getNumeroDuplicata() {
+        return numeroDuplicata;
+    }
+
+    public void setNumeroDuplicata(final String numeroDuplicata) {
+        DFStringValidador.tamanho60(numeroDuplicata, "Numero da Duplicata");
+        this.numeroDuplicata = numeroDuplicata;
+    }
+
+    public LocalDate getDataVencimento() {
+        return dataVencimento;
+    }
+
+    public void setDataVencimento(final LocalDate dataVencimento) {
+        this.dataVencimento = dataVencimento;
+    }
+
+    public String getValorDuplicata() {
+        return valorDuplicata;
+    }
+
+    public void setValorDuplicata(final BigDecimal valorDuplicata) {
+        this.valorDuplicata = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorDuplicata, "Valor Duplicata");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoCobrancaFatura.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoCobrancaFatura.java
@@ -1,0 +1,62 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "fat")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoCobrancaFatura extends DFBase {
+    private static final long serialVersionUID = 4430617027634028923L;
+
+    @Element(name = "nFat", required = false)
+    private String numeroFatura;
+
+    @Element(name = "vOrig", required = false)
+    private String valorOriginal;
+
+    @Element(name = "vDesc", required = false)
+    private String valorDesconto;
+
+    @Element(name = "vLiq", required = false)
+    private String valorLiquido;
+
+    public String getNumeroFatura() {
+        return numeroFatura;
+    }
+
+    public void setNumeroFatura(final String numeroFatura) {
+        DFStringValidador.tamanho60(numeroFatura, "Numero da Fatura");
+        this.numeroFatura = numeroFatura;
+    }
+
+    public String getValorOriginal() {
+        return valorOriginal;
+    }
+
+    public void setValorOriginal(final BigDecimal valorOriginal) {
+        this.valorOriginal = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorOriginal, "Valor Original");
+    }
+
+    public String getValorDesconto() {
+        return valorDesconto;
+    }
+
+    public void setValorDesconto(final BigDecimal valorDesconto) {
+        this.valorDesconto = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorDesconto, "Valor Desconto");
+    }
+
+    public String getValorLiquido() {
+        return valorLiquido;
+    }
+
+    public void setValorLiquido(final BigDecimal valorLiquido) {
+        this.valorLiquido = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorLiquido, "Valor Liquido");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoDocumentos.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoDocumentos.java
@@ -1,0 +1,87 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Root(name = "infDocRef")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoDocumentos extends DFBase {
+    private static final long serialVersionUID = 7527096776018371935L;
+
+    @Element(name = "nDoc", required = false)
+    private String numeroDocumento;
+
+    @Element(name = "serie", required = false)
+    private String serie;
+
+    @Element(name = "subserie", required = false)
+    private String subserie;
+
+    @Element(name = "dEmi", required = false)
+    private LocalDate dataEmissao;
+
+    @Element(name = "vDoc", required = false)
+    private String valorDocumento;
+
+    @Element(name = "chBPe", required = false)
+    private String chaveBilhetePassagem;
+
+    public String getNumeroDocumento() {
+        return numeroDocumento;
+    }
+
+    public void setNumeroDocumento(final String numeroDocumento) {
+        DFStringValidador.tamanho20(numeroDocumento, "Numero Documento");
+        this.numeroDocumento = numeroDocumento;
+    }
+
+    public String getSerie() {
+        return serie;
+    }
+
+    public void setSerie(final String serie) {
+        DFStringValidador.tamanho3(serie, "Serie");
+        this.serie = serie;
+    }
+
+    public String getSubserie() {
+        return subserie;
+    }
+
+    public void setSubserie(final String subserie) {
+        DFStringValidador.tamanho3(subserie, "Subserie");
+        this.subserie = subserie;
+    }
+
+    public LocalDate getDataEmissao() {
+        return dataEmissao;
+    }
+
+    public void setDataEmissao(final LocalDate dataEmissao) {
+        this.dataEmissao = dataEmissao;
+    }
+
+    public String getValorDocumento() {
+        return valorDocumento;
+    }
+
+    public void setValorDocumento(final BigDecimal valorDocumento) {
+        this.valorDocumento = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorDocumento, "Valor Documento");
+    }
+
+    public String getChaveBilhetePassagem() {
+        return chaveBilhetePassagem;
+    }
+
+    public void setChaveBilhetePassagem(final String chaveBilhetePassagem) {
+        this.chaveBilhetePassagem = chaveBilhetePassagem;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoGTVe.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoGTVe.java
@@ -1,0 +1,40 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.util.List;
+
+@Root(name = "infGTVe")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoGTVe extends DFBase {
+    private static final long serialVersionUID = -7819895569994558919L;
+
+    @Element(name = "chCTe")
+    private String chaveGTVe;
+
+    @ElementList(name = "Comp", inline = true)
+    private List<CTeOSInfoCTeNormalInfoGTVeComp> comp;
+
+    public String getChaveGTVe() {
+        return chaveGTVe;
+    }
+
+    public void setChaveGTVe(final String chaveGTVe) {
+        DFStringValidador.exatamente44N(chaveGTVe, "Chave de acesso da Guia de Transporte de Valores Eletrônica (GTVe)");
+        this.chaveGTVe = chaveGTVe;
+    }
+
+    public List<CTeOSInfoCTeNormalInfoGTVeComp> getComp() {
+        return comp;
+    }
+
+    public void setComp(final List<CTeOSInfoCTeNormalInfoGTVeComp> comp) {
+        this.comp = comp;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoGTVeComp.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoGTVeComp.java
@@ -1,0 +1,52 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.CTipoComponenteGTVe;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "Comp")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoGTVeComp extends DFBase {
+    private static final long serialVersionUID = 3107443189436692983L;
+
+    @Element(name = "tpComp")
+    private CTipoComponenteGTVe tipoComponente;
+
+    @Element(name = "vComp")
+    private String valorComponente;
+
+    @Element(name = "xComp", required = false)
+    private String nomeComponente;
+
+    public CTipoComponenteGTVe getTipoComponente() {
+        return tipoComponente;
+    }
+
+    public void setTipoComponente(final CTipoComponenteGTVe tipoComponente) {
+        this.tipoComponente = tipoComponente;
+    }
+
+    public String getValorComponente() {
+        return valorComponente;
+    }
+
+    public void setValorComponente(final BigDecimal valorComponente) {
+        this.valorComponente = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorComponente, "Valor do componente");
+    }
+
+    public String getNomeComponente() {
+        return nomeComponente;
+    }
+
+    public void setNomeComponente(final String nomeComponente) {
+        DFStringValidador.tamanho15(nomeComponente, "Nome do componente");
+        this.nomeComponente = nomeComponente;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoModal.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoModal.java
@@ -1,0 +1,39 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "infModal")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoModal extends DFBase {
+    private static final long serialVersionUID = 8987158163135069115L;
+
+    @Element(name = "rodoOS", required = false)
+    private CTeOSInfoCTeNormalInfoModalRodoviario rodoviario;
+
+    @Attribute(name = "versaoModal")
+    private String versao;
+
+    public CTeOSInfoCTeNormalInfoModalRodoviario getRodoviario() {
+        return this.rodoviario;
+    }
+
+    public void setRodoviario(final CTeOSInfoCTeNormalInfoModalRodoviario rodoviario) {
+        this.rodoviario = rodoviario;
+    }
+
+    public String getVersao() {
+        return this.versao;
+    }
+
+    /**
+     * Versão do leiaute específico para o Modal
+     */
+    public void setVersao(final String versaoModal) {
+        this.versao = versaoModal;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoModalRodoviario.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoModalRodoviario.java
@@ -1,0 +1,60 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "rodoOS")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoModalRodoviario extends DFBase {
+    private static final long serialVersionUID = -5367579900038295412L;
+
+    @Element(name = "TAF", required = false)
+    private String termoAutorizacaoFretamento;
+
+    @Element(name = "NroRegEstadual", required = false)
+    private String numeroRegistroEstadual;
+
+    @Element(name = "veic", required = false)
+    private CTeOSInfoCTeNormalInfoModalRodoviarioVeiculo veiculo;
+
+    @Element(name = "infFretamento", required = false)
+    private CTeOSInfoCTeNormalInfoModalRodoviarioFretamento fretamento;
+
+    public String getTermoAutorizacaoFretamento() {
+        return termoAutorizacaoFretamento;
+    }
+
+    public void setTermoAutorizacaoFretamento(final String termoAutorizacaoFretamento) {
+        DFStringValidador.tamanho12(termoAutorizacaoFretamento, "Termo de Autorização de Fretamento");
+        this.termoAutorizacaoFretamento = termoAutorizacaoFretamento;
+    }
+
+    public String getNumeroRegistroEstadual() {
+        return numeroRegistroEstadual;
+    }
+
+    public void setNumeroRegistroEstadual(final String numeroRegistroEstadual) {
+        DFStringValidador.tamanho25N(numeroRegistroEstadual, "Número do Registro Estadual");
+        this.numeroRegistroEstadual = numeroRegistroEstadual;
+    }
+
+    public CTeOSInfoCTeNormalInfoModalRodoviarioVeiculo getVeiculo() {
+        return veiculo;
+    }
+
+    public void setVeiculo(final CTeOSInfoCTeNormalInfoModalRodoviarioVeiculo veiculo) {
+        this.veiculo = veiculo;
+    }
+
+    public CTeOSInfoCTeNormalInfoModalRodoviarioFretamento getFretamento() {
+        return fretamento;
+    }
+
+    public void setFretamento(final CTeOSInfoCTeNormalInfoModalRodoviarioFretamento fretamento) {
+        this.fretamento = fretamento;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoModalRodoviarioFretamento.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoModalRodoviarioFretamento.java
@@ -1,0 +1,38 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.CTTipoFretamento;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.time.ZonedDateTime;
+
+@Root(name = "infFretamento")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoModalRodoviarioFretamento extends DFBase {
+    private static final long serialVersionUID = 8999239864502092146L;
+
+    @Element(name = "tpFretamento")
+    private CTTipoFretamento tipoFretamento;
+
+    @Element(name = "dhViagem", required = false)
+    private ZonedDateTime dataHoraViagem;
+
+    public CTTipoFretamento getTipoFretamento() {
+        return tipoFretamento;
+    }
+
+    public void setTipoFretamento(final CTTipoFretamento tipoFretamento) {
+        this.tipoFretamento = tipoFretamento;
+    }
+
+    public ZonedDateTime getDataHoraViagem() {
+        return dataHoraViagem;
+    }
+
+    public void setDataHoraViagem(final ZonedDateTime dataHoraViagem) {
+        this.dataHoraViagem = dataHoraViagem;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoModalRodoviarioVeiculo.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoModalRodoviarioVeiculo.java
@@ -1,0 +1,61 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "veic")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoModalRodoviarioVeiculo extends DFBase {
+    private static final long serialVersionUID = 5278574973196952726L;
+
+    @Element(name = "placa")
+    private String placa;
+
+    @Element(name = "RENAVAM", required = false)
+    private String renavam;
+
+    @Element(name = "prop", required = false)
+    private CTeOSInfoCTeNormalInfoModalRodoviarioVeiculoProprietario proprietario;
+
+    @Element(name = "UF")
+    private String uf;
+
+    public String getPlaca() {
+        return placa;
+    }
+
+    public void setPlaca(final String placa) {
+        DFStringValidador.placaDeVeiculo(placa, "Placa do veículo");
+        this.placa = placa;
+    }
+
+    public String getRenavam() {
+        return renavam;
+    }
+
+    public void setRenavam(final String renavam) {
+        this.renavam = DFStringValidador.validaIntervalo(renavam, 9, 11, "Renavam do reboque");
+    }
+
+    public CTeOSInfoCTeNormalInfoModalRodoviarioVeiculoProprietario getProprietario() {
+        return proprietario;
+    }
+
+    public void setProprietario(final CTeOSInfoCTeNormalInfoModalRodoviarioVeiculoProprietario proprietario) {
+        this.proprietario = proprietario;
+    }
+
+    public String getUf() {
+        return uf;
+    }
+
+    public void setUf(final String uf) {
+        DFStringValidador.exatamente2(uf, "UF");
+        this.uf = uf;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoModalRodoviarioVeiculoProprietario.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoModalRodoviarioVeiculoProprietario.java
@@ -1,0 +1,118 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.DFUnidadeFederativa;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.CTTipoProprietario;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "prop")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoModalRodoviarioVeiculoProprietario extends DFBase {
+    private static final long serialVersionUID = -7624273019279765397L;
+
+    @Element(name = "CPF", required = false)
+    private String cpf;
+
+    @Element(name = "CNPJ", required = false)
+    private String cnpj;
+
+    @Element(name = "TAF", required = false)
+    private String termoAutorizacaoFretamento;
+
+    @Element(name = "NroRegEstadual", required = false)
+    private String numeroRegistroEstadual;
+
+    @Element(name = "xNome")
+    private String razaoSocial;
+
+    @Element(name = "IE")
+    private String inscricaoEstadual;
+
+    @Element(name = "UF")
+    private String unidadeFederativa;
+
+    @Element(name = "tpProp", required = false)
+    private CTTipoProprietario tipoProprietario;
+
+    public String getCpf() {
+        return cpf;
+    }
+
+    public void setCpf(final String cpf) {
+        if (this.cnpj != null) {
+            throw new IllegalStateException("Nao deve setar CPF se CNPJ esteja setado em proprietario do Veículo ");
+        }
+        this.cpf = DFStringValidador.cpf(cpf, "proprietario do Veículo");
+        this.cpf = cpf;
+    }
+
+    public String getCnpj() {
+        return cnpj;
+    }
+
+    public void setCnpj(final String cnpj) {
+        if (this.cpf != null) {
+            throw new IllegalStateException("Nao deve setar CNPJ se CPF esteja setado em proprietario do Veículo");
+        }
+        this.cnpj = DFStringValidador.cnpj(cnpj, "proprietario do Veículo");
+    }
+
+    public String getRazaoSocial() {
+        return razaoSocial;
+    }
+
+    public void setRazaoSocial(final String razaoSocial) {
+        this.razaoSocial = razaoSocial;
+    }
+
+    public String getInscricaoEstadual() {
+        return inscricaoEstadual;
+    }
+
+    public void setInscricaoEstadual(final String inscricaoEstadual) {
+        DFStringValidador.inscricaoEstadual(inscricaoEstadual);
+        this.inscricaoEstadual = inscricaoEstadual;
+    }
+
+    public String getUnidadeFederativa() {
+        return unidadeFederativa;
+    }
+
+    public void setUnidadeFederativa(final String unidadeFederativa) {
+        this.unidadeFederativa = unidadeFederativa;
+    }
+
+    public void setUnidadeFederativa(DFUnidadeFederativa unidadeFederativa) {
+        this.unidadeFederativa = unidadeFederativa.getCodigo();
+    }
+
+    public String getTermoAutorizacaoFretamento() {
+        return termoAutorizacaoFretamento;
+    }
+
+    public void setTermoAutorizacaoFretamento(final String termoAutorizacaoFretamento) {
+        DFStringValidador.tamanho12(termoAutorizacaoFretamento, "Termo de Autorização de Fretamento");
+        this.termoAutorizacaoFretamento = termoAutorizacaoFretamento;
+    }
+
+    public String getNumeroRegistroEstadual() {
+        return numeroRegistroEstadual;
+    }
+
+    public void setNumeroRegistroEstadual(final String numeroRegistroEstadual) {
+        DFStringValidador.tamanho25N(numeroRegistroEstadual, "Número do Registro Estadual");
+        this.numeroRegistroEstadual = numeroRegistroEstadual;
+    }
+
+    public CTTipoProprietario getTipoProprietario() {
+        return tipoProprietario;
+    }
+
+    public void setTipoProprietario(final CTTipoProprietario tipoProprietario) {
+        this.tipoProprietario = tipoProprietario;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoServico.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalInfoServico.java
@@ -1,0 +1,40 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.util.List;
+
+@Root(name = "infServico")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalInfoServico extends DFBase {
+    private static final long serialVersionUID = -6918550471184804059L;
+
+    @Element(name = "xDescServ")
+    private String descricaoServico;
+
+    @ElementList(name = "infQ", inline = true, required = false)
+    private List<CTeOSInfoCTeNormalInfoCargaInformacoesQuantidadeCarga> informacoesQuantidadeCarga;
+
+    public String getDescricaoServico() {
+        return descricaoServico;
+    }
+
+    public void setDescricaoServico(final String descricaoServico) {
+        DFStringValidador.tamanho30(descricaoServico, "Descricao Servico");
+        this.descricaoServico = descricaoServico;
+    }
+
+    public List<CTeOSInfoCTeNormalInfoCargaInformacoesQuantidadeCarga> getInformacoesQuantidadeCarga() {
+        return informacoesQuantidadeCarga;
+    }
+
+    public void setInformacoesQuantidadeCarga(List<CTeOSInfoCTeNormalInfoCargaInformacoesQuantidadeCarga> informacoesQuantidadeCarga) {
+        this.informacoesQuantidadeCarga = informacoesQuantidadeCarga;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalSeguro.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoCTeNormalSeguro.java
@@ -1,0 +1,51 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.CTResponsavelSeguro;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "seg")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoCTeNormalSeguro extends DFBase {
+    private static final long serialVersionUID = -7791328283494118369L;
+
+    @Element(name = "respSeg")
+    private CTResponsavelSeguro responsavelSeguro;
+
+    @Element(name = "xSeg", required = false)
+    private String nomeSeguradora;
+
+    @Element(name = "nApol", required = false)
+    private String numeroApolice;
+
+    public CTResponsavelSeguro getResponsavelSeguro() {
+        return responsavelSeguro;
+    }
+
+    public void setResponsavelSeguro(final CTResponsavelSeguro responsavelSeguro) {
+        this.responsavelSeguro = responsavelSeguro;
+    }
+
+    public String getNomeSeguradora() {
+        return nomeSeguradora;
+    }
+
+    public void setNomeSeguradora(final String nomeSeguradora) {
+        DFStringValidador.tamanho30(nomeSeguradora, "Nome da seguradora");
+        this.nomeSeguradora = nomeSeguradora;
+    }
+
+    public String getNumeroApolice() {
+        return numeroApolice;
+    }
+
+    public void setNumeroApolice(final String numeroApolice) {
+        DFStringValidador.tamanho20(numeroApolice, "Número da apólice");
+        this.numeroApolice = numeroApolice;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoDadosComplementares.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoDadosComplementares.java
@@ -1,0 +1,110 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFListValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.util.List;
+
+@Root(name = "compl")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoDadosComplementares extends DFBase {
+    private static final long serialVersionUID = -8686019717867243514L;
+
+    @Element(name = "xCaracAd", required = false)
+    private String caracteristicasTransporte;
+
+    @Element(name = "xCaracSer", required = false)
+    private String caracteristicasServico;
+
+    @Element(name = "xEmi", required = false)
+    private String funcionarioEmissor;
+
+    @Element(name = "xObs", required = false)
+    private String observacaoGeral;
+
+    @ElementList(name = "ObsCont", inline = true, required = false)
+    private List<CTeOSInfoDadosComplementaresObservacaoContribuinte> observacaoContribuinte;
+
+    @ElementList(name = "ObsFisco", inline = true, required = false)
+    private List<CTeOSInfoDadosComplementaresObservacaoFisco> observacaoFisco;
+
+    public String getCaracteristicasTransporte() {
+        return this.caracteristicasTransporte;
+    }
+
+    /**
+     * Característica adicional do transporte<br>
+     * Texto livre: REENTREGA; DEVOLUÇÃO; REFATURAMENTO; etc
+     */
+    public void setCaracteristicasTransporte(final String caracteristicasTransporte) {
+        DFStringValidador.tamanho15(caracteristicasTransporte, "Característica adicional do transporte");
+        this.caracteristicasTransporte = caracteristicasTransporte;
+    }
+
+    public String getCaracteristicasServico() {
+        return this.caracteristicasServico;
+    }
+
+    /**
+     * Característica adicional do serviço<br>
+     * Texto livre: ENTREGA EXPRESSA; LOGÍSTICA REVERSA; CONVENCIONAL; EMERGENCIAL; etc
+     */
+    public void setCaracteristicasServico(final String caracteristicasServico) {
+        DFStringValidador.tamanho30(caracteristicasServico, "Característica adicional do serviço");
+        this.caracteristicasServico = caracteristicasServico;
+    }
+
+    public String getFuncionarioEmissor() {
+        return this.funcionarioEmissor;
+    }
+
+    /**
+     * Funcionário emissor do CTe
+     */
+    public void setFuncionarioEmissor(final String funcionarioEmissor) {
+        DFStringValidador.tamanho20(funcionarioEmissor, "Funcionário emissor do CTe");
+        this.funcionarioEmissor = funcionarioEmissor;
+    }
+
+    public String getObservacaoGeral() {
+        return this.observacaoGeral;
+    }
+
+    /**
+     * Observações Gerais
+     */
+    public void setObservacaoGeral(final String observacaoGeral) {
+        DFStringValidador.tamanho2000(observacaoGeral, "Observações Gerais");
+        this.observacaoGeral = observacaoGeral;
+    }
+
+    public List<CTeOSInfoDadosComplementaresObservacaoContribuinte> getObservacaoContribuinte() {
+        return this.observacaoContribuinte;
+    }
+
+    /**
+     * Campo de uso livre do contribuinte
+     */
+    public void setObservacaoContribuinte(final List<CTeOSInfoDadosComplementaresObservacaoContribuinte> observacaoContribuinte) {
+        DFListValidador.tamanho10(observacaoContribuinte, "Observação de interesse do contribuinte");
+        this.observacaoContribuinte = observacaoContribuinte;
+    }
+
+    public List<CTeOSInfoDadosComplementaresObservacaoFisco> getObservacaoFisco() {
+        return this.observacaoFisco;
+    }
+
+    /**
+     * Campo de uso livre do contribuinte
+     */
+    public void setObservacaoFisco(final List<CTeOSInfoDadosComplementaresObservacaoFisco> observacaoFisco) {
+        DFListValidador.tamanho10(observacaoFisco, "Observação de interesse do fisco");
+        this.observacaoFisco = observacaoFisco;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoDadosComplementaresObservacaoContribuinte.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoDadosComplementaresObservacaoContribuinte.java
@@ -1,0 +1,45 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "ObsCont")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoDadosComplementaresObservacaoContribuinte extends DFBase {
+    private static final long serialVersionUID = 3363633720721437281L;
+
+    @Attribute(name = "xCampo")
+    private String campo;
+
+    @Element(name = "xTexto")
+    private String texto;
+
+    public String getCampo() {
+        return this.campo;
+    }
+
+    /**
+     * Identificação do campo
+     */
+    public void setCampo(final String campo) {
+        DFStringValidador.tamanho20(campo, "Identificação do campo");
+        this.campo = campo;
+    }
+
+    public String getTexto() {
+        return this.texto;
+    }
+
+    /**
+     * Identificação do texto
+     */
+    public void setTexto(final String texto) {
+        DFStringValidador.tamanho160(texto, "Identificação do texto");
+        this.texto = texto;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoDadosComplementaresObservacaoFisco.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoDadosComplementaresObservacaoFisco.java
@@ -1,0 +1,45 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "ObsFisco")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoDadosComplementaresObservacaoFisco extends DFBase {
+    private static final long serialVersionUID = -2703860850692444439L;
+
+    @Attribute(name = "xCampo")
+    private String campo;
+
+    @Element(name = "xTexto")
+    private String texto;
+
+    public String getCampo() {
+        return this.campo;
+    }
+
+    /**
+     * Identificação do campo
+     */
+    public void setCampo(final String campo) {
+        DFStringValidador.tamanho20(campo, "Identificação do campo");
+        this.campo = campo;
+    }
+
+    public String getTexto() {
+        return this.texto;
+    }
+
+    /**
+     * Identificação do texto
+     */
+    public void setTexto(final String texto) {
+        DFStringValidador.tamanho60(texto, "Identificação do texto");
+        this.texto = texto;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoEmitente.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoEmitente.java
@@ -1,0 +1,117 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.CTTipoRegimeTributario;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "emit")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoEmitente extends DFBase {
+    private static final long serialVersionUID = 3236506485275091047L;
+
+    @Element(name = "CNPJ")
+    private String cnpj;
+
+    @Element(name = "IE")
+    private String inscricaoEstadual;
+
+    @Element(name = "IEST", required = false)
+    private String inscricaoEstadualST;
+
+    @Element(name = "xNome")
+    private String razaoSocial;
+
+    @Element(name = "xFant", required = false)
+    private String nomeFantasia;
+
+    @Element(name = "enderEmit")
+    private CTeOSEnderecoEmitente endereco;
+
+    @Element(name = "CRT")
+    private CTTipoRegimeTributario tipoRegimeTributario;
+
+    public String getCnpj() {
+        return this.cnpj;
+    }
+
+    /**
+     * CNPJ do emitente<br>
+     * Informar zeros não significativos
+     */
+    public void setCnpj(final String cnpj) {
+        DFStringValidador.cnpj(cnpj);
+        this.cnpj = cnpj;
+    }
+
+    public String getInscricaoEstadual() {
+        return this.inscricaoEstadual;
+    }
+
+    /**
+     * Inscrição Estadual do Emitente
+     */
+    public void setInscricaoEstadual(final String inscricaoEstadual) {
+        DFStringValidador.inscricaoEstadualSemIsencao(inscricaoEstadual);
+        this.inscricaoEstadual = inscricaoEstadual;
+    }
+
+    public String getInscricaoEstadualST() {
+        return this.inscricaoEstadualST;
+    }
+
+    /**
+     * Inscrição Estadual do Substituto Tributário
+     */
+    public void setInscricaoEstadualST(final String inscricaoEstadualST) {
+        DFStringValidador.tamanho14N(inscricaoEstadualST, "Inscrição Estadual do Substituto Tributário");
+        this.inscricaoEstadualST = inscricaoEstadualST;
+    }
+
+    public String getRazaoSocial() {
+        return this.razaoSocial;
+    }
+
+    /**
+     * Razão social ou Nome do emitente
+     */
+    public void setRazaoSocial(final String xNome) {
+        DFStringValidador.tamanho2ate60(xNome, "Razão social ou Nome do emitente");
+        this.razaoSocial = xNome;
+    }
+
+    public String getNomeFantasia() {
+        return this.nomeFantasia;
+    }
+
+    /**
+     * Nome fantasia
+     */
+    public void setNomeFantasia(final String xFant) {
+        DFStringValidador.tamanho2ate60(xFant, "Nome fantasia");
+        this.nomeFantasia = xFant;
+    }
+
+    public CTeOSEnderecoEmitente getEnderEmit() {
+        return this.endereco;
+    }
+
+    /**
+     * Endereço do emitente
+     */
+    public void setEnderEmit(final CTeOSEnderecoEmitente enderEmit) {
+        this.endereco = enderEmit;
+    }
+
+    public CTTipoRegimeTributario getTipoRegimeTributario() {
+        return tipoRegimeTributario;
+    }
+
+    public CTeOSInfoEmitente setTipoRegimeTributario(final CTTipoRegimeTributario tipoRegimeTributario) {
+        this.tipoRegimeTributario = tipoRegimeTributario;
+        return this;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoIdentificacao.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoIdentificacao.java
@@ -1,0 +1,509 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFAmbiente;
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.DFModelo;
+import com.fincatto.documentofiscal.DFUnidadeFederativa;
+import com.fincatto.documentofiscal.cte.CTTipoEmissao;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.*;
+import com.fincatto.documentofiscal.validadores.DFIntegerValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+@Root(name = "ide")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoIdentificacao extends DFBase {
+    private static final long serialVersionUID = -8453848058358735289L;
+
+    @Element(name = "cUF")
+    private DFUnidadeFederativa codigoUF;
+
+    @Element(name = "cCT")
+    private String codigoNumerico;
+
+    @Element(name = "CFOP")
+    private String cfop;
+
+    @Element(name = "natOp")
+    private String naturezaOperacao;
+
+    @Element(name = "mod")
+    private DFModelo modelo;
+
+    @Element(name = "serie")
+    private Integer serie;
+
+    @Element(name = "nCT")
+    private Integer numero;
+
+    @Element(name = "dhEmi")
+    private ZonedDateTime dataEmissao;
+
+    @Element(name = "tpImp")
+    private CTTipoImpressao tipoImpressao;
+
+    @Element(name = "tpEmis")
+    private CTTipoEmissao tipoEmissao;
+
+    @Element(name = "cDV")
+    private Integer digitoVerificador;
+
+    @Element(name = "tpAmb")
+    private DFAmbiente ambiente;
+
+    @Element(name = "tpCTe")
+    private CTFinalidade finalidade;
+
+    @Element(name = "procEmi")
+    private CTProcessoEmissao processoEmissao;
+
+    @Element(name = "verProc")
+    private String versaoProcessoEmissao;
+
+    @Element(name = "cMunEnv")
+    private String codigoMunicipioEnvio;
+
+    @Element(name = "xMunEnv")
+    private String descricaoMunicipioEnvio;
+
+    @Element(name = "UFEnv")
+    private String siglaUFEnvio;
+
+    @Element(name = "modal")
+    private CTModal modalidadeFrete;
+
+    @Element(name = "tpServ")
+    private CTTipoServicoOS tipoServico;
+
+    @Element(name = "indIEToma")
+    private CTIndicadorTomador indIEToma;
+
+    @Element(name = "cMunIni")
+    private String codigoMunicipioInicio;
+
+    @Element(name = "xMunIni")
+    private String descricaoMunicipioInicio;
+
+    @Element(name = "UFIni")
+    private String siglaUfInicio;
+
+    @Element(name = "cMunFim")
+    private String codigoMunicipioFim;
+
+    @Element(name = "xMunFim")
+    private String descricaoMunicipioFim;
+
+    @Element(name = "UFFim")
+    private String siglaUfFim;
+
+    @ElementList(entry = "infPercurso", inline = true, required = false)
+    private List<CTeOSInfoIdentificacaoUfPercurso> identificacaoUfPercursos;
+
+    @Element(name = "dhCont", required = false)
+    private LocalDateTime dataContingencia;
+
+    @Element(name = "xJust", required = false)
+    private String justificativa;
+
+    public DFUnidadeFederativa getCodigoUF() {
+        return this.codigoUF;
+    }
+    
+    /**
+     * Codigo da UF do emitente do CT-e.
+     */
+    public void setCodigoUF(final DFUnidadeFederativa codigoUF) {
+        this.codigoUF = codigoUF;
+    }
+    
+    public String getCodigoNumerico() {
+        return this.codigoNumerico;
+    }
+    
+    /**
+     * Codigo numerico que compoe a Chave de Acesso.<br>
+     * Numero aleatorio gerado pelo emitente para cada CT-e, com o objetivo de evitar acessos indevidos ao documento.
+     */
+    public void setCodigoNumerico(final String codigoNumerico) {
+        DFStringValidador.exatamente8N(codigoNumerico, "Codigo Numerico");
+        this.codigoNumerico = codigoNumerico;
+    }
+    
+    public String getCfop() {
+        return this.cfop;
+    }
+    
+    /**
+     * Codigo Fiscal de Operacoes e Prestacoes
+     */
+    public void setCfop(final String cfop) {
+        DFStringValidador.exatamente4N(cfop, "CFOP");
+        this.cfop = cfop;
+    }
+    
+    public String getNaturezaOperacao() {
+        return this.naturezaOperacao;
+    }
+    
+    /**
+     * Natureza da Operacao
+     */
+    public void setNaturezaOperacao(final String naturezaOperacao) {
+        DFStringValidador.tamanho2ate60(naturezaOperacao, "Natureza da Operacao");
+        this.naturezaOperacao = naturezaOperacao;
+    }
+    
+    public DFModelo getModelo() {
+        return this.modelo;
+    }
+    
+    /**
+     * Modelo do documento fiscal<br>
+     * Utilizar o codigo 57 para identificacao do CT-e, emitido em substituicao aos modelos de conhecimentos em papel.
+     */
+    public void setModelo(final DFModelo modelo) {
+        this.modelo = modelo;
+    }
+    
+    public Integer getSerie() {
+        return this.serie;
+    }
+    
+    /**
+     * Serie do CT-e<br>
+     * Preencher com "0" no caso de serie unica
+     */
+    public void setSerie(final Integer serie) {
+        DFIntegerValidador.tamanho3(serie, "Serie");
+        this.serie = serie;
+    }
+    
+    public Integer getNumero() {
+        return this.numero;
+    }
+    
+    /**
+     * Numero do CT-e
+     */
+    public void setNumero(final Integer numero) {
+        DFIntegerValidador.tamanho9(numero, "Numero");
+        this.numero = numero;
+    }
+    
+    public ZonedDateTime getDataEmissao() {
+        return this.dataEmissao;
+    }
+    
+    /**
+     * Data e hora de emissao do CT-e<br>
+     * Formato AAAA-MM-DDTHH:MM:DD TZD
+     */
+    public void setDataEmissao(final ZonedDateTime dataEmissao) {
+        this.dataEmissao = dataEmissao;
+    }
+    
+    public CTTipoImpressao getTipoImpressao() {
+        return this.tipoImpressao;
+    }
+    
+    /**
+     * Formato de impressao do DACTE<br>
+     * Preencher com: 1 - Retrato; 2 - Paisagem.
+     */
+    public void setTipoImpressao(final CTTipoImpressao tipoImpressao) {
+        this.tipoImpressao = tipoImpressao;
+    }
+    
+    public CTTipoEmissao getTipoEmissao() {
+        return this.tipoEmissao;
+    }
+    
+    /**
+     * Forma de emissao do CT-e<br>
+     * Preencher com:<br>
+     * 1 - Normal;<br>
+     * 4 - EPEC pela SVC; 5 - Contingencia FSDA;<br>
+     * 7 - Autorizacao pela SVC-RS;<br>
+     * 8 - Autorizacao pela SVC-SP;<br>
+     */
+    public void setTipoEmissao(final CTTipoEmissao tipoEmissao) {
+        this.tipoEmissao = tipoEmissao;
+    }
+    
+    public Integer getDigitoVerificador() {
+        return this.digitoVerificador;
+    }
+    
+    /**
+     * Digito Verificador da chave de acesso do CT-e<br>
+     * Informar o digito de controle da chave de acesso do CT-e, que deve ser calculado com a aplicacao do algoritmo modulo 11 (base 2,9) da chave de acesso.
+     */
+    public void setDigitoVerificador(final Integer digitoVerificador) {
+        DFIntegerValidador.exatamente1(digitoVerificador, "DV");
+        this.digitoVerificador = digitoVerificador;
+    }
+    
+    public DFAmbiente getAmbiente() {
+        return this.ambiente;
+    }
+    
+    /**
+     * Tipo do Ambiente<br>
+     * Preencher com:<br>
+     * 1 - Producao;<br>
+     * 2 - Homologacao
+     */
+    public void setAmbiente(final DFAmbiente ambiente) {
+        this.ambiente = ambiente;
+    }
+    
+    public CTFinalidade getFinalidade() {
+        return this.finalidade;
+    }
+    
+    /**
+     * Tipo do CT-e<br>
+     * Preencher com:<br>
+     * 0 - CT-e Normal;<br>
+     * 1 - CT-e de Complemento de Valores;<br>
+     * 2 - CT-e de Anulacao;<br>
+     * 3 - CT-e Substituto
+     */
+    public void setFinalidade(final CTFinalidade finalidade) {
+        this.finalidade = finalidade;
+    }
+    
+    public CTProcessoEmissao getProcessoEmissao() {
+        return this.processoEmissao;
+    }
+    
+    /**
+     * Identificador do processo de emissao do CT-e<br>
+     * Preencher com:<br>
+     * 0 - emissao de CT-e com aplicativo do contribuinte;<br>
+     * 3- emissao CT-e pelo contribuinte com aplicativo fornecido pelo Fisco.
+     */
+    public void setProcessoEmissao(final CTProcessoEmissao processoEmissao) {
+        this.processoEmissao = processoEmissao;
+    }
+    
+    public String getVersaoProcessoEmissao() {
+        return this.versaoProcessoEmissao;
+    }
+    
+    /**
+     * Versao do processo de emissao<br>
+     * Iinformar a versao do aplicativo emissor de CT-e.
+     */
+    public void setVersaoProcessoEmissao(final String versaoProcessoEmissao) {
+        DFStringValidador.tamanho20(versaoProcessoEmissao, "Versao Aplicativo Emissor");
+        this.versaoProcessoEmissao = versaoProcessoEmissao;
+    }
+    
+    public String getCodigoMunicipioEnvio() {
+        return this.codigoMunicipioEnvio;
+    }
+    
+    /**
+     * Codigo do Municipio de envio do CT-e (de onde o documento foi transmitido)<br>
+     * Utilizar a tabela do IBGE. Informar 9999999 para as operacoes com o exterior.
+     */
+    public void setCodigoMunicipioEnvio(final String codigoMunicipioEnvio) {
+        DFStringValidador.exatamente7N(codigoMunicipioEnvio, "Codigo do Municipio de envio do CT-e");
+        this.codigoMunicipioEnvio = codigoMunicipioEnvio;
+    }
+    
+    public String getDescricaoMunicipioEnvio() {
+        return this.descricaoMunicipioEnvio;
+    }
+    
+    /**
+     * Nome do Municipio de envio do CT-e (de onde o documento foi transmitido)<br>
+     * Informar PAIS/Municipio para as operacoes com o exterior.
+     */
+    public void setDescricaoMunicipioEnvio(final String descricaoMunicipioEnvio) {
+        DFStringValidador.tamanho2ate60(descricaoMunicipioEnvio, "Nome do Municipio de envio do CT-e");
+        this.descricaoMunicipioEnvio = descricaoMunicipioEnvio;
+    }
+    
+    public String getSiglaUFEnvio() {
+        return this.siglaUFEnvio;
+    }
+    
+    /**
+     * Sigla da UF de envio do CT-e (de onde o documento foi transmitido)<br>
+     * Informar 'EX' para operacoes com o exterior.
+     */
+    public void setSiglaUFEnvio(final String siglaUFEnvio) {
+        DFStringValidador.exatamente2(siglaUFEnvio, "Sigla da UF de envio do CT-e");
+        this.siglaUFEnvio = siglaUFEnvio;
+    }
+    
+    public CTModal getModalidadeFrete() {
+        return this.modalidadeFrete;
+    }
+    
+    /**
+     * Modal<br>
+     * Preencher com:<br>
+     * 01 - Rodoviario;<br>
+     * 02 - Aereo;<br>
+     * 03 - Aquaviario;<br>
+     * 04 - Ferroviario;<br>
+     * 05 - Dutoviario;<br>
+     * 06 - Multimodal;
+     */
+    public void setModalidadeFrete(final CTModal modalidadeFrete) {
+        this.modalidadeFrete = modalidadeFrete;
+    }
+    
+    public CTTipoServicoOS getTipoServico() {
+        return this.tipoServico;
+    }
+    
+    /**
+     * Tipo do Servico<br>
+     * Preencher com:<br>
+     * 0 - Normal;<br>
+     * 1 - Subcontratacao;<br>
+     * 2 - Redespacho;<br>
+     * 3 - Redespacho Intermediario;<br>
+     * 4 - Servico Vinculado a Multimodal
+     */
+    public void setTipoServico(final CTTipoServicoOS tipoServico) {
+        this.tipoServico = tipoServico;
+    }
+    
+    public String getCodigoMunicipioInicio() {
+        return this.codigoMunicipioInicio;
+    }
+    
+    /**
+     * Codigo do Municipio de inicio da prestacao<br>
+     * Utilizar a tabela do IBGE. Informar 9999999 para operacoes com o exterior.
+     */
+    public void setCodigoMunicipioInicio(final String codigoMunicipioInicio) {
+        DFStringValidador.exatamente7N(codigoMunicipioInicio, "Codigo do Municipio de inicio da prestacao");
+        this.codigoMunicipioInicio = codigoMunicipioInicio;
+    }
+    
+    public String getDescricaoMunicipioInicio() {
+        return this.descricaoMunicipioInicio;
+    }
+    
+    /**
+     * Nome do Municipio do inicio da prestacao<br>
+     * Informar 'EXTERIOR' para operacoes com o exterior.
+     */
+    public void setDescricaoMunicipioInicio(final String descricaoMunicipioInicio) {
+        DFStringValidador.tamanho2ate60(descricaoMunicipioInicio, "Nome do Municipio do inicio da prestacao");
+        this.descricaoMunicipioInicio = descricaoMunicipioInicio;
+    }
+    
+    public String getSiglaUfInicio() {
+        return this.siglaUfInicio;
+    }
+    
+    /**
+     * UF do inicio da prestacao<br>
+     * Informar 'EX' para operacoes com o exterior.
+     */
+    public void setSiglaUfInicio(final String siglaUfInicio) {
+        DFStringValidador.exatamente2(siglaUfInicio, "UF do inicio da prestacao");
+        this.siglaUfInicio = siglaUfInicio;
+    }
+    
+    public String getCodigoMunicipioFim() {
+        return this.codigoMunicipioFim;
+    }
+    
+    /**
+     * Codigo do Municipio de termino da prestacao<br>
+     * Utilizar a tabela do IBGE. Informar 9999999 para operacoes com o exterior.
+     */
+    public void setCodigoMunicipioFim(final String codigoMunicipioFim) {
+        DFStringValidador.exatamente7N(codigoMunicipioFim, "Codigo do Municipio de termino da prestacao");
+        this.codigoMunicipioFim = codigoMunicipioFim;
+    }
+    
+    public String getDescricaoMunicipioFim() {
+        return this.descricaoMunicipioFim;
+    }
+    
+    /**
+     * Nome do Municipio do termino da prestacao<br>
+     * Informar 'EXTERIOR' para operacoes com o exterior.
+     */
+    public void setDescricaoMunicipioFim(final String descricaoMunicipioFim) {
+        DFStringValidador.tamanho2ate60(descricaoMunicipioFim, "Nome do Municipio do termino da prestacao");
+        this.descricaoMunicipioFim = descricaoMunicipioFim;
+    }
+    
+    public String getSiglaUfFim() {
+        return this.siglaUfFim;
+    }
+    
+    /**
+     * UF do termino da prestacao<br>
+     * Informar 'EX' para operacoes com o exterior.
+     */
+    public void setSiglaUfFim(final String siglaUfFim) {
+        DFStringValidador.exatamente2(siglaUfFim, "UF do termino da prestacao");
+        this.siglaUfFim = siglaUfFim;
+    }
+    
+    public CTIndicadorTomador getIndIEToma() {
+        return this.indIEToma;
+    }
+    
+    /**
+     * Indicador do papel do tomador na prestacao do servico:<br>
+     * 1 – Contribuinte ICMS;<br>
+     * 2 – Contribuinte isento de inscricao;<br>
+     * 9 – Nao Contribuinte<br>
+     * Aplica-se ao tomador que for indicado no toma3 ou toma4
+     */
+    public void setIndIEToma(final CTIndicadorTomador indIEToma) {
+        this.indIEToma = indIEToma;
+    }
+    
+    public LocalDateTime getDataContingencia() {
+        return this.dataContingencia;
+    }
+    
+    /**
+     * Data e Hora da entrada em contingencia<br>
+     * Informar a data e hora no formato AAAA-MM-DDTHH:MM:SS
+     */
+    public void setDataContingencia(final LocalDateTime dataContingencia) {
+        this.dataContingencia = dataContingencia;
+    }
+    
+    public String getJustificativa() {
+        return this.justificativa;
+    }
+    
+    /**
+     * Justificativa da entrada em contingencia
+     */
+    public void setJustificativa(final String justificativa) {
+        DFStringValidador.tamanho15a256(justificativa, "Justificativa da entrada em contingencia");
+        this.justificativa = justificativa;
+    }
+
+    public List<CTeOSInfoIdentificacaoUfPercurso> getIdentificacaoUfPercursos() {
+        return identificacaoUfPercursos;
+    }
+
+    public void setIdentificacaoUfPercursos(List<CTeOSInfoIdentificacaoUfPercurso> identificacaoUfPercursos) {
+        this.identificacaoUfPercursos = identificacaoUfPercursos;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoIdentificacaoTomador.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoIdentificacaoTomador.java
@@ -1,0 +1,137 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "toma")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoIdentificacaoTomador extends DFBase {
+    private static final long serialVersionUID = -7014772748798643095L;
+
+    @Element(name = "CNPJ", required = false)
+    private String cnpj;
+
+    @Element(name = "CPF", required = false)
+    private String cpf;
+
+    @Element(name = "IE", required = false)
+    private String inscricaoEstadual;
+
+    @Element(name = "xNome")
+    private String razaoSocial;
+
+    @Element(name = "xFant", required = false)
+    private String nomeFantasia;
+
+    @Element(name = "fone", required = false)
+    private String telefone;
+
+    @Element(name = "enderToma")
+    private CTeOSEndereco enderTomadorServico;
+
+    @Element(name = "email", required = false)
+    private String email;
+
+    public String getCnpj() {
+        return this.cnpj;
+    }
+
+    /**
+     * Número do CNPJ<br>
+     * Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros. Informar os zeros não significativos.
+     */
+    public void setCnpj(final String cnpj) {
+        DFStringValidador.cnpj(cnpj);
+        this.cnpj = cnpj;
+    }
+
+    public String getCpf() {
+        return this.cpf;
+    }
+
+    /**
+     * Número do CPF<br>
+     * Informar os zeros não significativos.
+     */
+    public void setCpf(final String cpf) {
+        DFStringValidador.cpf(cpf);
+        this.cpf = cpf;
+    }
+
+    public String getInscricaoEstadual() {
+        return this.inscricaoEstadual;
+    }
+
+    /**
+     * Inscrição Estadual<br>
+     * Informar a IE do tomador ou ISENTO se tomador é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o tomador não seja contribuinte do ICMS não informar o conteúdo.
+     */
+    public void setInscricaoEstadual(final String inscricaoEstadual) {
+        DFStringValidador.inscricaoEstadual(inscricaoEstadual);
+        this.inscricaoEstadual = inscricaoEstadual;
+    }
+
+    public String getRazaoSocial() {
+        return this.razaoSocial;
+    }
+
+    /**
+     * Razão Social ou Nome
+     */
+    public void setRazaoSocial(final String razaoSocial) {
+        DFStringValidador.tamanho2ate60(razaoSocial, "Razão Social ou Nome");
+        this.razaoSocial = razaoSocial;
+    }
+
+    public String getNomeFantasia() {
+        return this.nomeFantasia;
+    }
+
+    /**
+     * Nome Fantasia
+     */
+    public void setNomeFantasia(final String nomeFantasia) {
+        DFStringValidador.tamanho2ate60(nomeFantasia, "Nome Fantasia");
+        this.nomeFantasia = nomeFantasia;
+    }
+
+    public String getTelefone() {
+        return this.telefone;
+    }
+
+    /**
+     * Telefone
+     */
+    public void setTelefone(final String telefone) {
+        DFStringValidador.telefone(telefone);
+        this.telefone = telefone;
+    }
+
+    public CTeOSEndereco getEnderTomadorServico() {
+        return this.enderTomadorServico;
+    }
+
+    /**
+     * Dados do endereço
+     */
+    public void setEnderTomadorServico(final CTeOSEndereco enderTomadorServico) {
+        this.enderTomadorServico = enderTomadorServico;
+    }
+
+    public String getEmail() {
+        return this.email;
+    }
+
+    /**
+     * Endereço de email
+     */
+    public void setEmail(final String email) {
+        DFStringValidador.tamanho60(email, "Endereço de email");
+        DFStringValidador.email(email);
+        this.email = email;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoIdentificacaoUfPercurso.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoIdentificacaoUfPercurso.java
@@ -1,0 +1,37 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.DFUnidadeFederativa;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+
+@Root(name = "infPercurso")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoIdentificacaoUfPercurso extends DFBase {
+    private static final long serialVersionUID = -8756073376187638453L;
+
+    @Element(name = "UFPer")
+    private String ufPercurso;
+
+    public CTeOSInfoIdentificacaoUfPercurso() {
+    }
+
+    public CTeOSInfoIdentificacaoUfPercurso(final DFUnidadeFederativa ufPercurso) {
+        this.ufPercurso = ufPercurso.getCodigo();
+    }
+
+    public String getUfPercurso() {
+        return this.ufPercurso;
+    }
+
+    public void setUfPercurso(final String ufPercurso) {
+        this.ufPercurso = ufPercurso;
+    }
+
+    public void setUfPercurso(final DFUnidadeFederativa ufPercurso) {
+        this.ufPercurso = ufPercurso.getCodigo();
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostos.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostos.java
@@ -1,0 +1,87 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "imp")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostos extends DFBase {
+    private static final long serialVersionUID = -8373764548950257942L;
+
+    @Element(name = "ICMS")
+    private CTeOSInfoInformacoesRelativasImpostosICMS icms;
+
+    @Element(name = "vTotTrib", required = false)
+    private String valorTotalTributos;
+
+    @Element(name = "infAdFisco", required = false)
+    private String informacoesAdicionaisFisco;
+
+    @Element(name = "ICMSUFFim", required = false)
+    private CTeOSInfoInformacoesRelativasImpostosICMSPartilha icmsPartilha;
+
+    @Element(name = "infTribFed", required = false)
+    private CTeOSInfoInformacoesRelativasImpostosTributosFederais tributosFederais;
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS getIcms() {
+        return this.icms;
+    }
+
+    /**
+     * Informações relativas ao ICMS
+     */
+    public void setIcms(final CTeOSInfoInformacoesRelativasImpostosICMS icms) {
+        this.icms = icms;
+    }
+
+    public String getValorTotalTributos() {
+        return this.valorTotalTributos;
+    }
+
+    /**
+     * Valor Total dos Tributos
+     */
+    public void setValorTotalTributos(final BigDecimal valorTotalTributos) {
+        this.valorTotalTributos = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorTotalTributos, "Valor Total dos Tributos");
+    }
+
+    public String getInformacoesAdicionaisFisco() {
+        return this.informacoesAdicionaisFisco;
+    }
+
+    /**
+     * Informações adicionais de interesse do Fisco<br>
+     * Norma referenciada, informações complementares, etc
+     */
+    public void setInformacoesAdicionaisFisco(final String informacoesAdicionaisFisco) {
+        DFStringValidador.tamanho2000(informacoesAdicionaisFisco, "Informações adicionais de interesse do Fisco");
+        this.informacoesAdicionaisFisco = informacoesAdicionaisFisco;
+    }
+
+    public CTeOSInfoInformacoesRelativasImpostosICMSPartilha getIcmsPartilha() {
+        return this.icmsPartilha;
+    }
+
+    /**
+     * Informações do ICMS de partilha com a UF de término do serviço de transporte na operação interestadual<br>
+     * Grupo a ser informado nas prestações interestaduais para consumidor final, não contribuinte do ICMS
+     */
+    public void setIcmsPartilha(final CTeOSInfoInformacoesRelativasImpostosICMSPartilha icmsPartilha) {
+        this.icmsPartilha = icmsPartilha;
+    }
+
+    public CTeOSInfoInformacoesRelativasImpostosTributosFederais getTributosFederais() {
+        return tributosFederais;
+    }
+
+    public void setTributosFederais(final CTeOSInfoInformacoesRelativasImpostosTributosFederais tributosFederais) {
+        this.tributosFederais = tributosFederais;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS.java
@@ -1,0 +1,120 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "ICMS")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostosICMS extends DFBase {
+
+    @Element(name = "ICMS00", required = false)
+    private CTeOSInfoInformacoesRelativasImpostosICMS00 icms00;
+
+    @Element(name = "ICMS20", required = false)
+    private CTeOSInfoInformacoesRelativasImpostosICMS20 icms20;
+
+    @Element(name = "ICMS45", required = false)
+    private CTeOSInfoInformacoesRelativasImpostosICMS45 icms45;
+
+    @Element(name = "ICMS60", required = false)
+    private CTeOSInfoInformacoesRelativasImpostosICMS60 icms60;
+
+    @Element(name = "ICMS90", required = false)
+    private CTeOSInfoInformacoesRelativasImpostosICMS90 icms90;
+
+    @Element(name = "ICMSOutraUF", required = false)
+    private CTeOSInfoInformacoesRelativasImpostosICMSOutraUF icmsOutraUF;
+
+    @Element(name = "ICMSSN", required = false)
+    private CTeOSInfoInformacoesRelativasImpostosICMSSN icmssn;
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS() {
+        this.icms00 = null;
+        this.icms20 = null;
+        this.icms45 = null;
+        this.icms60 = null;
+        this.icms90 = null;
+        this.icmsOutraUF = null;
+        this.icmssn = null;
+    }
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS00 getIcms00() {
+        return this.icms00;
+    }
+
+    /**
+     * Prestação sujeito à tributação normal do ICMS
+     */
+    public void setIcms00(final CTeOSInfoInformacoesRelativasImpostosICMS00 icms00) {
+        this.icms00 = icms00;
+    }
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS20 getIcms20() {
+        return this.icms20;
+    }
+
+    /**
+     * Prestação sujeito à tributação com redução de BC do ICMS<
+     */
+    public void setIcms20(final CTeOSInfoInformacoesRelativasImpostosICMS20 icms20) {
+        this.icms20 = icms20;
+    }
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS45 getIcms45() {
+        return this.icms45;
+    }
+
+    /**
+     * ICMS Isento, não Tributado ou diferido
+     */
+    public void setIcms45(final CTeOSInfoInformacoesRelativasImpostosICMS45 icms45) {
+        this.icms45 = icms45;
+    }
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS60 getIcms60() {
+        return this.icms60;
+    }
+
+    /**
+     * Tributação pelo ICMS60 - ICMS cobrado por substituição tributária.Responsabilidade do recolhimento do ICMS atribuído ao tomador ou 3º por ST
+     */
+    public void setIcms60(final CTeOSInfoInformacoesRelativasImpostosICMS60 icms60) {
+        this.icms60 = icms60;
+    }
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS90 getIcms90() {
+        return this.icms90;
+    }
+
+    /**
+     * ICMS Outros
+     */
+    public void setIcms90(final CTeOSInfoInformacoesRelativasImpostosICMS90 icms90) {
+        this.icms90 = icms90;
+    }
+
+    public CTeOSInfoInformacoesRelativasImpostosICMSOutraUF getIcmsOutraUF() {
+        return this.icmsOutraUF;
+    }
+
+    /**
+     * ICMS devido à UF de origem da prestação, quando diferente da UF do emitente
+     */
+    public void setIcmsOutraUF(final CTeOSInfoInformacoesRelativasImpostosICMSOutraUF icmsOutraUF) {
+        this.icmsOutraUF = icmsOutraUF;
+    }
+
+    public CTeOSInfoInformacoesRelativasImpostosICMSSN getIcmssn() {
+        return this.icmssn;
+    }
+
+    /**
+     * Simples Nacional
+     */
+    public void setIcmssn(final CTeOSInfoInformacoesRelativasImpostosICMSSN icmssn) {
+        this.icmssn = icmssn;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS00.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS00.java
@@ -1,0 +1,80 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.CTCodigoSituacaoTributariaICMS;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "ICMS00")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostosICMS00 extends DFBase {
+    
+    @Element(name = "CST")
+    private CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria;
+    
+    @Element(name = "vBC")
+    private String baseCalculoICMS;
+    
+    @Element(name = "pICMS")
+    private String aliquotaICMS;
+    
+    @Element(name = "vICMS")
+    private String valorICMS;
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS00() {
+        this.codigoSituacaoTributaria = null;
+        this.baseCalculoICMS = null;
+        this.aliquotaICMS = null;
+        this.valorICMS = null;
+    }
+
+    public CTCodigoSituacaoTributariaICMS getCodigoSituacaoTributaria() {
+        return this.codigoSituacaoTributaria;
+    }
+
+    /**
+     * classificação Tributária do Serviço<br>
+     * 00 - tributação normal ICMS
+     */
+    public void setCodigoSituacaoTributaria(final CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria) {
+        this.codigoSituacaoTributaria = codigoSituacaoTributaria;
+    }
+
+    public String getBaseCalculoICMS() {
+        return this.baseCalculoICMS;
+    }
+
+    /**
+     * Valor da BC do ICMS
+     */
+    public void setBaseCalculoICMS(final BigDecimal baseCalculoICMS) {
+        this.baseCalculoICMS = DFBigDecimalValidador.tamanho15Com2CasasDecimais(baseCalculoICMS, "Valor da BC do ICMS");
+    }
+
+    public String getAliquotaICMS() {
+        return this.aliquotaICMS;
+    }
+
+    /**
+     * Alíquota do ICMS
+     */
+    public void setAliquotaICMS(final BigDecimal aliquotaICMS) {
+        this.aliquotaICMS = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaICMS, "Alíquota do ICMS");
+    }
+
+    public String getValorICMS() {
+        return this.valorICMS;
+    }
+
+    /**
+     * Valor do ICMS
+     */
+    public void setValorICMS(final BigDecimal valorICMS) {
+        this.valorICMS = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorICMS, "Valor do ICMS");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS20.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS20.java
@@ -1,0 +1,95 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.CTCodigoSituacaoTributariaICMS;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "ICMS20")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostosICMS20 extends DFBase {
+    
+    @Element(name = "CST")
+    private CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria;
+    
+    @Element(name = "pRedBC")
+    private String aliquotaReducaoBaseCalculoICMS;
+    
+    @Element(name = "vBC")
+    private String baseCalculoICMS;
+    
+    @Element(name = "pICMS")
+    private String aliquotaICMS;
+    
+    @Element(name = "vICMS")
+    private String valorICMS;
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS20() {
+        this.codigoSituacaoTributaria = null;
+        this.aliquotaReducaoBaseCalculoICMS = null;
+        this.baseCalculoICMS = null;
+        this.aliquotaICMS = null;
+        this.valorICMS = null;
+    }
+
+    public CTCodigoSituacaoTributariaICMS getCodigoSituacaoTributaria() {
+        return this.codigoSituacaoTributaria;
+    }
+
+    /**
+     * Classificação Tributária do serviço<br>
+     * 20 - tributação com BC reduzida do ICMS
+     */
+    public void setCodigoSituacaoTributaria(final CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria) {
+        this.codigoSituacaoTributaria = codigoSituacaoTributaria;
+    }
+
+    public String getAliquotaReducaoBaseCalculoICMS() {
+        return this.aliquotaReducaoBaseCalculoICMS;
+    }
+
+    /**
+     * Percentual de redução da BC
+     */
+    public void setAliquotaReducaoBaseCalculoICMS(final BigDecimal aliquotaReducaoBaseCalculoICMS) {
+        this.aliquotaReducaoBaseCalculoICMS = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaReducaoBaseCalculoICMS, "Percentual de redução da BC");
+    }
+
+    public String getBaseCalculoICMS() {
+        return this.baseCalculoICMS;
+    }
+
+    /**
+     * Valor da BC do ICMS
+     */
+    public void setBaseCalculoICMS(final BigDecimal baseCalculoICMS) {
+        this.baseCalculoICMS = DFBigDecimalValidador.tamanho15Com2CasasDecimais(baseCalculoICMS, "Valor da BC do ICMS");
+    }
+
+    public String getAliquotaICMS() {
+        return this.aliquotaICMS;
+    }
+
+    /**
+     * Alíquota do ICMS
+     */
+    public void setAliquotaICMS(final BigDecimal aliquotaICMS) {
+        this.aliquotaICMS = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaICMS, "Alíquota do ICMS");
+    }
+
+    public String getValorICMS() {
+        return this.valorICMS;
+    }
+
+    /**
+     * Valor do ICMS
+     */
+    public void setValorICMS(final BigDecimal valorICMS) {
+        this.valorICMS = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorICMS, "Valor do ICMS");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS45.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS45.java
@@ -1,0 +1,35 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.CTCodigoSituacaoTributariaICMS;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "ICMS45")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostosICMS45 extends DFBase {
+    
+    @Element(name = "CST")
+    private CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria;
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS45() {
+        this.codigoSituacaoTributaria = null;
+    }
+
+    public CTCodigoSituacaoTributariaICMS getCodigoSituacaoTributaria() {
+        return this.codigoSituacaoTributaria;
+    }
+
+    /**
+     * Classificação Tributária do Serviço<br>
+     * Preencher com:<br>
+     * 40 - ICMS isenção;<br>
+     * 41 - ICMS não tributada;<br>
+     * 51 - ICMS diferido
+     */
+    public void setCodigoSituacaoTributaria(final CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria) {
+        this.codigoSituacaoTributaria = codigoSituacaoTributaria;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS60.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS60.java
@@ -1,0 +1,99 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.CTCodigoSituacaoTributariaICMS;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "ICMS60")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostosICMS60 extends DFBase {
+    
+    @Element(name = "CST")
+    private CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria;
+    
+    @Element(name = "vBCSTRet")
+    private String baseCalculoICMSSTRetido;
+    
+    @Element(name = "vICMSSTRet")
+    private String valorICMSSTRetido;
+    
+    @Element(name = "pICMSSTRet")
+    private String aliquotaICMSSTRetido;
+
+    @Element(name = "vCred", required = false)
+    private String valorCredito;
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS60() {
+        this.codigoSituacaoTributaria = null;
+        this.baseCalculoICMSSTRetido = null;
+        this.valorICMSSTRetido = null;
+        this.aliquotaICMSSTRetido = null;
+        this.valorCredito = null;
+    }
+
+    public CTCodigoSituacaoTributariaICMS getCodigoSituacaoTributaria() {
+        return this.codigoSituacaoTributaria;
+    }
+
+    /**
+     * Classificação Tributária do Serviço<br>
+     * 60 - ICMS cobrado por substituição tributária
+     */
+    public void setCodigoSituacaoTributaria(final CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria) {
+        this.codigoSituacaoTributaria = codigoSituacaoTributaria;
+    }
+
+    public String getBaseCalculoICMSSTRetido() {
+        return this.baseCalculoICMSSTRetido;
+    }
+
+    /**
+     * Valor da BC do ICMS ST retido<br>
+     * Valor do frete sobre o qual será calculado o ICMS a ser substituído na Prestação.
+     */
+    public void setBaseCalculoICMSSTRetido(final BigDecimal baseCalculoICMSSTRetido) {
+        this.baseCalculoICMSSTRetido = DFBigDecimalValidador.tamanho15Com2CasasDecimais(baseCalculoICMSSTRetido, "Valor da BC do ICMS ST retido");
+    }
+
+    public String getValorICMSSTRetido() {
+        return this.valorICMSSTRetido;
+    }
+
+    /**
+     * Valor do ICMS ST retido<br>
+     * Resultado da multiplicação do “vBCSTRet” x “pICMSSTRet” – que será valor do ICMS a ser retido pelo Substituto. Podendo o valor do ICMS a ser retido efetivamente, sofrer ajustes conforme a opção tributaria do transportador substituído.
+     */
+    public void setValorICMSSTRetido(final BigDecimal valorICMSSTRetido) {
+        this.valorICMSSTRetido = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorICMSSTRetido, "Valor do ICMS ST retido");
+    }
+
+    public String getAliquotaICMSSTRetido() {
+        return this.aliquotaICMSSTRetido;
+    }
+
+    /**
+     * Alíquota do ICMS<br>
+     * Percentual de Alíquota incidente na prestação de serviço de transporte.
+     */
+    public void setAliquotaICMSSTRetido(final BigDecimal aliquotaICMSSTRetido) {
+        this.aliquotaICMSSTRetido = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaICMSSTRetido, "Alíquota do ICMS");
+    }
+
+    public String getValorCredito() {
+        return this.valorCredito;
+    }
+
+    /**
+     * Valor do Crédito outorgado/Presumido<br>
+     * Preencher somente quando o transportador substituído, for optante pelo crédito outorgado previsto no Convênio 106/96 e corresponde ao percentual de 20% do valor do ICMS ST retido.
+     */
+    public void setValorCredito(final BigDecimal valorCredito) {
+        this.valorCredito = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorCredito, "Valor do Crédito outorgado/Presumido");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS90.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostosICMS90.java
@@ -1,0 +1,110 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.CTCodigoSituacaoTributariaICMS;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "ICMS90")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostosICMS90 extends DFBase {
+    
+    @Element(name = "CST")
+    private CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria;
+
+    @Element(name = "pRedBC", required = false)
+    private String aliquotaReducaoBaseCalculo;
+    
+    @Element(name = "vBC")
+    private String baseCalculoICMS;
+    
+    @Element(name = "pICMS")
+    private String aliquotaICMS;
+    
+    @Element(name = "vICMS")
+    private String valorICMS;
+
+    @Element(name = "vCred", required = false)
+    private String valorCredito;
+
+    public CTeOSInfoInformacoesRelativasImpostosICMS90() {
+        this.codigoSituacaoTributaria = null;
+        this.aliquotaReducaoBaseCalculo = null;
+        this.baseCalculoICMS = null;
+        this.aliquotaICMS = null;
+        this.valorICMS = null;
+        this.valorCredito = null;
+    }
+
+    public CTCodigoSituacaoTributariaICMS getCodigoSituacaoTributaria() {
+        return this.codigoSituacaoTributaria;
+    }
+
+    /**
+     * Classificação Tributária do Serviço<br>
+     * 90 - ICMS outros
+     */
+    public void setCodigoSituacaoTributaria(final CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria) {
+        this.codigoSituacaoTributaria = codigoSituacaoTributaria;
+    }
+
+    public String getAliquotaReducaoBaseCalculo() {
+        return this.aliquotaReducaoBaseCalculo;
+    }
+
+    /**
+     * Percentual de redução da BC
+     */
+    public void setAliquotaReducaoBaseCalculo(final BigDecimal aliquotaReducaoBaseCalculo) {
+        this.aliquotaReducaoBaseCalculo = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaReducaoBaseCalculo, "Percentual de redução da BC");
+    }
+
+    public String getBaseCalculoICMS() {
+        return this.baseCalculoICMS;
+    }
+
+    /**
+     * Valor da BC do ICMS
+     */
+    public void setBaseCalculoICMS(final BigDecimal baseCalculoICMS) {
+        this.baseCalculoICMS = DFBigDecimalValidador.tamanho15Com2CasasDecimais(baseCalculoICMS, "Valor da BC do ICMS");
+    }
+
+    public String getAliquotaICMS() {
+        return this.aliquotaICMS;
+    }
+
+    /**
+     * Alíquota do ICMS
+     */
+    public void setAliquotaICMS(final BigDecimal aliquotaICMS) {
+        this.aliquotaICMS = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaICMS, "Alíquota do ICMS");
+    }
+
+    public String getValorICMS() {
+        return this.valorICMS;
+    }
+
+    /**
+     * Valor do ICMS
+     */
+    public void setValorICMS(final BigDecimal valorICMS) {
+        this.valorICMS = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorICMS, "Valor do ICMS");
+    }
+
+    public String getValorCredito() {
+        return this.valorCredito;
+    }
+
+    /**
+     * Valor do Crédito Outorgado/Presumido
+     */
+    public void setValorCredito(final BigDecimal valorCredito) {
+        this.valorCredito = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorCredito, "Valor do Crédito Outorgado/Presumido");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostosICMSOutraUF.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostosICMSOutraUF.java
@@ -1,0 +1,95 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.CTCodigoSituacaoTributariaICMS;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "ICMSOutraUF")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostosICMSOutraUF extends DFBase {
+    
+    @Element(name = "CST")
+    private CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria;
+
+    @Element(name = "pRedBCOutraUF", required = false)
+    private String aliquotaReducaoBaseCalculoICMSOutraUF;
+    
+    @Element(name = "vBCOutraUF")
+    private String baseCalculoICMSOutraUF;
+    
+    @Element(name = "pICMSOutraUF")
+    private String aliquotaICMSOutraUF;
+    
+    @Element(name = "vICMSOutraUF")
+    private String valorICMSOutraUF;
+
+    public CTeOSInfoInformacoesRelativasImpostosICMSOutraUF() {
+        this.codigoSituacaoTributaria = null;
+        this.aliquotaReducaoBaseCalculoICMSOutraUF = null;
+        this.baseCalculoICMSOutraUF = null;
+        this.aliquotaICMSOutraUF = null;
+        this.valorICMSOutraUF = null;
+    }
+
+    public CTCodigoSituacaoTributariaICMS getCodigoSituacaoTributaria() {
+        return this.codigoSituacaoTributaria;
+    }
+
+    /**
+     * Classificação Tributária do Serviço<br>
+     * 90 - ICMS Outra UF
+     */
+    public void setCodigoSituacaoTributaria(final CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria) {
+        this.codigoSituacaoTributaria = codigoSituacaoTributaria;
+    }
+
+    public String getAliquotaReducaoBaseCalculoICMSOutraUF() {
+        return this.aliquotaReducaoBaseCalculoICMSOutraUF;
+    }
+
+    /**
+     * Percentual de redução da BC
+     */
+    public void setAliquotaReducaoBaseCalculoICMSOutraUF(final BigDecimal aliquotaReducaoBaseCalculoICMSOutraUF) {
+        this.aliquotaReducaoBaseCalculoICMSOutraUF = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaReducaoBaseCalculoICMSOutraUF, "Percentual de redução da BC");
+    }
+
+    public String getBaseCalculoICMSOutraUF() {
+        return this.baseCalculoICMSOutraUF;
+    }
+
+    /**
+     * Valor da BC do ICMS
+     */
+    public void setBaseCalculoICMSOutraUF(final BigDecimal baseCalculoICMSOutraUF) {
+        this.baseCalculoICMSOutraUF = DFBigDecimalValidador.tamanho15Com2CasasDecimais(baseCalculoICMSOutraUF, "Valor da BC do ICMS");
+    }
+
+    public String getAliquotaICMSOutraUF() {
+        return this.aliquotaICMSOutraUF;
+    }
+
+    /**
+     * Alíquota do ICMS
+     */
+    public void setAliquotaICMSOutraUF(final BigDecimal aliquotaICMSOutraUF) {
+        this.aliquotaICMSOutraUF = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaICMSOutraUF, "Alíquota do ICMS");
+    }
+
+    public String getValorICMSOutraUF() {
+        return this.valorICMSOutraUF;
+    }
+
+    /**
+     * Valor do ICMS devido outra UF
+     */
+    public void setValorICMSOutraUF(final BigDecimal valorICMSOutraUF) {
+        this.valorICMSOutraUF = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorICMSOutraUF, "Valor do ICMS devido outra UF");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostosICMSPartilha.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostosICMSPartilha.java
@@ -1,0 +1,145 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "ICMSUFFim")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostosICMSPartilha extends DFBase {
+    
+    @Element(name = "vBCUFFim")
+    private String bcICMS;
+    
+    @Element(name = "pFCPUFFim")
+    private String aliquotaFCP;
+    
+    @Element(name = "pICMSUFFim")
+    private String aliquotaInterna;
+    
+    @Element(name = "pICMSInter")
+    private String aliquotaInterestadual;
+    
+    @Element(name = "pICMSInterPart", required = false)
+    private String aliquotaPartilha;
+
+    @Element(name = "vFCPUFFim")
+    private String valorFCP;
+    
+    @Element(name = "vICMSUFFim")
+    private String valorUfDestino;
+    
+    @Element(name = "vICMSUFIni")
+    private String valorUf;
+
+    public CTeOSInfoInformacoesRelativasImpostosICMSPartilha() {
+        this.bcICMS = null;
+        this.aliquotaFCP = null;
+        this.aliquotaInterna = null;
+        this.aliquotaInterestadual = null;
+        this.aliquotaPartilha = null;
+        this.valorFCP = null;
+        this.valorUfDestino = null;
+        this.valorUf = null;
+    }
+
+    public String getBcICMS() {
+        return this.bcICMS;
+    }
+
+    /**
+     * Valor da BC do ICMS na UF de término da prestação do serviço de transporte
+     */
+    public void setBcICMS(final BigDecimal bcICMS) {
+        this.bcICMS = DFBigDecimalValidador.tamanho15Com2CasasDecimais(bcICMS, "Valor da BC do ICMS na UF de término da prestação do serviço de transporte");
+    }
+
+    public String getAliquotaFCP() {
+        return this.aliquotaFCP;
+    }
+
+    /**
+     * Percentual do ICMS relativo ao Fundo de Combate à pobreza (FCP) na UF de término da prestação do serviço de transporte<br>
+     * Alíquota adotada nas operações internas na UF do destinatário
+     */
+    public void setAliquotaFCP(final BigDecimal aliquotaFCP) {
+        this.aliquotaFCP = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaFCP, "Percentual do ICMS relativo ao Fundo de Combate à pobreza (FCP)");
+    }
+
+    public String getAliquotaInterna() {
+        return this.aliquotaInterna;
+    }
+
+    /**
+     * Alíquota interna da UF de término da prestação do serviço de transporte<br>
+     * Alíquota adotada nas operações internas na UF do destinatário
+     */
+    public void setAliquotaInterna(final BigDecimal aliquotaInterna) {
+        this.aliquotaInterna = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaInterna, "Alíquota interna da UF de término da prestação do serviço de transporte");
+    }
+
+    public String getAliquotaInterestadual() {
+        return this.aliquotaInterestadual;
+    }
+
+    /**
+     * Alíquota interestadual das UF envolvidas
+     */
+    public void setAliquotaInterestadual(final BigDecimal aliquotaInterestadual) {
+        this.aliquotaInterestadual = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaInterestadual, "Alíquota interestadual das UF envolvidas");
+    }
+
+    public String getAliquotaPartilha() {
+        return this.aliquotaPartilha;
+    }
+
+    /**
+     * Percentual provisório de partilha entre os estados<br>
+     * Percentual de partilha para a UF do destinatário:<br>
+     * - 40% em 2016;<br>
+     * - 60% em 2017;<br>
+     * - 80% em 2018;<br>
+     * - 100% a partir de 2019.
+     */
+    public void setAliquotaPartilha(final BigDecimal aliquotaPartilha) {
+        this.aliquotaPartilha = DFBigDecimalValidador.tamanho5Com2CasasDecimais(aliquotaPartilha, "Percentual provisório de partilha entre os estados");
+    }
+
+    public String getValorFCP() {
+        return this.valorFCP;
+    }
+
+    /**
+     * Valor do ICMS relativo ao Fundo de Combate á Pobreza (FCP) da UF de término da prestação
+     */
+    public void setValorFCP(final BigDecimal valorFCP) {
+        this.valorFCP = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorFCP, "Valor do ICMS relativo ao Fundo de Combate á Pobreza (FCP)");
+    }
+
+    public String getValorUfDestino() {
+        return this.valorUfDestino;
+    }
+
+    /**
+     * Valor do ICMS de partilha para a UF de término da prestação do serviço de transporte
+     */
+    public void setValorUfDestino(final BigDecimal valorUfDestino) {
+        this.valorUfDestino = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorUfDestino, "Valor do ICMS de partilha para a UF de término da prestação do serviço de transporte");
+    }
+
+    public String getValorUf() {
+        return this.valorUf;
+    }
+
+    /**
+     * Valor do ICMS de partilha para a UF de início da prestação do serviço de transporte
+     */
+    public void setValorUf(final BigDecimal valorUf) {
+        this.valorUf = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorUf, "Valor do ICMS de partilha para a UF de início da prestação do serviço de transporte");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostosICMSSN.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostosICMSSN.java
@@ -1,0 +1,47 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.CTCodigoSituacaoTributariaICMS;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "ICMSSN")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostosICMSSN extends DFBase {
+    
+    @Element(name = "CST")
+    private CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria;
+    
+    @Element(name = "indSN")
+    private String indicadorSN;
+
+    public CTeOSInfoInformacoesRelativasImpostosICMSSN() {
+        this.codigoSituacaoTributaria = null;
+        this.indicadorSN = null;
+    }
+
+    public CTCodigoSituacaoTributariaICMS getCodigoSituacaoTributaria() {
+        return this.codigoSituacaoTributaria;
+    }
+
+    /**
+     * Classificação Tributária do Serviço<br>
+     * 90 - ICMS Simples Nacional
+     */
+    public void setCodigoSituacaoTributaria(final CTCodigoSituacaoTributariaICMS codigoSituacaoTributaria) {
+        this.codigoSituacaoTributaria = codigoSituacaoTributaria;
+    }
+
+    public String getIndicadorSN() {
+        return this.indicadorSN;
+    }
+
+    /**
+     * Indica se o contribuinte é Simples Nacional 1=Sim
+     */
+    public void setIndicadorSN(final String indicadorSN) {
+        this.indicadorSN = indicadorSN;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostosTributosFederais.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoInformacoesRelativasImpostosTributosFederais.java
@@ -1,0 +1,71 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "infTribFed")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoInformacoesRelativasImpostosTributosFederais extends DFBase {
+    private static final long serialVersionUID = -5969100532189710320L;
+
+    @Element(name = "vPIS", required = false)
+    private String valorPIS;
+
+    @Element(name = "vCOFINS", required = false)
+    private String valorCOFINS;
+
+    @Element(name = "vIR", required = false)
+    private String valorIR;
+
+    @Element(name = "vINSS", required = false)
+    private String valorINSS;
+
+    @Element(name = "vCSLL", required = false)
+    private String valorCSLL;
+
+    public String getValorPIS() {
+        return valorPIS;
+    }
+
+    public void setValorPIS(final BigDecimal valorPIS) {
+        this.valorPIS = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorPIS, "Valor PIS");
+    }
+
+    public String getValorCOFINS() {
+        return valorCOFINS;
+    }
+
+    public void setValorCOFINS(final BigDecimal valorCOFINS) {
+        this.valorCOFINS = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorCOFINS, "Valor COFINS");
+    }
+
+    public String getValorIR() {
+        return valorIR;
+    }
+
+    public void setValorIR(final BigDecimal valorIR) {
+        this.valorIR = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorIR, "Valor IR");
+    }
+
+    public String getValorINSS() {
+        return valorINSS;
+    }
+
+    public void setValorINSS(final BigDecimal valorINSS) {
+        this.valorINSS = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorINSS, "Valor INSS");
+    }
+
+    public String getValorCSLL() {
+        return valorCSLL;
+    }
+
+    public void setValorCSLL(final BigDecimal valorCSLL) {
+        this.valorCSLL = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorCSLL, "Valor CSLL");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoResponsavelTecnico.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoResponsavelTecnico.java
@@ -1,0 +1,91 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "infRespTec")
+@Namespace(reference = "http://www.portalfiscal.inf.br/cte")
+public class CTeOSInfoResponsavelTecnico extends DFBase {
+    private static final long serialVersionUID = 2049320360410243067L;
+
+    @Element(name = "CNPJ")
+    private String cnpj;
+
+    @Element(name = "xContato")
+    private String contatoNome;
+
+    @Element(name = "email")
+    private String email;
+
+    @Element(name = "fone")
+    private String telefone;
+
+    @Element(name = "idCSRT", required = false)
+    private String idCSRT;
+
+    @Element(name = "hashCSRT", required = false)
+    private String hashCSRT;
+
+    public String getCnpj() {
+        return cnpj;
+    }
+
+    public CTeOSInfoResponsavelTecnico setCnpj(String cnpj) {
+        DFStringValidador.cnpj(cnpj);
+        this.cnpj = cnpj;
+        return this;
+    }
+
+    public String getContatoNome() {
+        return contatoNome;
+    }
+
+    public CTeOSInfoResponsavelTecnico setContatoNome(String contatoNome) {
+        DFStringValidador.tamanho2ate60(contatoNome, "Responsavel tecnico");
+        this.contatoNome = contatoNome;
+        return this;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public CTeOSInfoResponsavelTecnico setEmail(String email) {
+        DFStringValidador.email(email, "Responsavel tecnico ");
+        DFStringValidador.validaIntervalo(email, 6, 60, "Responsavel tecnico");
+        this.email = email;
+        return this;
+    }
+
+    public String getTelefone() {
+        return telefone;
+    }
+
+    public CTeOSInfoResponsavelTecnico setTelefone(String telefone) {
+        DFStringValidador.telefone(telefone, "Responsavel tecnico");
+        this.telefone = telefone;
+        return this;
+    }
+
+    public String getIdCSRT() {
+        return idCSRT;
+    }
+
+    public void setIdCSRT(String idCSRT) {
+        DFStringValidador.exatamente2N(idCSRT, "Responsavel tecnico");
+        this.idCSRT = idCSRT;
+    }
+
+    public String getHashCSRT() {
+        return hashCSRT;
+    }
+
+    public void setHashCSRT(String hashCSRT) {
+        DFStringValidador.isBase64(hashCSRT, "HASH CSRT em Responsavel tecnico");
+        this.hashCSRT = hashCSRT;
+    }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoSuplementares.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoSuplementares.java
@@ -1,0 +1,25 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "infCTeSupl")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoSuplementares extends DFBase {
+    private static final long serialVersionUID = 5643192963806193737L;
+
+    @Element(name = "qrCodCTe")
+    private String qrCode;
+
+    public String getQrCode() {
+        return qrCode;
+    }
+
+    public CTeOSInfoSuplementares setQrCode(String qrCode) {
+        this.qrCode = qrCode;
+        return this;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoValorPrestacaoServico.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoValorPrestacaoServico.java
@@ -1,0 +1,61 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+@Root(name = "vPrest")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoValorPrestacaoServico extends DFBase {
+    private static final long serialVersionUID = -5913703822180633261L;
+    
+    @Element(name = "vTPrest")
+    private String valorTotalPrestacaoServico;
+    
+    @Element(name = "vRec")
+    private String valorReceber;
+
+    @ElementList(name = "Comp", inline = true, required = false)
+    private List<CTeOSInfoValorPrestacaoServicoComponentesValorPrestacao> componentesValorPrestacao;
+
+    public String getValorTotalPrestacaoServico() {
+        return this.valorTotalPrestacaoServico;
+    }
+
+    /**
+     * Valor Total da Prestação do Serviço<br>
+     * Pode conter zeros quando o CT-e for de complemento de ICMS
+     */
+    public void setValorTotalPrestacaoServico(final BigDecimal valorTotalPrestacaoServico) {
+        this.valorTotalPrestacaoServico = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorTotalPrestacaoServico, "Valor Total da Prestação do Serviço");
+    }
+
+    public String getValorReceber() {
+        return this.valorReceber;
+    }
+
+    /**
+     * Valor a Receber
+     */
+    public void setValorReceber(final BigDecimal valorReceber) {
+        this.valorReceber = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorReceber, "Valor a Receber");
+    }
+
+    public List<CTeOSInfoValorPrestacaoServicoComponentesValorPrestacao> getComponentesValorPrestacao() {
+        return this.componentesValorPrestacao;
+    }
+
+    /**
+     * Componentes do Valor da Prestação
+     */
+    public void setComponentesValorPrestacao(final List<CTeOSInfoValorPrestacaoServicoComponentesValorPrestacao> componentesValorPrestacao) {
+        this.componentesValorPrestacao = componentesValorPrestacao;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoValorPrestacaoServicoComponentesValorPrestacao.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSInfoValorPrestacaoServicoComponentesValorPrestacao.java
@@ -1,0 +1,47 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+@Root(name = "Comp")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSInfoValorPrestacaoServicoComponentesValorPrestacao extends DFBase {
+    private static final long serialVersionUID = 8206239265618792602L;
+
+    @Element(name = "xNome")
+    private String nomeComponente;
+
+    @Element(name = "vComp")
+    private String valorComponente;
+
+    public String getNomeComponente() {
+        return this.nomeComponente;
+    }
+
+    /**
+     * Nome do componente<br>
+     * Exemplos: FRETE PESO, FRETE VALOR, SEC/CAT, ADEME, AGENDAMENTO, etc
+     */
+    public void setNomeComponente(final String nomeComponente) {
+        DFStringValidador.tamanho15(nomeComponente, "Nome do componente");
+        this.nomeComponente = nomeComponente;
+    }
+
+    public String getValorComponente() {
+        return this.valorComponente;
+    }
+
+    /**
+     * Valor do componente
+     */
+    public void setValorComponente(final BigDecimal valorComponente) {
+        this.valorComponente = DFBigDecimalValidador.tamanho15Com2CasasDecimais(valorComponente, "Valor do componente");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSProcessado.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/os/CTeOSProcessado.java
@@ -1,0 +1,62 @@
+package com.fincatto.documentofiscal.cte400.classes.os;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.envio.CTeProtocolo;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "cteOSProc")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeOSProcessado extends DFBase {
+    private static final long serialVersionUID = 137030186528448628L;
+
+    /**
+     * Tipo IP versão 4
+     */
+    @Attribute(name = "ipTransmissor", required = false)
+    private String ipTransmissor;
+
+    @Attribute(name = "versao")
+    private String versao;
+
+    @Element(name = "CTeOS")
+    private CTeOS cte;
+
+    @Element(name = "protCTe")
+    private CTeProtocolo protocolo;
+
+    public String getIpTransmissor() {
+        return this.ipTransmissor;
+    }
+
+    public void setIpTransmissor(final String ipTransmissor) {
+        this.ipTransmissor = ipTransmissor;
+    }
+
+    public String getVersao() {
+        return this.versao;
+    }
+
+    public void setVersao(final String versao) {
+        this.versao = versao;
+    }
+
+    public CTeOS getCte() {
+        return this.cte;
+    }
+
+    public void setCte(final CTeOS cte) {
+        this.cte = cte;
+    }
+
+    public CTeProtocolo getProtocolo() {
+        return this.protocolo;
+    }
+
+    public void setProtocolo(final CTeProtocolo protocolo) {
+        this.protocolo = protocolo;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/transformers/CTResponsavelSeguroTransformer.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/transformers/CTResponsavelSeguroTransformer.java
@@ -1,0 +1,18 @@
+package com.fincatto.documentofiscal.cte400.transformers;
+
+import com.fincatto.documentofiscal.cte400.classes.CTResponsavelSeguro;
+import org.simpleframework.xml.transform.Transform;
+
+public class CTResponsavelSeguroTransformer implements Transform<CTResponsavelSeguro> {
+
+    @Override
+    public CTResponsavelSeguro read(final String codigo) {
+        return CTResponsavelSeguro.valueOfCodigo(codigo);
+    }
+
+    @Override
+    public String write(final CTResponsavelSeguro tipo) {
+        return tipo.getCodigo();
+    }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/transformers/CTTipoFretamentoTransformer.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/transformers/CTTipoFretamentoTransformer.java
@@ -1,0 +1,18 @@
+package com.fincatto.documentofiscal.cte400.transformers;
+
+import com.fincatto.documentofiscal.cte400.classes.CTTipoFretamento;
+import org.simpleframework.xml.transform.Transform;
+
+public class CTTipoFretamentoTransformer implements Transform<CTTipoFretamento> {
+
+    @Override
+    public CTTipoFretamento read(final String codigo) {
+        return CTTipoFretamento.valueOfCodigo(codigo);
+    }
+
+    @Override
+    public String write(final CTTipoFretamento tipo) {
+        return tipo.getCodigo();
+    }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/transformers/CTTipoProprietarioTransformer.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/transformers/CTTipoProprietarioTransformer.java
@@ -1,0 +1,18 @@
+package com.fincatto.documentofiscal.cte400.transformers;
+
+import com.fincatto.documentofiscal.cte400.classes.CTTipoProprietario;
+import org.simpleframework.xml.transform.Transform;
+
+public class CTTipoProprietarioTransformer implements Transform<CTTipoProprietario> {
+
+    @Override
+    public CTTipoProprietario read(final String codigo) {
+        return CTTipoProprietario.valueOfCodigo(codigo);
+    }
+
+    @Override
+    public String write(final CTTipoProprietario tipo) {
+        return tipo.getCodigo();
+    }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/transformers/CTTipoServicoOSTransformer.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/transformers/CTTipoServicoOSTransformer.java
@@ -1,0 +1,18 @@
+package com.fincatto.documentofiscal.cte400.transformers;
+
+import com.fincatto.documentofiscal.cte400.classes.CTTipoServicoOS;
+import org.simpleframework.xml.transform.Transform;
+
+public class CTTipoServicoOSTransformer implements Transform<CTTipoServicoOS> {
+
+    @Override
+    public CTTipoServicoOS read(final String codigo) {
+        return CTTipoServicoOS.valueOfCodigo(codigo);
+    }
+
+    @Override
+    public String write(final CTTipoServicoOS tipo) {
+        return tipo.getCodigo();
+    }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/transformers/CTipoComponenteGTVeTransformer.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/transformers/CTipoComponenteGTVeTransformer.java
@@ -1,0 +1,18 @@
+package com.fincatto.documentofiscal.cte400.transformers;
+
+import com.fincatto.documentofiscal.cte400.classes.CTipoComponenteGTVe;
+import org.simpleframework.xml.transform.Transform;
+
+public class CTipoComponenteGTVeTransformer implements Transform<CTipoComponenteGTVe> {
+
+    @Override
+    public CTipoComponenteGTVe read(final String codigo) {
+        return CTipoComponenteGTVe.valueOfCodigo(codigo);
+    }
+
+    @Override
+    public String write(final CTipoComponenteGTVe tipo) {
+        return tipo.getCodigo();
+    }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSCancelamento.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSCancelamento.java
@@ -1,5 +1,6 @@
 package com.fincatto.documentofiscal.cte400.webservices;
 
+import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEventoRetorno;
@@ -9,14 +10,16 @@ import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 class WSCancelamento extends WSRecepcaoEvento {
     private static final String DESCRICAO_EVENTO = "Cancelamento";
     private static final BigDecimal VERSAO_LEIAUTE = new BigDecimal("4.00");
     private static final String EVENTO_CANCELAMENTO = "110111";
+    private static final List<DFModelo> modelosPermitidos = List.of(DFModelo.CTE, DFModelo.CTeOS);
     
     WSCancelamento(final CTeConfig config) {
-        super(config);
+        super(config, modelosPermitidos);
     }
     
     CTeEventoRetorno cancelaNotaAssinada(final String chaveAcesso, final String eventoAssinadoXml) throws Exception {

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSCancelamentoComprovanteEntrega.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSCancelamentoComprovanteEntrega.java
@@ -1,5 +1,6 @@
 package com.fincatto.documentofiscal.cte400.webservices;
 
+import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEventoRetorno;
@@ -9,14 +10,16 @@ import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 class WSCancelamentoComprovanteEntrega extends WSRecepcaoEvento {
     private static final String DESCRICAO_EVENTO = "Cancelamento do Comprovante de Entrega do CT-e";
     private static final BigDecimal VERSAO_LEIAUTE = new BigDecimal("4.00");
     private static final String EVENTO_COMPROVANTE_DE_ENTREGA = "110181";
+    private static final List<DFModelo> modelosPermitidos = List.of(DFModelo.CTE);
 
     WSCancelamentoComprovanteEntrega(final CTeConfig config) {
-        super(config);
+        super(config, modelosPermitidos);
     }
 
     CTeEventoRetorno cancelaComprovanteEntregaAssinado(final String chaveAcesso, final String eventoAssinadoXml) throws Exception {

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSCancelamentoInsucessoEntrega.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSCancelamentoInsucessoEntrega.java
@@ -1,5 +1,6 @@
 package com.fincatto.documentofiscal.cte400.webservices;
 
+import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEventoRetorno;
@@ -9,14 +10,16 @@ import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 class WSCancelamentoInsucessoEntrega extends WSRecepcaoEvento {
     private static final String DESCRICAO_EVENTO = "Cancelamento do Insucesso de Entrega do CT-e";
     private static final BigDecimal VERSAO_LEIAUTE = new BigDecimal("4.00");
     private static final String EVENTO_CANCELAMENTO_INSUCESSO_DE_ENTREGA = "110191";
+    private static final List<DFModelo> modelosPermitidos = List.of(DFModelo.CTE);
 
     WSCancelamentoInsucessoEntrega(final CTeConfig config) {
-        super(config);
+        super(config, modelosPermitidos);
     }
 
     CTeEventoRetorno cancelaInsucessoEntregaAssinado(final String chaveAcesso, final String eventoAssinadoXml) throws Exception {

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSCancelamentoPrestacaoEmDesacordo.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSCancelamentoPrestacaoEmDesacordo.java
@@ -1,5 +1,6 @@
 package com.fincatto.documentofiscal.cte400.webservices;
 
+import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEventoRetorno;
@@ -9,14 +10,16 @@ import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 class WSCancelamentoPrestacaoEmDesacordo extends WSRecepcaoEvento {
     private static final String DESCRICAO_EVENTO = "Cancelamento Prestacao do Servico em Desacordo";
     private static final BigDecimal VERSAO_LEIAUTE = new BigDecimal("4.00");
     private static final String EVENTO_CANCELAMENTO_DESACORDO = "610111";
+    private static final List<DFModelo> modelosPermitidos = List.of(DFModelo.CTE, DFModelo.CTeOS);
 
     WSCancelamentoPrestacaoEmDesacordo(final CTeConfig config) {
-        super(config);
+        super(config, modelosPermitidos);
     }
 
     CTeEventoRetorno cancelaPrestacaoEmDesacordoAssinado(final String chaveAcesso, final String eventoAssinadoXml) throws Exception {

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSCartaCorrecao.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSCartaCorrecao.java
@@ -1,5 +1,6 @@
 package com.fincatto.documentofiscal.cte400.webservices;
 
+import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEventoRetorno;
@@ -16,9 +17,10 @@ class WSCartaCorrecao extends WSRecepcaoEvento {
     private static final String DESCRICAO_EVENTO = "Carta de Correcao";
     private static final BigDecimal VERSAO_LEIAUTE = new BigDecimal("4.00");
     private static final String EVENTO_CARTA_DE_CORRECAO = "110110";
+    private static final List<DFModelo> modelosPermitidos = List.of(DFModelo.CTE, DFModelo.CTeOS);
 
     WSCartaCorrecao(final CTeConfig config) {
-        super(config);
+        super(config, modelosPermitidos);
     }
 
     CTeEventoRetorno corrigeNotaAssinada(final String chaveAcesso, final String eventoAssinadoXml) throws Exception {

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSComprovanteEntrega.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSComprovanteEntrega.java
@@ -1,5 +1,6 @@
 package com.fincatto.documentofiscal.cte400.webservices;
 
+import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEventoRetorno;
@@ -9,14 +10,16 @@ import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 class WSComprovanteEntrega extends WSRecepcaoEvento {
     private static final String DESCRICAO_EVENTO = "Comprovante de Entrega do CT-e";
     private static final BigDecimal VERSAO_LEIAUTE = new BigDecimal("4.00");
     private static final String EVENTO_COMPROVANTE_DE_ENTREGA = "110180";
+    private static final List<DFModelo> modelosPermitidos = List.of(DFModelo.CTE);
 
     WSComprovanteEntrega(final CTeConfig config) {
-        super(config);
+        super(config, modelosPermitidos);
     }
 
     CTeEventoRetorno comprovanteEntregaAssinado(final String chaveAcesso, final String eventoAssinadoXml) throws Exception {

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSEpec.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSEpec.java
@@ -1,5 +1,6 @@
 package com.fincatto.documentofiscal.cte400.webservices;
 
+import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEventoRetorno;
@@ -9,14 +10,16 @@ import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 class WSEpec extends WSRecepcaoEvento {
     private static final String DESCRICAO_EVENTO = "EPEC";
     private static final BigDecimal VERSAO_LEIAUTE = new BigDecimal("4.00");
     private static final String EVENTO_EPEC = "110113";
+    private static final List<DFModelo> modelosPermitidos = List.of(DFModelo.CTE);
 
     WSEpec(final CTeConfig config) {
-        super(config);
+        super(config, modelosPermitidos);
     }
     
     CTeEventoRetorno enviaEpecAssinado(final String chaveAcesso, final String eventoAssinadoXml) throws Exception {

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSFacade.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSFacade.java
@@ -6,6 +6,7 @@ import com.fincatto.documentofiscal.cte.classes.distribuicao.CTDistribuicaoIntRe
 import com.fincatto.documentofiscal.cte.webservices.distribuicao.WSDistribuicaoCTe;
 import com.fincatto.documentofiscal.cte400.classes.consultastatusservico.CTeConsStatServRet;
 import com.fincatto.documentofiscal.cte400.classes.envio.CTeEnvioRetornoDados;
+import com.fincatto.documentofiscal.cte400.classes.envio.CTeOSEnvioRetornoDados;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEventoRetorno;
 import com.fincatto.documentofiscal.cte400.classes.evento.cartacorrecao.CTeInformacaoCartaCorrecao;
 import com.fincatto.documentofiscal.cte400.classes.evento.comprovanteentrega.CTeEnviaEventoComprovanteEntrega;
@@ -14,6 +15,7 @@ import com.fincatto.documentofiscal.cte400.classes.evento.gtv.CTeEnviaEventoGtv;
 import com.fincatto.documentofiscal.cte400.classes.evento.insucessoentrega.CTeEnviaEventoInsucessoEntrega;
 import com.fincatto.documentofiscal.cte400.classes.nota.CTeNota;
 import com.fincatto.documentofiscal.cte400.classes.nota.consulta.CTeNotaConsultaRetorno;
+import com.fincatto.documentofiscal.cte400.classes.os.CTeOS;
 import com.fincatto.documentofiscal.utils.DFSocketFactory;
 import org.apache.commons.httpclient.protocol.Protocol;
 
@@ -42,6 +44,7 @@ public class WSFacade {
     private final WSCancelamentoPrestacaoEmDesacordo wsCancelamentoPrestacaoEmDesacordo;
     private final WSInsucessoEntrega wsInsucessoEntrega;
     private final WSCancelamentoInsucessoEntrega wsCancelamentoInsucessoEntrega;
+    private final WSRecepcaoCTeOS wsRecepcaoCTeOS;
 
     public WSFacade(final CTeConfig config) throws IOException, KeyManagementException, UnrecoverableKeyException, KeyStoreException, NoSuchAlgorithmException, CertificateException {
         Protocol.registerProtocol("https", new Protocol("https", new DFSocketFactory(config), 443));
@@ -60,6 +63,7 @@ public class WSFacade {
         this.wsCancelamentoPrestacaoEmDesacordo = new WSCancelamentoPrestacaoEmDesacordo(config);
         this.wsInsucessoEntrega = new WSInsucessoEntrega(config);
         this.wsCancelamentoInsucessoEntrega = new WSCancelamentoInsucessoEntrega(config);
+        this.wsRecepcaoCTeOS = new WSRecepcaoCTeOS(config);
     }
 
     /**
@@ -552,6 +556,17 @@ public class WSFacade {
      */
     public String getXmlAssinadoInsucessoEntrega(final String chave, final CTeEnviaEventoInsucessoEntrega insucessoEntrega, final int sequencialEvento) throws Exception {
         return this.wsInsucessoEntrega.getXmlAssinado(chave, insucessoEntrega, sequencialEvento);
+    }
+
+    /**
+     * Faz o envio do CT-e de Outros Serviços para a SEFAZ.
+     *
+     * @param cteOS a ser eviado para a SEFAZ
+     * @return dados do retorno do envio do CT-e OS e o xml assinado
+     * @throws Exception caso nao consiga gerar o xml ou problema de conexao com o sefaz
+     * */
+    public CTeOSEnvioRetornoDados envioRecepcaoLote(CTeOS cteOS) throws Exception {
+        return this.wsRecepcaoCTeOS.enviaCTe(cteOS);
     }
 
 }

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSGtv.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSGtv.java
@@ -1,5 +1,6 @@
 package com.fincatto.documentofiscal.cte400.webservices;
 
+import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEventoRetorno;
@@ -9,14 +10,16 @@ import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 class WSGtv extends WSRecepcaoEvento {
     private static final String DESCRICAO_EVENTO = "Informacoes da GTV";
     private static final BigDecimal VERSAO_LEIAUTE = new BigDecimal("4.00");
     private static final String EVENTO_GTV = "110170";
+    private static final List<DFModelo> modelosPermitidos = List.of(DFModelo.CTeOS);
 
     WSGtv(final CTeConfig config) {
-        super(config);
+        super(config, modelosPermitidos);
     }
     
     CTeEventoRetorno enviaGtvAssinada(final String chaveAcesso, final String eventoAssinadoXml) throws Exception {

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSInsucessoEntrega.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSInsucessoEntrega.java
@@ -1,5 +1,6 @@
 package com.fincatto.documentofiscal.cte400.webservices;
 
+import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEventoRetorno;
@@ -9,14 +10,16 @@ import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 class WSInsucessoEntrega extends WSRecepcaoEvento {
     private static final String DESCRICAO_EVENTO = "Insucesso na Entrega do CT-e";
     private static final BigDecimal VERSAO_LEIAUTE = new BigDecimal("4.00");
     private static final String EVENTO_INSUCESSO_DE_ENTREGA = "110190";
+    private static final List<DFModelo> modelosPermitidos = List.of(DFModelo.CTE);
 
     WSInsucessoEntrega(final CTeConfig config) {
-        super(config);
+        super(config, modelosPermitidos);
     }
 
     CTeEventoRetorno insucessoEntregaAssinado(final String chaveAcesso, final String eventoAssinadoXml) throws Exception {

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSPrestacaoEmDesacordo.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSPrestacaoEmDesacordo.java
@@ -1,5 +1,6 @@
 package com.fincatto.documentofiscal.cte400.webservices;
 
+import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEventoRetorno;
@@ -9,14 +10,16 @@ import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 class WSPrestacaoEmDesacordo extends WSRecepcaoEvento {
     private static final String DESCRICAO_EVENTO = "Prestacao do Servico em Desacordo";
     private static final BigDecimal VERSAO_LEIAUTE = new BigDecimal("4.00");
     private static final String EVENTO_SERVICO_EM_DESACORDO = "610110";
+    private static final List<DFModelo> modelosPermitidos = List.of(DFModelo.CTE, DFModelo.CTeOS);
 
     WSPrestacaoEmDesacordo(final CTeConfig config) {
-        super(config);
+        super(config, modelosPermitidos);
     }
 
     CTeEventoRetorno prestacaoEmDesacordoAssinada(final String chaveAcesso, final String eventoAssinadoXml) throws Exception {

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSRecepcaoCTeOS.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSRecepcaoCTeOS.java
@@ -1,0 +1,58 @@
+package com.fincatto.documentofiscal.cte400.webservices;
+
+import com.fincatto.documentofiscal.DFLog;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.CTAutorizador400;
+import com.fincatto.documentofiscal.cte400.classes.envio.CTeOSEnvioRetorno;
+import com.fincatto.documentofiscal.cte400.classes.envio.CTeOSEnvioRetornoDados;
+import com.fincatto.documentofiscal.cte400.classes.os.CTeOS;
+import com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoOSV4Stub;
+import com.fincatto.documentofiscal.utils.DFAssinaturaDigital;
+import com.fincatto.documentofiscal.validadores.DFXMLValidador;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.zip.GZIPOutputStream;
+
+class WSRecepcaoCTeOS implements DFLog {
+    private final CTeConfig config;
+
+    WSRecepcaoCTeOS(final CTeConfig config) {
+        this.config = config;
+    }
+    
+    public CTeOSEnvioRetornoDados enviaCTe(CTeOS cteOS) throws Exception {
+        final String documentoAssinado = new DFAssinaturaDigital(this.config).assinarDocumento(cteOS.toString(), "infCte");
+        final CTeOS cteAssinado = this.config.getPersister().read(CTeOS.class, documentoAssinado);
+
+        final CTeOSEnvioRetorno retorno = comunicaLote(documentoAssinado);
+        return new CTeOSEnvioRetornoDados(retorno, cteAssinado);
+    }
+    
+    private CTeOSEnvioRetorno comunicaLote(final String cteAssinadoXml) throws Exception {
+        DFXMLValidador.validaNotaCTeOS400(cteAssinadoXml);
+
+        String conteudoCompactado;
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
+             try (GZIPOutputStream gzipOutputStream = new GZIPOutputStream(byteArrayOutputStream)) {
+                 gzipOutputStream.write(cteAssinadoXml.getBytes(StandardCharsets.UTF_8));
+             }
+            conteudoCompactado = Base64.getEncoder().encodeToString(byteArrayOutputStream.toByteArray());
+        }
+
+        final CTeRecepcaoOSV4Stub.CteDadosMsg dados = new CTeRecepcaoOSV4Stub.CteDadosMsg();
+        dados.setCteDadosMsg(conteudoCompactado);
+
+        final CTAutorizador400 autorizador = CTAutorizador400.valueOfTipoEmissao(this.config.getTipoEmissao(), this.config.getCUF());
+        final String endpoint = autorizador.getCteRecepcaoSinc(this.config.getAmbiente());
+        if (endpoint == null) {
+            throw new IllegalArgumentException("Nao foi possivel encontrar URL para Recepcao OS, autorizador " + autorizador.name() + ", UF " + this.config.getCUF().name());
+        }
+        final CTeRecepcaoOSV4Stub.CteRecepcaoOSResult autorizacaoLoteResult = new CTeRecepcaoOSV4Stub(endpoint, config).cteRecepcaoOS(dados);
+        final CTeOSEnvioRetorno retorno = this.config.getPersister().read(CTeOSEnvioRetorno.class, autorizacaoLoteResult.getExtraElement().toString());
+        this.getLogger().debug(retorno.toString());
+        return retorno;
+    }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSRecepcaoEvento.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSRecepcaoEvento.java
@@ -1,6 +1,7 @@
 package com.fincatto.documentofiscal.cte400.webservices;
 
 import com.fincatto.documentofiscal.DFLog;
+import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte400.classes.CTAutorizador400;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeDetalhamentoEvento;
@@ -15,13 +16,16 @@ import org.apache.axiom.om.util.AXIOMUtil;
 
 import java.math.BigDecimal;
 import java.time.ZonedDateTime;
+import java.util.List;
 
 abstract class WSRecepcaoEvento implements DFLog {
 
     protected final CTeConfig config;
+    private final List<DFModelo> modelosPermitidos;
 
-    WSRecepcaoEvento(CTeConfig config) {
+    WSRecepcaoEvento(CTeConfig config, List<DFModelo> modelosPermitidos) {
         this.config = config;
+        this.modelosPermitidos = modelosPermitidos;
     }
 
     protected OMElement efetuaEvento(final String xmlAssinado, final String chaveAcesso, final BigDecimal versao) throws Exception {
@@ -33,9 +37,13 @@ abstract class WSRecepcaoEvento implements DFLog {
     }
 
     protected OMElement efetuaEvento(final String xmlAssinado, final String chaveAcesso, final BigDecimal versao, final boolean contingencia) throws Exception {
+        final CTChaveParser ctChaveParser = new CTChaveParser(chaveAcesso);
+        if (!modelosPermitidos.contains(ctChaveParser.getModelo())) {
+            throw new IllegalArgumentException("CT-e do modelo \"" + ctChaveParser.getModelo().toString() + "\" não é permitido nesse evento.");
+        }
+
         DFXMLValidador.validaEventoCTe400(xmlAssinado);
 
-        final CTChaveParser ctChaveParser = new CTChaveParser(chaveAcesso);
         final CTeRecepcaoEventoV4Stub.CteDadosMsg dados = new CTeRecepcaoEventoV4Stub.CteDadosMsg();
 
         final OMElement omElementXML = AXIOMUtil.stringToOM(xmlAssinado);

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSRegistroMultimodal.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSRegistroMultimodal.java
@@ -1,5 +1,6 @@
 package com.fincatto.documentofiscal.cte400.webservices;
 
+import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.cte.CTeConfig;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEvento;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEventoRetorno;
@@ -9,14 +10,16 @@ import com.fincatto.documentofiscal.validadores.DFXMLValidador;
 import org.apache.axiom.om.OMElement;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 class WSRegistroMultimodal extends WSRecepcaoEvento {
     private static final String DESCRICAO_EVENTO = "Registro Multimodal";
     private static final BigDecimal VERSAO_LEIAUTE = new BigDecimal("4.00");
     private static final String EVENTO_REGISTRO_MULTIMODAL = "110160";
+    private static final List<DFModelo> modelosPermitidos = List.of(DFModelo.CTE);
 
     WSRegistroMultimodal(final CTeConfig config) {
-        super(config);
+        super(config, modelosPermitidos);
     }
 
     CTeEventoRetorno registroMultimodalAssinado(final String chaveAcesso, final String eventoAssinadoXml) throws Exception {

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/gerado/CTeRecepcaoOSV4Stub.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/gerado/CTeRecepcaoOSV4Stub.java
@@ -1,0 +1,1115 @@
+/**
+ * CTeRecepcaoOSV4Stub.java
+ *
+ * This file was auto-generated from WSDL
+ * by the Apache Axis2 version: 1.6.4  Built on : Dec 28, 2015 (10:03:39 GMT)
+ */
+package com.fincatto.documentofiscal.cte400.webservices.gerado;
+
+
+import com.fincatto.documentofiscal.DFConfig;
+import com.fincatto.documentofiscal.utils.MessageContextFactory;
+
+/*
+ *  CTeRecepcaoOSV4Stub java implementation
+ */
+public class CTeRecepcaoOSV4Stub extends org.apache.axis2.client.Stub {
+    private static int counter = 0;
+    protected org.apache.axis2.description.AxisOperation[] _operations;
+
+    //hashmaps to keep the fault mapping
+    private java.util.HashMap faultExceptionNameMap = new java.util.HashMap();
+    private java.util.HashMap faultExceptionClassNameMap = new java.util.HashMap();
+    private java.util.HashMap faultMessageMap = new java.util.HashMap();
+    private javax.xml.namespace.QName[] opNameArray = null;
+    private final DFConfig config;
+
+    /**
+     *Constructor that takes in a configContext
+     */
+    public CTeRecepcaoOSV4Stub(
+        org.apache.axis2.context.ConfigurationContext configurationContext,
+        java.lang.String targetEndpoint, DFConfig config) throws org.apache.axis2.AxisFault {
+        this(configurationContext, targetEndpoint, false, config);
+    }
+
+    /**
+     * Constructor that takes in a configContext  and useseperate listner
+     */
+    public CTeRecepcaoOSV4Stub(
+        org.apache.axis2.context.ConfigurationContext configurationContext,
+        java.lang.String targetEndpoint, boolean useSeparateListener, DFConfig config)
+        throws org.apache.axis2.AxisFault {
+        //To populate AxisService
+        populateAxisService();
+        populateFaults();
+
+        _serviceClient = new org.apache.axis2.client.ServiceClient(configurationContext,
+                _service);
+
+        _serviceClient.getOptions()
+                      .setTo(new org.apache.axis2.addressing.EndpointReference(
+                targetEndpoint));
+        _serviceClient.getOptions().setUseSeparateListener(useSeparateListener);
+
+        //Set the soap version
+        _serviceClient.getOptions()
+                      .setSoapVersionURI(org.apache.axiom.soap.SOAP12Constants.SOAP_ENVELOPE_NAMESPACE_URI);
+        this.config = config;
+    }
+
+    /**
+     * Constructor taking the target endpoint
+     */
+    public CTeRecepcaoOSV4Stub(java.lang.String targetEndpoint, DFConfig config)
+        throws org.apache.axis2.AxisFault {
+        this(null, targetEndpoint, config);
+    }
+
+    private static synchronized java.lang.String getUniqueSuffix() {
+        // reset the counter if it is greater than 99999
+        if (counter > 99999) {
+            counter = 0;
+        }
+
+        counter = counter + 1;
+
+        return java.lang.Long.toString(java.lang.System.currentTimeMillis()) +
+        "_" + counter;
+    }
+
+    private void populateAxisService() throws org.apache.axis2.AxisFault {
+        //creating the Service with a unique name
+        _service = new org.apache.axis2.description.AxisService(
+                "CTeRecepcaoOSV4" + getUniqueSuffix());
+        addAnonymousOperations();
+
+        //creating the operations
+        org.apache.axis2.description.AxisOperation __operation;
+
+        _operations = new org.apache.axis2.description.AxisOperation[1];
+
+        __operation = new org.apache.axis2.description.OutInAxisOperation();
+
+        __operation.setName(new javax.xml.namespace.QName(
+                "http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoOSV4",
+                "cteRecepcaoOS"));
+        _service.addOperation(__operation);
+
+        _operations[0] = __operation;
+    }
+
+    //populates the faults
+    private void populateFaults() {
+    }
+
+    /**
+     * Auto generated method signature
+     *
+     * @see com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoOSV4#cteRecepcaoOS
+     * @param cteDadosMsg
+     */
+    public com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoOSV4Stub.CteRecepcaoOSResult cteRecepcaoOS(
+        com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoOSV4Stub.CteDadosMsg cteDadosMsg)
+        throws java.rmi.RemoteException {
+        org.apache.axis2.context.MessageContext _messageContext = null;
+
+        try {
+            org.apache.axis2.client.OperationClient _operationClient = _serviceClient.createClient(_operations[0].getName());
+            _operationClient.getOptions()
+                            .setAction("http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoOSV4/cteRecepcaoOS");
+            _operationClient.getOptions().setExceptionToBeThrownOnSOAPFault(true);
+
+            addPropertyToOperationClient(_operationClient,
+                org.apache.axis2.description.WSDL2Constants.ATTR_WHTTP_QUERY_PARAMETER_SEPARATOR,
+                "&");
+
+            // create a message context
+            _messageContext = MessageContextFactory.INSTANCE.create(config);
+
+            // create SOAP envelope with that payload
+            org.apache.axiom.soap.SOAPEnvelope env = null;
+
+            env = toEnvelope(getFactory(_operationClient.getOptions()
+                                                        .getSoapVersionURI()),
+                    cteDadosMsg,
+                    optimizeContent(
+                        new javax.xml.namespace.QName(
+                            "http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoOSV4",
+                            "cteRecepcaoOS")),
+                    new javax.xml.namespace.QName(
+                        "http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoOSV4",
+                        "cteRecepcaoOS"));
+
+            //adding SOAP soap_headers
+            _serviceClient.addHeadersToEnvelope(env);
+            // set the message context with that soap envelope
+            _messageContext.setEnvelope(env);
+
+            // add the message contxt to the operation client
+            _operationClient.addMessageContext(_messageContext);
+
+            //execute the operation client
+            _operationClient.execute(true);
+
+            org.apache.axis2.context.MessageContext _returnMessageContext = _operationClient.getMessageContext(org.apache.axis2.wsdl.WSDLConstants.MESSAGE_LABEL_IN_VALUE);
+            org.apache.axiom.soap.SOAPEnvelope _returnEnv = _returnMessageContext.getEnvelope();
+
+            java.lang.Object object = fromOM(_returnEnv.getBody()
+                                                       .getFirstElement(),
+                    com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoOSV4Stub.CteRecepcaoOSResult.class,
+                    getEnvelopeNamespaces(_returnEnv));
+
+            return (com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoOSV4Stub.CteRecepcaoOSResult) object;
+        } catch (org.apache.axis2.AxisFault f) {
+            org.apache.axiom.om.OMElement faultElt = f.getDetail();
+
+            if (faultElt != null) {
+                if (faultExceptionNameMap.containsKey(
+                            new org.apache.axis2.client.FaultMapKey(
+                                faultElt.getQName(), "cteRecepcaoOS"))) {
+                    //make the fault by reflection
+                    try {
+                        java.lang.String exceptionClassName = (java.lang.String) faultExceptionClassNameMap.get(new org.apache.axis2.client.FaultMapKey(
+                                    faultElt.getQName(), "cteRecepcaoOS"));
+                        java.lang.Class exceptionClass = java.lang.Class.forName(exceptionClassName);
+                        java.lang.reflect.Constructor constructor = exceptionClass.getConstructor(java.lang.String.class);
+                        java.lang.Exception ex = (java.lang.Exception) constructor.newInstance(f.getMessage());
+
+                        //message class
+                        java.lang.String messageClassName = (java.lang.String) faultMessageMap.get(new org.apache.axis2.client.FaultMapKey(
+                                    faultElt.getQName(), "cteRecepcaoOS"));
+                        java.lang.Class messageClass = java.lang.Class.forName(messageClassName);
+                        java.lang.Object messageObject = fromOM(faultElt,
+                                messageClass, null);
+                        java.lang.reflect.Method m = exceptionClass.getMethod("setFaultMessage",
+                                new java.lang.Class[] { messageClass });
+                        m.invoke(ex, new java.lang.Object[] { messageObject });
+
+                        throw new java.rmi.RemoteException(ex.getMessage(), ex);
+                    } catch (java.lang.ClassCastException e) {
+                        // we cannot intantiate the class - throw the original Axis fault
+                        throw f;
+                    } catch (java.lang.ClassNotFoundException e) {
+                        // we cannot intantiate the class - throw the original Axis fault
+                        throw f;
+                    } catch (java.lang.NoSuchMethodException e) {
+                        // we cannot intantiate the class - throw the original Axis fault
+                        throw f;
+                    } catch (java.lang.reflect.InvocationTargetException e) {
+                        // we cannot intantiate the class - throw the original Axis fault
+                        throw f;
+                    } catch (java.lang.IllegalAccessException e) {
+                        // we cannot intantiate the class - throw the original Axis fault
+                        throw f;
+                    } catch (java.lang.InstantiationException e) {
+                        // we cannot intantiate the class - throw the original Axis fault
+                        throw f;
+                    }
+                } else {
+                    throw f;
+                }
+            } else {
+                throw f;
+            }
+        } finally {
+            if (_messageContext.getTransportOut() != null) {
+                _messageContext.getTransportOut().getSender()
+                               .cleanup(_messageContext);
+            }
+        }
+    }
+
+    /**
+     *  A utility method that copies the namepaces from the SOAPEnvelope
+     */
+    private java.util.Map getEnvelopeNamespaces(
+        org.apache.axiom.soap.SOAPEnvelope env) {
+        java.util.Map returnMap = new java.util.HashMap();
+        java.util.Iterator namespaceIterator = env.getAllDeclaredNamespaces();
+
+        while (namespaceIterator.hasNext()) {
+            org.apache.axiom.om.OMNamespace ns = (org.apache.axiom.om.OMNamespace) namespaceIterator.next();
+            returnMap.put(ns.getPrefix(), ns.getNamespaceURI());
+        }
+
+        return returnMap;
+    }
+
+    private boolean optimizeContent(javax.xml.namespace.QName opName) {
+        if (opNameArray == null) {
+            return false;
+        }
+
+        for (int i = 0; i < opNameArray.length; i++) {
+            if (opName.equals(opNameArray[i])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private org.apache.axiom.om.OMElement toOM(
+        com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoOSV4Stub.CteDadosMsg param,
+        boolean optimizeContent) throws org.apache.axis2.AxisFault {
+        try {
+            return param.getOMElement(com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoOSV4Stub.CteDadosMsg.MY_QNAME,
+                org.apache.axiom.om.OMAbstractFactory.getOMFactory());
+        } catch (org.apache.axis2.databinding.ADBException e) {
+            throw org.apache.axis2.AxisFault.makeFault(e);
+        }
+    }
+
+    private org.apache.axiom.om.OMElement toOM(
+        com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoOSV4Stub.CteRecepcaoOSResult param,
+        boolean optimizeContent) throws org.apache.axis2.AxisFault {
+        try {
+            return param.getOMElement(com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoOSV4Stub.CteRecepcaoOSResult.MY_QNAME,
+                org.apache.axiom.om.OMAbstractFactory.getOMFactory());
+        } catch (org.apache.axis2.databinding.ADBException e) {
+            throw org.apache.axis2.AxisFault.makeFault(e);
+        }
+    }
+
+    private org.apache.axiom.soap.SOAPEnvelope toEnvelope(
+        org.apache.axiom.soap.SOAPFactory factory,
+        com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoOSV4Stub.CteDadosMsg param,
+        boolean optimizeContent, javax.xml.namespace.QName methodQName)
+        throws org.apache.axis2.AxisFault {
+        try {
+            org.apache.axiom.soap.SOAPEnvelope emptyEnvelope = factory.getDefaultEnvelope();
+            emptyEnvelope.getBody()
+                         .addChild(param.getOMElement(
+                    com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoOSV4Stub.CteDadosMsg.MY_QNAME,
+                    factory));
+
+            return emptyEnvelope;
+        } catch (org.apache.axis2.databinding.ADBException e) {
+            throw org.apache.axis2.AxisFault.makeFault(e);
+        }
+    }
+
+    /* methods to provide back word compatibility */
+
+    /**
+     *  get the default envelope
+     */
+    private org.apache.axiom.soap.SOAPEnvelope toEnvelope(
+        org.apache.axiom.soap.SOAPFactory factory) {
+        return factory.getDefaultEnvelope();
+    }
+
+    private java.lang.Object fromOM(org.apache.axiom.om.OMElement param,
+        java.lang.Class type, java.util.Map extraNamespaces)
+        throws org.apache.axis2.AxisFault {
+        try {
+            if (com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoOSV4Stub.CteDadosMsg.class.equals(
+                        type)) {
+                return com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoOSV4Stub.CteDadosMsg.Factory.parse(param.getXMLStreamReaderWithoutCaching());
+            }
+
+            if (com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoOSV4Stub.CteRecepcaoOSResult.class.equals(
+                        type)) {
+                return com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoOSV4Stub.CteRecepcaoOSResult.Factory.parse(param.getXMLStreamReaderWithoutCaching());
+            }
+        } catch (java.lang.Exception e) {
+            throw org.apache.axis2.AxisFault.makeFault(e);
+        }
+
+        return null;
+    }
+
+    public static class CteRecepcaoOSResult implements org.apache.axis2.databinding.ADBBean {
+        public static final javax.xml.namespace.QName MY_QNAME = new javax.xml.namespace.QName("http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoOSV4",
+                "cteRecepcaoOSResult", "ns1");
+
+        /**
+         * field for ExtraElement
+         */
+        protected org.apache.axiom.om.OMElement localExtraElement;
+
+        /**
+         * Auto generated getter method
+         * @return org.apache.axiom.om.OMElement
+         */
+        public org.apache.axiom.om.OMElement getExtraElement() {
+            return localExtraElement;
+        }
+
+        /**
+         * Auto generated setter method
+         * @param param ExtraElement
+         */
+        public void setExtraElement(org.apache.axiom.om.OMElement param) {
+            this.localExtraElement = param;
+        }
+
+        /**
+         *
+         * @param parentQName
+         * @param factory
+         * @return org.apache.axiom.om.OMElement
+         */
+        public org.apache.axiom.om.OMElement getOMElement(
+            final javax.xml.namespace.QName parentQName,
+            final org.apache.axiom.om.OMFactory factory)
+            throws org.apache.axis2.databinding.ADBException {
+            org.apache.axiom.om.OMDataSource dataSource = new org.apache.axis2.databinding.ADBDataSource(this,
+                    MY_QNAME);
+
+            return factory.createOMElement(dataSource, MY_QNAME);
+        }
+
+        public void serialize(final javax.xml.namespace.QName parentQName,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException,
+                org.apache.axis2.databinding.ADBException {
+            serialize(parentQName, xmlWriter, false);
+        }
+
+        public void serialize(final javax.xml.namespace.QName parentQName,
+            javax.xml.stream.XMLStreamWriter xmlWriter, boolean serializeType)
+            throws javax.xml.stream.XMLStreamException,
+                org.apache.axis2.databinding.ADBException {
+            java.lang.String prefix = null;
+            java.lang.String namespace = null;
+
+            prefix = parentQName.getPrefix();
+            namespace = parentQName.getNamespaceURI();
+            writeStartElement(prefix, namespace, parentQName.getLocalPart(),
+                xmlWriter);
+
+            if (serializeType) {
+                java.lang.String namespacePrefix = registerPrefix(xmlWriter,
+                        "http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoOSV4");
+
+                if ((namespacePrefix != null) &&
+                        (namespacePrefix.trim().length() > 0)) {
+                    writeAttribute("xsi",
+                        "http://www.w3.org/2001/XMLSchema-instance", "type",
+                        namespacePrefix + ":cteRecepcaoOSResult", xmlWriter);
+                } else {
+                    writeAttribute("xsi",
+                        "http://www.w3.org/2001/XMLSchema-instance", "type",
+                        "cteRecepcaoOSResult", xmlWriter);
+                }
+            }
+
+            if (localExtraElement != null) {
+                localExtraElement.serialize(xmlWriter);
+            } else {
+                throw new org.apache.axis2.databinding.ADBException(
+                    "extraElement cannot be null!!");
+            }
+
+            xmlWriter.writeEndElement();
+        }
+
+        private static java.lang.String generatePrefix(
+            java.lang.String namespace) {
+            if (namespace.equals(
+                        "http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoOSV4")) {
+                return "ns1";
+            }
+
+            return org.apache.axis2.databinding.utils.BeanUtil.getUniquePrefix();
+        }
+
+        /**
+         * Utility method to write an element start tag.
+         */
+        private void writeStartElement(java.lang.String prefix,
+            java.lang.String namespace, java.lang.String localPart,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            java.lang.String writerPrefix = xmlWriter.getPrefix(namespace);
+
+            if (writerPrefix != null) {
+                xmlWriter.writeStartElement(namespace, localPart);
+            } else {
+                if (namespace.length() == 0) {
+                    prefix = "";
+                } else if (prefix == null) {
+                    prefix = generatePrefix(namespace);
+                }
+
+                xmlWriter.writeStartElement(prefix, localPart, namespace);
+                xmlWriter.writeNamespace(prefix, namespace);
+                xmlWriter.setPrefix(prefix, namespace);
+            }
+        }
+
+        /**
+         * Util method to write an attribute with the ns prefix
+         */
+        private void writeAttribute(java.lang.String prefix,
+            java.lang.String namespace, java.lang.String attName,
+            java.lang.String attValue,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            if (xmlWriter.getPrefix(namespace) == null) {
+                xmlWriter.writeNamespace(prefix, namespace);
+                xmlWriter.setPrefix(prefix, namespace);
+            }
+
+            xmlWriter.writeAttribute(namespace, attName, attValue);
+        }
+
+        /**
+         * Util method to write an attribute without the ns prefix
+         */
+        private void writeAttribute(java.lang.String namespace,
+            java.lang.String attName, java.lang.String attValue,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            if (namespace.equals("")) {
+                xmlWriter.writeAttribute(attName, attValue);
+            } else {
+                registerPrefix(xmlWriter, namespace);
+                xmlWriter.writeAttribute(namespace, attName, attValue);
+            }
+        }
+
+        /**
+         * Util method to write an attribute without the ns prefix
+         */
+        private void writeQNameAttribute(java.lang.String namespace,
+            java.lang.String attName, javax.xml.namespace.QName qname,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            java.lang.String attributeNamespace = qname.getNamespaceURI();
+            java.lang.String attributePrefix = xmlWriter.getPrefix(attributeNamespace);
+
+            if (attributePrefix == null) {
+                attributePrefix = registerPrefix(xmlWriter, attributeNamespace);
+            }
+
+            java.lang.String attributeValue;
+
+            if (attributePrefix.trim().length() > 0) {
+                attributeValue = attributePrefix + ":" + qname.getLocalPart();
+            } else {
+                attributeValue = qname.getLocalPart();
+            }
+
+            if (namespace.equals("")) {
+                xmlWriter.writeAttribute(attName, attributeValue);
+            } else {
+                registerPrefix(xmlWriter, namespace);
+                xmlWriter.writeAttribute(namespace, attName, attributeValue);
+            }
+        }
+
+        /**
+         *  method to handle Qnames
+         */
+        private void writeQName(javax.xml.namespace.QName qname,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            java.lang.String namespaceURI = qname.getNamespaceURI();
+
+            if (namespaceURI != null) {
+                java.lang.String prefix = xmlWriter.getPrefix(namespaceURI);
+
+                if (prefix == null) {
+                    prefix = generatePrefix(namespaceURI);
+                    xmlWriter.writeNamespace(prefix, namespaceURI);
+                    xmlWriter.setPrefix(prefix, namespaceURI);
+                }
+
+                if (prefix.trim().length() > 0) {
+                    xmlWriter.writeCharacters(prefix + ":" +
+                        org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                            qname));
+                } else {
+                    // i.e this is the default namespace
+                    xmlWriter.writeCharacters(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                            qname));
+                }
+            } else {
+                xmlWriter.writeCharacters(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                        qname));
+            }
+        }
+
+        private void writeQNames(javax.xml.namespace.QName[] qnames,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            if (qnames != null) {
+                // we have to store this data until last moment since it is not possible to write any
+                // namespace data after writing the charactor data
+                java.lang.StringBuffer stringToWrite = new java.lang.StringBuffer();
+                java.lang.String namespaceURI = null;
+                java.lang.String prefix = null;
+
+                for (int i = 0; i < qnames.length; i++) {
+                    if (i > 0) {
+                        stringToWrite.append(" ");
+                    }
+
+                    namespaceURI = qnames[i].getNamespaceURI();
+
+                    if (namespaceURI != null) {
+                        prefix = xmlWriter.getPrefix(namespaceURI);
+
+                        if ((prefix == null) || (prefix.length() == 0)) {
+                            prefix = generatePrefix(namespaceURI);
+                            xmlWriter.writeNamespace(prefix, namespaceURI);
+                            xmlWriter.setPrefix(prefix, namespaceURI);
+                        }
+
+                        if (prefix.trim().length() > 0) {
+                            stringToWrite.append(prefix).append(":")
+                                         .append(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                                    qnames[i]));
+                        } else {
+                            stringToWrite.append(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                                    qnames[i]));
+                        }
+                    } else {
+                        stringToWrite.append(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                                qnames[i]));
+                    }
+                }
+
+                xmlWriter.writeCharacters(stringToWrite.toString());
+            }
+        }
+
+        /**
+         * Register a namespace prefix
+         */
+        private java.lang.String registerPrefix(
+            javax.xml.stream.XMLStreamWriter xmlWriter,
+            java.lang.String namespace)
+            throws javax.xml.stream.XMLStreamException {
+            java.lang.String prefix = xmlWriter.getPrefix(namespace);
+
+            if (prefix == null) {
+                prefix = generatePrefix(namespace);
+
+                javax.xml.namespace.NamespaceContext nsContext = xmlWriter.getNamespaceContext();
+
+                while (true) {
+                    java.lang.String uri = nsContext.getNamespaceURI(prefix);
+
+                    if ((uri == null) || (uri.length() == 0)) {
+                        break;
+                    }
+
+                    prefix = org.apache.axis2.databinding.utils.BeanUtil.getUniquePrefix();
+                }
+
+                xmlWriter.writeNamespace(prefix, namespace);
+                xmlWriter.setPrefix(prefix, namespace);
+            }
+
+            return prefix;
+        }
+
+        /**
+         * databinding method to get an XML representation of this object
+         *
+         */
+        public javax.xml.stream.XMLStreamReader getPullParser(
+            javax.xml.namespace.QName qName)
+            throws org.apache.axis2.databinding.ADBException {
+            java.util.ArrayList elementList = new java.util.ArrayList();
+            java.util.ArrayList attribList = new java.util.ArrayList();
+
+            if (localExtraElement != null) {
+                elementList.add(org.apache.axis2.databinding.utils.Constants.OM_ELEMENT_KEY);
+                elementList.add(localExtraElement);
+            } else {
+                throw new org.apache.axis2.databinding.ADBException(
+                    "extraElement cannot be null!!");
+            }
+
+            return new org.apache.axis2.databinding.utils.reader.ADBXMLStreamReaderImpl(qName,
+                elementList.toArray(), attribList.toArray());
+        }
+
+        /**
+         *  Factory class that keeps the parse method
+         */
+        public static class Factory {
+            /**
+             * static method to create the object
+             * Precondition:  If this object is an element, the current or next start element starts this object and any intervening reader events are ignorable
+             *                If this object is not an element, it is a complex type and the reader is at the event just after the outer start element
+             * Postcondition: If this object is an element, the reader is positioned at its end element
+             *                If this object is a complex type, the reader is positioned at the end element of its outer element
+             */
+            public static CteRecepcaoOSResult parse(
+                javax.xml.stream.XMLStreamReader reader)
+                throws java.lang.Exception {
+                CteRecepcaoOSResult object = new CteRecepcaoOSResult();
+
+                int event;
+                java.lang.String nillableValue = null;
+                java.lang.String prefix = "";
+                java.lang.String namespaceuri = "";
+
+                try {
+                    while (!reader.isStartElement() && !reader.isEndElement())
+                        reader.next();
+
+                    if (reader.getAttributeValue(
+                                "http://www.w3.org/2001/XMLSchema-instance",
+                                "type") != null) {
+                        java.lang.String fullTypeName = reader.getAttributeValue("http://www.w3.org/2001/XMLSchema-instance",
+                                "type");
+
+                        if (fullTypeName != null) {
+                            java.lang.String nsPrefix = null;
+
+                            if (fullTypeName.indexOf(":") > -1) {
+                                nsPrefix = fullTypeName.substring(0,
+                                        fullTypeName.indexOf(":"));
+                            }
+
+                            nsPrefix = (nsPrefix == null) ? "" : nsPrefix;
+
+                            java.lang.String type = fullTypeName.substring(fullTypeName.indexOf(
+                                        ":") + 1);
+
+                            if (!"cteRecepcaoOSResult".equals(type)) {
+                                //find namespace for the prefix
+                                java.lang.String nsUri = reader.getNamespaceContext()
+                                                               .getNamespaceURI(nsPrefix);
+
+                                return (CteRecepcaoOSResult) ExtensionMapper.getTypeObject(nsUri,
+                                    type, reader);
+                            }
+                        }
+                    }
+
+                    // Note all attributes that were handled. Used to differ normal attributes
+                    // from anyAttributes.
+                    java.util.Vector handledAttributes = new java.util.Vector();
+
+                    reader.next();
+
+                    while (!reader.isStartElement() && !reader.isEndElement())
+                        reader.next();
+
+                    if (reader.isStartElement()) {
+                        //use the QName from the parser as the name for the builder
+                        javax.xml.namespace.QName startQname1 = reader.getName();
+
+                        // We need to wrap the reader so that it produces a fake START_DOCUMENT event
+                        // this is needed by the builder classes
+                        org.apache.axis2.databinding.utils.NamedStaxOMBuilder builder1 =
+                            new org.apache.axis2.databinding.utils.NamedStaxOMBuilder(new org.apache.axis2.util.StreamWrapper(
+                                    reader), startQname1);
+                        object.setExtraElement(builder1.getOMElement());
+
+                        reader.next();
+                    } // End of if for expected property start element
+
+                    else {
+                        // A start element we are not expecting indicates an invalid parameter was passed
+                        throw new org.apache.axis2.databinding.ADBException(
+                            "Unexpected subelement " + reader.getName());
+                    }
+
+                    while (!reader.isStartElement() && !reader.isEndElement())
+                        reader.next();
+
+                    if (reader.isStartElement()) {
+                        // A start element we are not expecting indicates a trailing invalid property
+                        throw new org.apache.axis2.databinding.ADBException(
+                            "Unexpected subelement " + reader.getName());
+                    }
+                } catch (javax.xml.stream.XMLStreamException e) {
+                    throw new java.lang.Exception(e);
+                }
+
+                return object;
+            }
+        } //end of factory class
+    }
+
+    public static class CteDadosMsg implements org.apache.axis2.databinding.ADBBean {
+        public static final javax.xml.namespace.QName MY_QNAME = new javax.xml.namespace.QName("http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoOSV4",
+                "cteDadosMsg", "ns1");
+
+        /**
+         * field for CteDadosMsg
+         */
+        protected java.lang.String localCteDadosMsg;
+
+        /**
+         * Auto generated getter method
+         * @return java.lang.String
+         */
+        public java.lang.String getCteDadosMsg() {
+            return localCteDadosMsg;
+        }
+
+        /**
+         * Auto generated setter method
+         * @param param CteDadosMsg
+         */
+        public void setCteDadosMsg(java.lang.String param) {
+            this.localCteDadosMsg = param;
+        }
+
+        /**
+         *
+         * @param parentQName
+         * @param factory
+         * @return org.apache.axiom.om.OMElement
+         */
+        public org.apache.axiom.om.OMElement getOMElement(
+            final javax.xml.namespace.QName parentQName,
+            final org.apache.axiom.om.OMFactory factory)
+            throws org.apache.axis2.databinding.ADBException {
+            org.apache.axiom.om.OMDataSource dataSource = new org.apache.axis2.databinding.ADBDataSource(this,
+                    MY_QNAME);
+
+            return factory.createOMElement(dataSource, MY_QNAME);
+        }
+
+        public void serialize(final javax.xml.namespace.QName parentQName,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException,
+                org.apache.axis2.databinding.ADBException {
+            serialize(parentQName, xmlWriter, false);
+        }
+
+        public void serialize(final javax.xml.namespace.QName parentQName,
+            javax.xml.stream.XMLStreamWriter xmlWriter, boolean serializeType)
+            throws javax.xml.stream.XMLStreamException,
+                org.apache.axis2.databinding.ADBException {
+            //We can safely assume an element has only one type associated with it
+            java.lang.String namespace = "http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoOSV4";
+            java.lang.String _localName = "cteDadosMsg";
+
+            writeStartElement(null, namespace, _localName, xmlWriter);
+
+            // add the type details if this is used in a simple type
+            if (serializeType) {
+                java.lang.String namespacePrefix = registerPrefix(xmlWriter,
+                        "http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoOSV4");
+
+                if ((namespacePrefix != null) &&
+                        (namespacePrefix.trim().length() > 0)) {
+                    writeAttribute("xsi",
+                        "http://www.w3.org/2001/XMLSchema-instance", "type",
+                        namespacePrefix + ":cteDadosMsg", xmlWriter);
+                } else {
+                    writeAttribute("xsi",
+                        "http://www.w3.org/2001/XMLSchema-instance", "type",
+                        "cteDadosMsg", xmlWriter);
+                }
+            }
+
+            if (localCteDadosMsg == null) {
+                throw new org.apache.axis2.databinding.ADBException(
+                    "cteDadosMsg cannot be null !!");
+            } else {
+                xmlWriter.writeCharacters(localCteDadosMsg);
+            }
+
+            xmlWriter.writeEndElement();
+        }
+
+        private static java.lang.String generatePrefix(
+            java.lang.String namespace) {
+            if (namespace.equals(
+                        "http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoOSV4")) {
+                return "ns1";
+            }
+
+            return org.apache.axis2.databinding.utils.BeanUtil.getUniquePrefix();
+        }
+
+        /**
+         * Utility method to write an element start tag.
+         */
+        private void writeStartElement(java.lang.String prefix,
+            java.lang.String namespace, java.lang.String localPart,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            java.lang.String writerPrefix = xmlWriter.getPrefix(namespace);
+
+            if (writerPrefix != null) {
+                xmlWriter.writeStartElement(namespace, localPart);
+            } else {
+                if (namespace.length() == 0) {
+                    prefix = "";
+                } else if (prefix == null) {
+                    prefix = generatePrefix(namespace);
+                }
+
+                xmlWriter.writeStartElement(prefix, localPart, namespace);
+                xmlWriter.writeNamespace(prefix, namespace);
+                xmlWriter.setPrefix(prefix, namespace);
+            }
+        }
+
+        /**
+         * Util method to write an attribute with the ns prefix
+         */
+        private void writeAttribute(java.lang.String prefix,
+            java.lang.String namespace, java.lang.String attName,
+            java.lang.String attValue,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            if (xmlWriter.getPrefix(namespace) == null) {
+                xmlWriter.writeNamespace(prefix, namespace);
+                xmlWriter.setPrefix(prefix, namespace);
+            }
+
+            xmlWriter.writeAttribute(namespace, attName, attValue);
+        }
+
+        /**
+         * Util method to write an attribute without the ns prefix
+         */
+        private void writeAttribute(java.lang.String namespace,
+            java.lang.String attName, java.lang.String attValue,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            if (namespace.equals("")) {
+                xmlWriter.writeAttribute(attName, attValue);
+            } else {
+                registerPrefix(xmlWriter, namespace);
+                xmlWriter.writeAttribute(namespace, attName, attValue);
+            }
+        }
+
+        /**
+         * Util method to write an attribute without the ns prefix
+         */
+        private void writeQNameAttribute(java.lang.String namespace,
+            java.lang.String attName, javax.xml.namespace.QName qname,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            java.lang.String attributeNamespace = qname.getNamespaceURI();
+            java.lang.String attributePrefix = xmlWriter.getPrefix(attributeNamespace);
+
+            if (attributePrefix == null) {
+                attributePrefix = registerPrefix(xmlWriter, attributeNamespace);
+            }
+
+            java.lang.String attributeValue;
+
+            if (attributePrefix.trim().length() > 0) {
+                attributeValue = attributePrefix + ":" + qname.getLocalPart();
+            } else {
+                attributeValue = qname.getLocalPart();
+            }
+
+            if (namespace.equals("")) {
+                xmlWriter.writeAttribute(attName, attributeValue);
+            } else {
+                registerPrefix(xmlWriter, namespace);
+                xmlWriter.writeAttribute(namespace, attName, attributeValue);
+            }
+        }
+
+        /**
+         *  method to handle Qnames
+         */
+        private void writeQName(javax.xml.namespace.QName qname,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            java.lang.String namespaceURI = qname.getNamespaceURI();
+
+            if (namespaceURI != null) {
+                java.lang.String prefix = xmlWriter.getPrefix(namespaceURI);
+
+                if (prefix == null) {
+                    prefix = generatePrefix(namespaceURI);
+                    xmlWriter.writeNamespace(prefix, namespaceURI);
+                    xmlWriter.setPrefix(prefix, namespaceURI);
+                }
+
+                if (prefix.trim().length() > 0) {
+                    xmlWriter.writeCharacters(prefix + ":" +
+                        org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                            qname));
+                } else {
+                    // i.e this is the default namespace
+                    xmlWriter.writeCharacters(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                            qname));
+                }
+            } else {
+                xmlWriter.writeCharacters(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                        qname));
+            }
+        }
+
+        private void writeQNames(javax.xml.namespace.QName[] qnames,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            if (qnames != null) {
+                // we have to store this data until last moment since it is not possible to write any
+                // namespace data after writing the charactor data
+                java.lang.StringBuffer stringToWrite = new java.lang.StringBuffer();
+                java.lang.String namespaceURI = null;
+                java.lang.String prefix = null;
+
+                for (int i = 0; i < qnames.length; i++) {
+                    if (i > 0) {
+                        stringToWrite.append(" ");
+                    }
+
+                    namespaceURI = qnames[i].getNamespaceURI();
+
+                    if (namespaceURI != null) {
+                        prefix = xmlWriter.getPrefix(namespaceURI);
+
+                        if ((prefix == null) || (prefix.length() == 0)) {
+                            prefix = generatePrefix(namespaceURI);
+                            xmlWriter.writeNamespace(prefix, namespaceURI);
+                            xmlWriter.setPrefix(prefix, namespaceURI);
+                        }
+
+                        if (prefix.trim().length() > 0) {
+                            stringToWrite.append(prefix).append(":")
+                                         .append(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                                    qnames[i]));
+                        } else {
+                            stringToWrite.append(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                                    qnames[i]));
+                        }
+                    } else {
+                        stringToWrite.append(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                                qnames[i]));
+                    }
+                }
+
+                xmlWriter.writeCharacters(stringToWrite.toString());
+            }
+        }
+
+        /**
+         * Register a namespace prefix
+         */
+        private java.lang.String registerPrefix(
+            javax.xml.stream.XMLStreamWriter xmlWriter,
+            java.lang.String namespace)
+            throws javax.xml.stream.XMLStreamException {
+            java.lang.String prefix = xmlWriter.getPrefix(namespace);
+
+            if (prefix == null) {
+                prefix = generatePrefix(namespace);
+
+                javax.xml.namespace.NamespaceContext nsContext = xmlWriter.getNamespaceContext();
+
+                while (true) {
+                    java.lang.String uri = nsContext.getNamespaceURI(prefix);
+
+                    if ((uri == null) || (uri.length() == 0)) {
+                        break;
+                    }
+
+                    prefix = org.apache.axis2.databinding.utils.BeanUtil.getUniquePrefix();
+                }
+
+                xmlWriter.writeNamespace(prefix, namespace);
+                xmlWriter.setPrefix(prefix, namespace);
+            }
+
+            return prefix;
+        }
+
+        /**
+         * databinding method to get an XML representation of this object
+         *
+         */
+        public javax.xml.stream.XMLStreamReader getPullParser(
+            javax.xml.namespace.QName qName)
+            throws org.apache.axis2.databinding.ADBException {
+            //We can safely assume an element has only one type associated with it
+            return new org.apache.axis2.databinding.utils.reader.ADBXMLStreamReaderImpl(MY_QNAME,
+                new java.lang.Object[] {
+                    org.apache.axis2.databinding.utils.reader.ADBXMLStreamReader.ELEMENT_TEXT,
+                    org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                        localCteDadosMsg)
+                }, null);
+        }
+
+        /**
+         *  Factory class that keeps the parse method
+         */
+        public static class Factory {
+            /**
+             * static method to create the object
+             * Precondition:  If this object is an element, the current or next start element starts this object and any intervening reader events are ignorable
+             *                If this object is not an element, it is a complex type and the reader is at the event just after the outer start element
+             * Postcondition: If this object is an element, the reader is positioned at its end element
+             *                If this object is a complex type, the reader is positioned at the end element of its outer element
+             */
+            public static CteDadosMsg parse(
+                javax.xml.stream.XMLStreamReader reader)
+                throws java.lang.Exception {
+                CteDadosMsg object = new CteDadosMsg();
+
+                int event;
+                java.lang.String nillableValue = null;
+                java.lang.String prefix = "";
+                java.lang.String namespaceuri = "";
+
+                try {
+                    while (!reader.isStartElement() && !reader.isEndElement())
+                        reader.next();
+
+                    // Note all attributes that were handled. Used to differ normal attributes
+                    // from anyAttributes.
+                    java.util.Vector handledAttributes = new java.util.Vector();
+
+                    while (!reader.isEndElement()) {
+                        if (reader.isStartElement()) {
+                            if (reader.isStartElement() &&
+                                    new javax.xml.namespace.QName(
+                                        "http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoOSV4",
+                                        "cteDadosMsg").equals(reader.getName())) {
+                                nillableValue = reader.getAttributeValue("http://www.w3.org/2001/XMLSchema-instance",
+                                        "nil");
+
+                                if ("true".equals(nillableValue) ||
+                                        "1".equals(nillableValue)) {
+                                    throw new org.apache.axis2.databinding.ADBException(
+                                        "The element: " + "cteDadosMsg" +
+                                        "  cannot be null");
+                                }
+
+                                java.lang.String content = reader.getElementText();
+
+                                object.setCteDadosMsg(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                                        content));
+                            } // End of if for expected property start element
+
+                            else {
+                                // A start element we are not expecting indicates an invalid parameter was passed
+                                throw new org.apache.axis2.databinding.ADBException(
+                                    "Unexpected subelement " +
+                                    reader.getName());
+                            }
+                        } else {
+                            reader.next();
+                        }
+                    } // end of while loop
+                } catch (javax.xml.stream.XMLStreamException e) {
+                    throw new java.lang.Exception(e);
+                }
+
+                return object;
+            }
+        } //end of factory class
+    }
+
+    public static class ExtensionMapper {
+        public static java.lang.Object getTypeObject(
+            java.lang.String namespaceURI, java.lang.String typeName,
+            javax.xml.stream.XMLStreamReader reader) throws java.lang.Exception {
+            throw new org.apache.axis2.databinding.ADBException(
+                "Unsupported type " + namespaceURI + " " + typeName);
+        }
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/transformers/DFRegistryMatcher.java
+++ b/src/main/java/com/fincatto/documentofiscal/transformers/DFRegistryMatcher.java
@@ -183,6 +183,11 @@ public class DFRegistryMatcher extends RegistryMatcher {
         super.bind(com.fincatto.documentofiscal.cte300.classes.CTIndicadoNegociavel.class, new com.fincatto.documentofiscal.cte300.transformes.CTIndicadoNegociavelTransformer());
         super.bind(com.fincatto.documentofiscal.cte300.classes.CTTipoRegimeTributario.class, new com.fincatto.documentofiscal.cte300.transformes.CTTipoRegimeTributarioTransformer());
         super.bind(com.fincatto.documentofiscal.cte300.classes.CTTipoEspecieGtv.class, new com.fincatto.documentofiscal.cte300.transformes.CTTipoEspecieGtvTransformer());
+        super.bind(com.fincatto.documentofiscal.cte300.classes.CTResponsavelSeguro.class, new com.fincatto.documentofiscal.cte300.transformes.CTResponsavelSeguroTransformer());
+        super.bind(com.fincatto.documentofiscal.cte300.classes.CTTipoFretamento.class, new com.fincatto.documentofiscal.cte300.transformes.CTTipoFretamentoTransformer());
+        super.bind(com.fincatto.documentofiscal.cte300.classes.CTTipoProprietario.class, new com.fincatto.documentofiscal.cte300.transformes.CTTipoProprietarioTransformer());
+        super.bind(com.fincatto.documentofiscal.cte300.classes.CTTipoServicoOS.class, new com.fincatto.documentofiscal.cte300.transformes.CTTipoServicoOSTransformer());
+        super.bind(com.fincatto.documentofiscal.cte300.classes.CTipoComponenteGTVe.class, new com.fincatto.documentofiscal.cte300.transformes.CTipoComponenteGTVeTransformer());
 
         // CTe 4.00
         super.bind(com.fincatto.documentofiscal.cte400.classes.CTFinalidade.class, new com.fincatto.documentofiscal.cte400.transformers.CTFinalidadeTransformes());
@@ -212,6 +217,12 @@ public class DFRegistryMatcher extends RegistryMatcher {
         super.bind(com.fincatto.documentofiscal.cte400.classes.CTTipoRegimeTributario.class, new com.fincatto.documentofiscal.cte400.transformers.CTTipoRegimeTributarioTransformer());
         super.bind(com.fincatto.documentofiscal.cte400.classes.CTTipoEspecieGtv.class, new com.fincatto.documentofiscal.cte400.transformers.CTTipoEspecieGtvTransformer());
         super.bind(com.fincatto.documentofiscal.cte400.classes.CTMotivoInsucesso.class, new com.fincatto.documentofiscal.cte400.transformers.CTMotivoInsucessoTransformer());
+        super.bind(com.fincatto.documentofiscal.cte400.classes.CTResponsavelSeguro.class, new com.fincatto.documentofiscal.cte400.transformers.CTResponsavelSeguroTransformer());
+        super.bind(com.fincatto.documentofiscal.cte400.classes.CTTipoFretamento.class, new com.fincatto.documentofiscal.cte400.transformers.CTTipoFretamentoTransformer());
+        super.bind(com.fincatto.documentofiscal.cte400.classes.CTTipoProprietario.class, new com.fincatto.documentofiscal.cte400.transformers.CTTipoProprietarioTransformer());
+        super.bind(com.fincatto.documentofiscal.cte400.classes.CTTipoServicoOS.class, new com.fincatto.documentofiscal.cte400.transformers.CTTipoServicoOSTransformer());
+        super.bind(com.fincatto.documentofiscal.cte400.classes.CTipoComponenteGTVe.class, new com.fincatto.documentofiscal.cte400.transformers.CTipoComponenteGTVeTransformer());
+
 
         // MDF-e
         super.bind(MDFModalidadeTransporte.class, new MDFModalidadeTransporteTransformer());

--- a/src/main/java/com/fincatto/documentofiscal/validadores/DFStringValidador.java
+++ b/src/main/java/com/fincatto/documentofiscal/validadores/DFStringValidador.java
@@ -355,6 +355,13 @@ public abstract class DFStringValidador {
         }
     }
 
+    public static void tamanho12N(final String string, final String info) {
+        if (string != null) {
+            DFStringValidador.apenasNumerico(string, info);
+            DFStringValidador.validaTamanhoMaximo(string, 12, info);
+        }
+    }
+
     public static void tamanho120(final String string, final String info) {
         if (string != null) {
             DFStringValidador.validaTamanhoMaximo(string, 120, info);
@@ -621,6 +628,13 @@ public abstract class DFStringValidador {
         if (string != null) {
             DFStringValidador.apenasNumerico(string, info);
             DFStringValidador.validaTamanhoExato(string, 20, info);
+        }
+    }
+
+    public static void tamanho25N(final String string, final String info) {
+        if (string != null) {
+            DFStringValidador.apenasNumerico(string, info);
+            DFStringValidador.validaTamanhoMaximo(string, 25, info);
         }
     }
 

--- a/src/main/java/com/fincatto/documentofiscal/validadores/DFXMLValidador.java
+++ b/src/main/java/com/fincatto/documentofiscal/validadores/DFXMLValidador.java
@@ -98,6 +98,10 @@ public final class DFXMLValidador {
         return DFXMLValidador.validaCTe(arquivoXML, "enviCTe_v3.00.xsd");
     }
 
+    public static boolean validaCTeOS300(final String arquivoXML) throws Exception {
+        return DFXMLValidador.validaCTe(arquivoXML, "cteOS_v3.00.xsd");
+    }
+
     public static boolean validaNotaCte(final String arquivoXML) throws Exception {
         return DFXMLValidador.validaCTe(arquivoXML, "cte_v3.00.xsd");
     }
@@ -148,6 +152,10 @@ public final class DFXMLValidador {
 
     public static boolean validaNotaCte400(final String arquivoXML) throws Exception {
         return DFXMLValidador.validaCTe400(arquivoXML, "cte_v4.00.xsd");
+    }
+
+    public static boolean validaNotaCTeOS400(final String arquivoXML) throws Exception {
+        return DFXMLValidador.validaCTe400(arquivoXML, "cteOS_v4.00.xsd");
     }
 
     public static boolean validaEventoCTe400(final String arquivoXML) throws Exception {

--- a/src/main/resources/schemas/PL_CTe_400/cteTiposBasico_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400/cteTiposBasico_v4.00.xsd
@@ -4515,6 +4515,8 @@ Onde v9.99 é a a designação genérica para a versão do arquivo. Por exemplo,
 															</xs:restriction>
 														</xs:simpleType>
 													</xs:element>
+,
+
 												</xs:sequence>
 											</xs:complexType>
 										</xs:element>

--- a/src/test/java/com/fincatto/documentofiscal/cte300/classes/CTAutorizador31Test.java
+++ b/src/test/java/com/fincatto/documentofiscal/cte300/classes/CTAutorizador31Test.java
@@ -4,7 +4,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.fincatto.documentofiscal.DFAmbiente;
-import com.fincatto.documentofiscal.cte300.classes.CTAutorizador31;
 
 public class CTAutorizador31Test {
 
@@ -18,6 +17,7 @@ public class CTAutorizador31Test {
     	Assert.assertEquals("https://homologacao.sefaz.mt.gov.br/ctews/services/CteConsulta", autorizador.getCteConsultaProtocolo(DFAmbiente.HOMOLOGACAO));
     	Assert.assertEquals("https://homologacao.sefaz.mt.gov.br/ctews/services/CteStatusServico", autorizador.getCteStatusServico(DFAmbiente.HOMOLOGACAO));
     	Assert.assertEquals("https://homologacao.sefaz.mt.gov.br/ctews2/services/CteRecepcaoEvento?wsdl", autorizador.getRecepcaoEvento(DFAmbiente.HOMOLOGACAO));
+		Assert.assertEquals("https://homologacao.sefaz.mt.gov.br/ctews/services/CteRecepcaoOS", autorizador.getCteRecepcaoOS(DFAmbiente.HOMOLOGACAO));
     	
     	Assert.assertEquals("https://cte.sefaz.mt.gov.br/ctews/services/CteRecepcao", autorizador.getCteRecepcao(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://cte.sefaz.mt.gov.br/ctews/services/CteRetRecepcao", autorizador.getCteRetRecepcao(DFAmbiente.PRODUCAO));
@@ -25,6 +25,7 @@ public class CTAutorizador31Test {
     	Assert.assertEquals("https://cte.sefaz.mt.gov.br/ctews/services/CteConsulta", autorizador.getCteConsultaProtocolo(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://cte.sefaz.mt.gov.br/ctews/services/CteStatusServico", autorizador.getCteStatusServico(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://cte.sefaz.mt.gov.br/ctews2/services/CteRecepcaoEvento?wsdl", autorizador.getRecepcaoEvento(DFAmbiente.PRODUCAO));
+		Assert.assertEquals("https://cte.sefaz.mt.gov.br/ctews/services/CteRecepcaoOS", autorizador.getCteRecepcaoOS(DFAmbiente.PRODUCAO));
     }
 
     @Test
@@ -37,6 +38,7 @@ public class CTAutorizador31Test {
     	Assert.assertEquals("https://homologacao.cte.ms.gov.br/ws/CteConsulta", autorizador.getCteConsultaProtocolo(DFAmbiente.HOMOLOGACAO));
     	Assert.assertEquals("https://homologacao.cte.ms.gov.br/ws/CteStatusServico", autorizador.getCteStatusServico(DFAmbiente.HOMOLOGACAO));
     	Assert.assertEquals("https://homologacao.cte.ms.gov.br/ws/CteRecepcaoEvento", autorizador.getRecepcaoEvento(DFAmbiente.HOMOLOGACAO));
+		Assert.assertEquals("https://homologacao.cte.ms.gov.br/ws/CteRecepcaoOS", autorizador.getCteRecepcaoOS(DFAmbiente.HOMOLOGACAO));
     	
     	Assert.assertEquals("https://producao.cte.ms.gov.br/ws/CteRecepcao", autorizador.getCteRecepcao(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://producao.cte.ms.gov.br/ws/CteRetRecepcao", autorizador.getCteRetRecepcao(DFAmbiente.PRODUCAO));
@@ -44,6 +46,7 @@ public class CTAutorizador31Test {
     	Assert.assertEquals("https://producao.cte.ms.gov.br/ws/CteConsulta", autorizador.getCteConsultaProtocolo(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://producao.cte.ms.gov.br/ws/CteStatusServico", autorizador.getCteStatusServico(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://producao.cte.ms.gov.br/ws/CteRecepcaoEvento", autorizador.getRecepcaoEvento(DFAmbiente.PRODUCAO));
+		Assert.assertEquals("https://producao.cte.ms.gov.br/ws/CteRecepcaoOS", autorizador.getCteRecepcaoOS(DFAmbiente.PRODUCAO));
     }
     
     @Test
@@ -56,6 +59,7 @@ public class CTAutorizador31Test {
     	Assert.assertEquals("https://hcte.fazenda.mg.gov.br/cte/services/CteConsulta", autorizador.getCteConsultaProtocolo(DFAmbiente.HOMOLOGACAO));
     	Assert.assertEquals("https://hcte.fazenda.mg.gov.br/cte/services/CteStatusServico", autorizador.getCteStatusServico(DFAmbiente.HOMOLOGACAO));
     	Assert.assertEquals("https://hcte.fazenda.mg.gov.br/cte/services/RecepcaoEvento", autorizador.getRecepcaoEvento(DFAmbiente.HOMOLOGACAO));
+		Assert.assertEquals("https://hcte.fazenda.mg.gov.br/cte/services/CteRecepcaoOS", autorizador.getCteRecepcaoOS(DFAmbiente.HOMOLOGACAO));
     	
     	Assert.assertEquals("https://cte.fazenda.mg.gov.br/cte/services/CteRecepcao", autorizador.getCteRecepcao(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://cte.fazenda.mg.gov.br/cte/services/CteRetRecepcao", autorizador.getCteRetRecepcao(DFAmbiente.PRODUCAO));
@@ -63,6 +67,7 @@ public class CTAutorizador31Test {
     	Assert.assertEquals("https://cte.fazenda.mg.gov.br/cte/services/CteConsulta", autorizador.getCteConsultaProtocolo(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://cte.fazenda.mg.gov.br/cte/services/CteStatusServico", autorizador.getCteStatusServico(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://cte.fazenda.mg.gov.br/cte/services/RecepcaoEvento", autorizador.getRecepcaoEvento(DFAmbiente.PRODUCAO));
+		Assert.assertEquals("https://cte.fazenda.mg.gov.br/cte/services/CteRecepcaoOS", autorizador.getCteRecepcaoOS(DFAmbiente.PRODUCAO));
     }
     
     @Test
@@ -75,6 +80,7 @@ public class CTAutorizador31Test {
     	Assert.assertEquals("https://homologacao.cte.fazenda.pr.gov.br/cte/CteConsulta?wsdl", autorizador.getCteConsultaProtocolo(DFAmbiente.HOMOLOGACAO));
     	Assert.assertEquals("https://homologacao.cte.fazenda.pr.gov.br/cte/CteStatusServico?wsdl", autorizador.getCteStatusServico(DFAmbiente.HOMOLOGACAO));
     	Assert.assertEquals("https://homologacao.cte.fazenda.pr.gov.br/cte/CteRecepcaoEvento?wsdl", autorizador.getRecepcaoEvento(DFAmbiente.HOMOLOGACAO));
+		Assert.assertEquals("https://homologacao.cte.fazenda.pr.gov.br/cte/CteRecepcaoOS", autorizador.getCteRecepcaoOS(DFAmbiente.HOMOLOGACAO));
     	
     	Assert.assertEquals("https://cte.fazenda.pr.gov.br/cte/CteRecepcao?wsdl", autorizador.getCteRecepcao(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://cte.fazenda.pr.gov.br/cte/CteRetRecepcao?wsdl", autorizador.getCteRetRecepcao(DFAmbiente.PRODUCAO));
@@ -82,6 +88,7 @@ public class CTAutorizador31Test {
     	Assert.assertEquals("https://cte.fazenda.pr.gov.br/cte/CteConsulta?wsdl", autorizador.getCteConsultaProtocolo(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://cte.fazenda.pr.gov.br/cte/CteStatusServico?wsdl", autorizador.getCteStatusServico(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://cte.fazenda.pr.gov.br/cte/CteRecepcaoEvento?wsdl", autorizador.getRecepcaoEvento(DFAmbiente.PRODUCAO));
+		Assert.assertEquals("https://cte.fazenda.pr.gov.br/cte/CteRecepcaoOS", autorizador.getCteRecepcaoOS(DFAmbiente.PRODUCAO));
     }
     
     @Test
@@ -94,6 +101,7 @@ public class CTAutorizador31Test {
     	Assert.assertEquals("https://cte-homologacao.svrs.rs.gov.br/ws/cteconsulta/CteConsulta.asmx", autorizador.getCteConsultaProtocolo(DFAmbiente.HOMOLOGACAO));
     	Assert.assertEquals("https://cte-homologacao.svrs.rs.gov.br/ws/ctestatusservico/CteStatusServico.asmx", autorizador.getCteStatusServico(DFAmbiente.HOMOLOGACAO));
     	Assert.assertEquals("https://cte-homologacao.svrs.rs.gov.br/ws/cterecepcaoevento/cterecepcaoevento.asmx", autorizador.getRecepcaoEvento(DFAmbiente.HOMOLOGACAO));
+		Assert.assertEquals("https://cte-homologacao.svrs.rs.gov.br/ws/cterecepcaoos/cterecepcaoos.asmx", autorizador.getCteRecepcaoOS(DFAmbiente.HOMOLOGACAO));
     	
     	Assert.assertEquals("https://cte.svrs.rs.gov.br/ws/cterecepcao/CteRecepcao.asmx", autorizador.getCteRecepcao(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://cte.svrs.rs.gov.br/ws/cteretrecepcao/cteRetRecepcao.asmx", autorizador.getCteRetRecepcao(DFAmbiente.PRODUCAO));
@@ -101,6 +109,7 @@ public class CTAutorizador31Test {
     	Assert.assertEquals("https://cte.svrs.rs.gov.br/ws/cteconsulta/CteConsulta.asmx", autorizador.getCteConsultaProtocolo(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://cte.svrs.rs.gov.br/ws/ctestatusservico/CteStatusServico.asmx", autorizador.getCteStatusServico(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://cte.svrs.rs.gov.br/ws/cterecepcaoevento/cterecepcaoevento.asmx", autorizador.getRecepcaoEvento(DFAmbiente.PRODUCAO));
+		Assert.assertEquals("https://cte.svrs.rs.gov.br/ws/cterecepcaoos/cterecepcaoos.asmx", autorizador.getCteRecepcaoOS(DFAmbiente.PRODUCAO));
     }
     
     @Test
@@ -113,6 +122,7 @@ public class CTAutorizador31Test {
     	Assert.assertEquals("https://homologacao.nfe.fazenda.sp.gov.br/cteWEB/services/cteConsulta.asmx", autorizador.getCteConsultaProtocolo(DFAmbiente.HOMOLOGACAO));
     	Assert.assertEquals("https://homologacao.nfe.fazenda.sp.gov.br/cteWEB/services/cteStatusServico.asmx", autorizador.getCteStatusServico(DFAmbiente.HOMOLOGACAO));
     	Assert.assertEquals("https://homologacao.nfe.fazenda.sp.gov.br/cteweb/services/cteRecepcaoEvento.asmx", autorizador.getRecepcaoEvento(DFAmbiente.HOMOLOGACAO));
+		Assert.assertEquals("https://homologacao.nfe.fazenda.sp.gov.br/cteWEB/services/cteRecepcaoOS.asmx", autorizador.getCteRecepcaoOS(DFAmbiente.HOMOLOGACAO));
     	
     	Assert.assertEquals("https://nfe.fazenda.sp.gov.br/cteWEB/services/cteRecepcao.asmx", autorizador.getCteRecepcao(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://nfe.fazenda.sp.gov.br/cteWEB/services/cteRetRecepcao.asmx", autorizador.getCteRetRecepcao(DFAmbiente.PRODUCAO));
@@ -120,6 +130,7 @@ public class CTAutorizador31Test {
     	Assert.assertEquals("https://nfe.fazenda.sp.gov.br/cteWEB/services/cteConsulta.asmx", autorizador.getCteConsultaProtocolo(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://nfe.fazenda.sp.gov.br/cteWEB/services/cteStatusServico.asmx", autorizador.getCteStatusServico(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://nfe.fazenda.sp.gov.br/cteweb/services/cteRecepcaoEvento.asmx", autorizador.getRecepcaoEvento(DFAmbiente.PRODUCAO));
+		Assert.assertEquals("https://nfe.fazenda.sp.gov.br/cteWEB/services/cteRecepcaoOS.asmx", autorizador.getCteRecepcaoOS(DFAmbiente.PRODUCAO));
     }
     
     @Test
@@ -132,6 +143,7 @@ public class CTAutorizador31Test {
     	Assert.assertEquals("https://cte-homologacao.svrs.rs.gov.br/ws/cteconsulta/CteConsulta.asmx", autorizador.getCteConsultaProtocolo(DFAmbiente.HOMOLOGACAO));
     	Assert.assertEquals("https://cte-homologacao.svrs.rs.gov.br/ws/ctestatusservico/CteStatusServico.asmx", autorizador.getCteStatusServico(DFAmbiente.HOMOLOGACAO));
     	Assert.assertEquals("https://cte-homologacao.svrs.rs.gov.br/ws/cterecepcaoevento/cterecepcaoevento.asmx", autorizador.getRecepcaoEvento(DFAmbiente.HOMOLOGACAO));
+		Assert.assertEquals("https://cte-homologacao.svrs.rs.gov.br/ws/cterecepcaoos/cterecepcaoos.asmx", autorizador.getCteRecepcaoOS(DFAmbiente.HOMOLOGACAO));
     	
     	Assert.assertEquals("https://cte.svrs.rs.gov.br/ws/cterecepcao/CteRecepcao.asmx", autorizador.getCteRecepcao(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://cte.svrs.rs.gov.br/ws/cteretrecepcao/cteRetRecepcao.asmx", autorizador.getCteRetRecepcao(DFAmbiente.PRODUCAO));
@@ -139,6 +151,7 @@ public class CTAutorizador31Test {
     	Assert.assertEquals("https://cte.svrs.rs.gov.br/ws/cteconsulta/CteConsulta.asmx", autorizador.getCteConsultaProtocolo(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://cte.svrs.rs.gov.br/ws/ctestatusservico/CteStatusServico.asmx", autorizador.getCteStatusServico(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://cte.svrs.rs.gov.br/ws/cterecepcaoevento/cterecepcaoevento.asmx", autorizador.getRecepcaoEvento(DFAmbiente.PRODUCAO));
+		Assert.assertEquals("https://cte.svrs.rs.gov.br/ws/cterecepcaoos/cterecepcaoos.asmx", autorizador.getCteRecepcaoOS(DFAmbiente.PRODUCAO));
     }
     
     @Test
@@ -151,6 +164,7 @@ public class CTAutorizador31Test {
     	Assert.assertEquals("https://homologacao.nfe.fazenda.sp.gov.br/cteWEB/services/CteConsulta.asmx", autorizador.getCteConsultaProtocolo(DFAmbiente.HOMOLOGACAO));
     	Assert.assertEquals("https://homologacao.nfe.fazenda.sp.gov.br/cteWEB/services/CteStatusServico.asmx", autorizador.getCteStatusServico(DFAmbiente.HOMOLOGACAO));
     	Assert.assertNull(autorizador.getRecepcaoEvento(DFAmbiente.HOMOLOGACAO));
+		Assert.assertEquals("https://homologacao.nfe.fazenda.sp.gov.br/cteWEB/services/cteRecepcaoOS.asmx", autorizador.getCteRecepcaoOS(DFAmbiente.HOMOLOGACAO));
     	
     	Assert.assertEquals("https://nfe.fazenda.sp.gov.br/cteWEB/services/cteRecepcao.asmx", autorizador.getCteRecepcao(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://nfe.fazenda.sp.gov.br/cteWEB/services/CteRetRecepcao.asmx", autorizador.getCteRetRecepcao(DFAmbiente.PRODUCAO));
@@ -158,5 +172,6 @@ public class CTAutorizador31Test {
     	Assert.assertEquals("https://nfe.fazenda.sp.gov.br/cteWEB/services/CteConsulta.asmx", autorizador.getCteConsultaProtocolo(DFAmbiente.PRODUCAO));
     	Assert.assertEquals("https://nfe.fazenda.sp.gov.br/cteWEB/services/CteStatusServico.asmx", autorizador.getCteStatusServico(DFAmbiente.PRODUCAO));
     	Assert.assertNull(autorizador.getRecepcaoEvento(DFAmbiente.PRODUCAO));
+		Assert.assertEquals("https://nfe.fazenda.sp.gov.br/cteWEB/services/cteRecepcaoOS.asmx", autorizador.getCteRecepcaoOS(DFAmbiente.PRODUCAO));
     }
 }


### PR DESCRIPTION
O CT-e de outros serviços (CT-e OS) é o documento que substitui a nota fiscal de serviço de transporte para os casos de  transporte de pessoas, transporte de valores e excesso de bagagem e também está definido nos serviços do CT-e.

Adicionei o layout desse documento para as versões 3.00 e 4.00, tratei o envio dele através do serviço de recepção específico (CteRecepcaoOS) e incluí uma validação nos eventos do CT-e porque nem todos os eventos podem ser gerado para o CT-e OS.


