### PR TITLE
Corrigido mapeamento da tag vICMSMonoOp na NF-e

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemImpostoICMS53.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemImpostoICMS53.java
@@ -23,7 +23,7 @@ public class NFNotaInfoItemImpostoICMS53 extends DFBase {
     @Element(name = "adRemICMS", required = false)
     private String percentualAliquota;
 
-    @Element(name = "vIcmsMonoOp", required = false)
+    @Element(name = "vICMSMonoOp", required = false)
     private String valorOperacao;
 
     @Element(name = "pDif", required = false)


### PR DESCRIPTION
Pequeno erro de digitação, estava como "v**Icms**MonoOp" em vez de "v**ICMS**MonoOp" e não era possível ler XMLs com essa tag.