### PR TITLE
Alterado descricao do evento de inclusao de DFe.

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/mdfe3/webservices/WSIncluirDFe.java
+++ b/src/main/java/com/fincatto/documentofiscal/mdfe3/webservices/WSIncluirDFe.java
@@ -20,7 +20,7 @@ import java.util.List;
  */
 class WSIncluirDFe implements DFLog {
 
-    private static final String DESCRICAO_EVENTO = "Inclusao de DF-e";
+    private static final String DESCRICAO_EVENTO = "Inclusao DF-e";
     private static final BigDecimal VERSAO_LEIAUTE = new BigDecimal("3.00");
     private static final String EVENTO_ENCERRAMENTO = "110115";
     private final MDFeConfig config;


### PR DESCRIPTION
Com a descricao 'Inclusao de DF-e' estava dando erro de validação, informando o  valor esperado como 'Inclusao DF-e'. Foi apenas removido a o 'de'.