### PR TITLE
ajuste link qrcode sefaz mg para ambiente de homologacao

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/CTAutorizador31.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/CTAutorizador31.java
@@ -131,7 +131,7 @@ public enum CTAutorizador31 {
     
         @Override
         public String getCteQrCode(DFAmbiente ambiente) {
-            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://cte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml" : "https://cte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml";
+            return "https://cte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml";
         }
     
         @Override

--- a/src/main/java/com/fincatto/documentofiscal/cte300/classes/CTAutorizador31.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte300/classes/CTAutorizador31.java
@@ -131,7 +131,7 @@ public enum CTAutorizador31 {
     
         @Override
         public String getCteQrCode(DFAmbiente ambiente) {
-            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://hcte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml" : "https://cte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml";
+            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://cte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml" : "https://cte.fazenda.mg.gov.br/portalcte/sistema/qrcode.xhtml";
         }
     
         @Override


### PR DESCRIPTION
Ajustando link do QRCode conforme documentação da SEFAZ de MG para ambiente de homologação e documento fiscal CTe.

#927 