### PR TITLE
ajustado conversao de codigo para tipo veiculo

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/NFNotaInfoTipoVeiculo.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/NFNotaInfoTipoVeiculo.java
@@ -1,7 +1,5 @@
 package com.fincatto.documentofiscal.nfe400.classes;
 
-import org.apache.commons.lang3.StringUtils;
-
 public enum NFNotaInfoTipoVeiculo {
 
     CICLOMOTO("2", "Ciclomotor"),
@@ -26,8 +24,6 @@ public enum NFNotaInfoTipoVeiculo {
     UTILITARIO("25","Utilit\u00e1rio"),
     MOTOR_CASA("26","Motor Casa");
 
-
-
     private final String codigo;
     private final String descricao;
 
@@ -41,8 +37,13 @@ public enum NFNotaInfoTipoVeiculo {
     }
 
     public static NFNotaInfoTipoVeiculo valueOfCodigo(final String codigo) {
+        if (codigo == null || codigo.isEmpty()) {
+            return null;
+        }
+
+        final int codigoAsInt = Integer.parseInt(codigo);
         for (final NFNotaInfoTipoVeiculo tipoVeiculo : NFNotaInfoTipoVeiculo.values()) {
-            if (tipoVeiculo.getCodigo().equals(codigo)) {
+            if (Integer.parseInt(tipoVeiculo.getCodigo()) == codigoAsInt) {
                 return tipoVeiculo;
             }
         }

--- a/src/test/java/com/fincatto/documentofiscal/nfe400/classes/NFNotaInfoTipoVeiculoTest.java
+++ b/src/test/java/com/fincatto/documentofiscal/nfe400/classes/NFNotaInfoTipoVeiculoTest.java
@@ -28,10 +28,45 @@ public class NFNotaInfoTipoVeiculoTest {
         Assert.assertEquals("24", NFNotaInfoTipoVeiculo.CARGA_CAM.getCodigo());
         Assert.assertEquals("25", NFNotaInfoTipoVeiculo.UTILITARIO.getCodigo());
         Assert.assertEquals("26", NFNotaInfoTipoVeiculo.MOTOR_CASA.getCodigo());
+    }
 
+    @Test
+    public void deveConverterCodigoParaEnum() {
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.CICLOMOTO, NFNotaInfoTipoVeiculo.valueOfCodigo("2"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.CICLOMOTO, NFNotaInfoTipoVeiculo.valueOfCodigo("02"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.MOTONETA, NFNotaInfoTipoVeiculo.valueOfCodigo("3"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.MOTONETA, NFNotaInfoTipoVeiculo.valueOfCodigo("003"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.MOTOCICLO, NFNotaInfoTipoVeiculo.valueOfCodigo("4"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.MOTOCICLO, NFNotaInfoTipoVeiculo.valueOfCodigo("0004"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.TRICICLO, NFNotaInfoTipoVeiculo.valueOfCodigo("5"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.TRICICLO, NFNotaInfoTipoVeiculo.valueOfCodigo("05"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.AUTOMOVEL, NFNotaInfoTipoVeiculo.valueOfCodigo("6"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.AUTOMOVEL, NFNotaInfoTipoVeiculo.valueOfCodigo("06"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.MICROONIBUS, NFNotaInfoTipoVeiculo.valueOfCodigo("7"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.MICROONIBUS, NFNotaInfoTipoVeiculo.valueOfCodigo("07"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.ONIBUS, NFNotaInfoTipoVeiculo.valueOfCodigo("8"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.ONIBUS, NFNotaInfoTipoVeiculo.valueOfCodigo("08"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.REBOQUE, NFNotaInfoTipoVeiculo.valueOfCodigo("10"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.SEMIRREBOQUE, NFNotaInfoTipoVeiculo.valueOfCodigo("11"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.CAMINHONETA, NFNotaInfoTipoVeiculo.valueOfCodigo("13"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.CAMINHAO, NFNotaInfoTipoVeiculo.valueOfCodigo("14"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.TRATOR, NFNotaInfoTipoVeiculo.valueOfCodigo("17"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.TRATOR_RODAS, NFNotaInfoTipoVeiculo.valueOfCodigo("18"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.TRATOR_ESTEIRAS, NFNotaInfoTipoVeiculo.valueOfCodigo("19"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.TRATOR_MISTO, NFNotaInfoTipoVeiculo.valueOfCodigo("20"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.QUADRICICLO, NFNotaInfoTipoVeiculo.valueOfCodigo("21"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.ESP_ONIBUS, NFNotaInfoTipoVeiculo.valueOfCodigo("22"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.MISTO_CAM, NFNotaInfoTipoVeiculo.valueOfCodigo("23"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.CARGA_CAM, NFNotaInfoTipoVeiculo.valueOfCodigo("24"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.UTILITARIO, NFNotaInfoTipoVeiculo.valueOfCodigo("25"));
+        Assert.assertEquals(NFNotaInfoTipoVeiculo.MOTOR_CASA, NFNotaInfoTipoVeiculo.valueOfCodigo("26"));
+    }
 
-
-
-
+    @Test
+    public void condigoInvalidoRetornaNulo() {
+        Assert.assertNull(NFNotaInfoTipoVeiculo.valueOfCodigo("27"));
+        Assert.assertNull(NFNotaInfoTipoVeiculo.valueOfCodigo("0"));
+        Assert.assertNull(NFNotaInfoTipoVeiculo.valueOfCodigo(""));
+        Assert.assertNull(NFNotaInfoTipoVeiculo.valueOfCodigo(null));
     }
 }


### PR DESCRIPTION
o campo no XML aceita por exemplo "01" e "1" para o mesmo caso, por isso é feito as conversões para int para comparar o numero