### PR TITLE
Implementação NF-e/NFC-e Nota Técnica 2025.002-RTC - Versão 1.10 e CT…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.wmixvideo</groupId>
     <artifactId>nfe</artifactId>
-    <version>4.0.85-SNAPSHOT</version>
+    <version>4.0.86-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>nfe</name>
     <description>Biblioteca de comunicacao de nota fiscal eletronica brasileira</description>

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeNotaInfoInformacoesRelativasImpostos.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeNotaInfoInformacoesRelativasImpostos.java
@@ -30,6 +30,12 @@ public class CTeNotaInfoInformacoesRelativasImpostos extends DFBase {
 
     @Element(name = "ICMSUFFim", required = false)
     private CTeNotaInfoInformacoesRelativasImpostosICMSPartilha icmsPartilha;
+    
+    @Element(name = "IBSCBS", required = false)
+    private CTeNotaInfoInformacoesRelativasImpostosIBSCBS ibsCbs;
+    
+    @Element(name = "vTotDFe", required = false)
+    private String vTotDFe;
 
     public CTeNotaInfoInformacoesRelativasImpostosICMS getIcms() {
         return this.icms;
@@ -77,4 +83,25 @@ public class CTeNotaInfoInformacoesRelativasImpostos extends DFBase {
     public void setIcmsPartilha(final CTeNotaInfoInformacoesRelativasImpostosICMSPartilha icmsPartilha) {
         this.icmsPartilha = icmsPartilha;
     }
+
+    public CTeNotaInfoInformacoesRelativasImpostosIBSCBS getIbsCbs() {
+      return ibsCbs;
+    }
+
+    /**
+     * Grupo de informações da composição do valor do IBS e da CBS
+     * @param ibsCbs 
+     */
+    public void setIbsCbs(CTeNotaInfoInformacoesRelativasImpostosIBSCBS ibsCbs) {
+      this.ibsCbs = ibsCbs;
+    }
+
+    public String getVTotDFe() {
+      return vTotDFe;
+    }
+
+    public void setVTotDFe(BigDecimal vTotDFe) {
+      this.vTotDFe = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vTotDFe, "Valor total do documento fiscal");
+    }
+    
 }

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeNotaInfoInformacoesRelativasImpostosIBSCBS.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeNotaInfoInformacoesRelativasImpostosIBSCBS.java
@@ -1,0 +1,334 @@
+package com.fincatto.documentofiscal.cte400.classes.nota;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import java.math.BigDecimal;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+/**
+ * Implementação Nota Técnica 2025.001 – Reforma Tributária do Consumo, Versão
+ * 1.05 de 06 de junho de 2025
+ *
+ * 15/06/2025
+ *
+ * @author Edivaldo Merlo Stens
+ */
+@Root(name = "IBSCBS")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeNotaInfoInformacoesRelativasImpostosIBSCBS extends DFBase {
+
+  private static final long serialVersionUID = -3330020091021955690L;
+
+  @Element(name = "CST", required = true)
+  private String cst;
+
+  @Element(name = "cClassTrib", required = true)
+  private String cClassTrib;
+
+  @Element(name = "gIBSCBS", required = false)
+  private TCIBS gIBSCBS;
+
+  public String getCST() {
+    return cst;
+  }
+
+  public void setCST(String cst) {
+    this.cst = cst;
+  }
+
+  public String getCClassTrib() {
+    return cClassTrib;
+  }
+
+  public void setCClassTrib(String cClassTrib) {
+    this.cClassTrib = cClassTrib;
+  }
+
+  public TCIBS getGIBSCBS() {
+    return gIBSCBS;
+  }
+
+  public void setGIBSCBS(TCIBS gIBSCBS) {
+    this.gIBSCBS = gIBSCBS;
+  }
+
+  @Root(name = "gIBSCBS")
+  @Namespace(reference = CTeConfig.NAMESPACE)
+  public class TCIBS extends DFBase {
+
+    private static final long serialVersionUID = 6387739393518311269L;
+
+    @Element(name = "vBC", required = true)
+    private String vBC;
+
+    @Element(name = "gIBSUF", required = true)
+    private TCIBS.GIBSUF gIBSUF;
+
+    @Element(name = "gIBSMun", required = true)
+    private TCIBS.GIBSMun gIBSMun;
+
+    @Element(name = "gCBS", required = true)
+    private TCIBS.GCBS gCBS;
+
+    @Element()
+    private CTeTTribRegular gTribRegular;
+
+    @Element(name = "gIBSCredPres")
+    private CTeTCredPres gIBSCredPres;
+
+    @Element(name = "gCBSCredPres")
+    private CTeTCredPres gCBSCredPres;
+
+    @Element()
+    private CTeTTribCompraGov gTribCompraGov;
+
+    public String getVBC() {
+      return vBC;
+    }
+
+    public void setVBC(BigDecimal vBC) {
+      this.vBC = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vBC, "Valor da Base de cálculo comum a IBS/CBS");
+    }
+
+    public GIBSUF getGIBSUF() {
+      return gIBSUF;
+    }
+
+    public void setGIBSUF(GIBSUF gIBSUF) {
+      this.gIBSUF = gIBSUF;
+    }
+
+    public GIBSMun getGIBSMun() {
+      return gIBSMun;
+    }
+
+    public void setGIBSMun(GIBSMun gIBSMun) {
+      this.gIBSMun = gIBSMun;
+    }
+
+    public GCBS getGCBS() {
+      return gCBS;
+    }
+
+    public void setGCBS(GCBS gCBS) {
+      this.gCBS = gCBS;
+    }
+
+    public CTeTTribRegular getGTribRegular() {
+      return gTribRegular;
+    }
+
+    public void setGTribRegular(CTeTTribRegular gTribRegular) {
+      this.gTribRegular = gTribRegular;
+    }
+
+    public CTeTCredPres getGIBSCredPres() {
+      return gIBSCredPres;
+    }
+
+    public void setGIBSCredPres(CTeTCredPres gIBSCredPres) {
+      this.gIBSCredPres = gIBSCredPres;
+    }
+
+    public CTeTCredPres getGCBSCredPres() {
+      return gCBSCredPres;
+    }
+
+    public void setGCBSCredPres(CTeTCredPres gCBSCredPres) {
+      this.gCBSCredPres = gCBSCredPres;
+    }
+
+    public CTeTTribCompraGov getGTribCompraGov() {
+      return gTribCompraGov;
+    }
+
+    public void setGTribCompraGov(CTeTTribCompraGov gTribCompraGov) {
+      this.gTribCompraGov = gTribCompraGov;
+    }
+
+    @Root(name = "gIBSUF")
+    @Namespace(reference = CTeConfig.NAMESPACE)
+    public class GIBSUF extends DFBase {
+
+      @Element(name = "pIBSUF", required = true)
+      private String pIBSUF;
+
+      @Element()
+      private CTeTDifIBS gDif;
+
+      @Element()
+      private CTeTDevTrib gDevTrib;
+
+      @Element()
+      private CTeTRed gRed;
+
+      @Element(name = "vIBSUF", required = true)
+      private String vIBSUF;
+
+      public String getPIBSUF() {
+        return pIBSUF;
+      }
+
+      public void setPIBSUF(BigDecimal pIBSUF) {
+        this.pIBSUF = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pIBSUF, "Alíquota do IBS Estadual ");
+      }
+
+      public CTeTDifIBS getGDif() {
+        return gDif;
+      }
+
+      public void setGDif(CTeTDifIBS gDif) {
+        this.gDif = gDif;
+      }
+
+      public CTeTDevTrib getGDevTrib() {
+        return gDevTrib;
+      }
+
+      public void setGDevTrib(CTeTDevTrib gDevTrib) {
+        this.gDevTrib = gDevTrib;
+      }
+
+      public CTeTRed getGRed() {
+        return gRed;
+      }
+
+      public void setGRed(CTeTRed gRed) {
+        this.gRed = gRed;
+      }
+
+      public String getVIBSUF() {
+        return vIBSUF;
+      }
+
+      public void setVIBSUF(BigDecimal vIBSUF) {
+        this.vIBSUF = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vIBSUF, "Valor do IBS de competência da UF ");
+      }
+
+    }
+
+    @Root(name = "gIBSMun")
+    @Namespace(reference = CTeConfig.NAMESPACE)
+    public class GIBSMun extends DFBase {
+
+      @Element(name = "pIBSMun", required = true)
+      private String pIBSMun;
+
+      @Element()
+      private CTeTDifIBS gDif;
+
+      @Element()
+      private CTeTDevTrib gDevTrib;
+
+      @Element()
+      private CTeTRed gRed;
+
+      @Element(name = "vIBSMun", required = true)
+      private String vIBSMun;
+
+      public String getPIBSMun() {
+        return pIBSMun;
+      }
+
+      public void setPIBSMun(BigDecimal pIBSMun) {
+        this.pIBSMun = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pIBSMun, "Alíquota do IBS Municipal");
+      }
+
+      public CTeTDifIBS getGDif() {
+        return gDif;
+      }
+
+      public void setGDif(CTeTDifIBS gDif) {
+        this.gDif = gDif;
+      }
+
+      public CTeTDevTrib getGDevTrib() {
+        return gDevTrib;
+      }
+
+      public void setGDevTrib(CTeTDevTrib gDevTrib) {
+        this.gDevTrib = gDevTrib;
+      }
+
+      public CTeTRed getGRed() {
+        return gRed;
+      }
+
+      public void setGRed(CTeTRed gRed) {
+        this.gRed = gRed;
+      }
+
+      public String getVIBSMun() {
+        return vIBSMun;
+      }
+
+      public void setVIBSMun(BigDecimal vIBSMun) {
+        this.vIBSMun = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vIBSMun, "Valor do IBS de competência do município");
+      }
+
+    }
+
+    @Root(name = "gCBS")
+    @Namespace(reference = CTeConfig.NAMESPACE)
+    public class GCBS extends DFBase {
+
+      @Element(name = "pCBS", required = true)
+      private String pCBS;
+
+      @Element()
+      private CTeTDifCBS gDif;
+
+      @Element()
+      private CTeTDevTrib gDevTrib;
+
+      @Element()
+      private CTeTRed gRed;
+
+      @Element(name = "vCBS", required = true)
+      private String vCBS;
+
+      public String getPCBS() {
+        return pCBS;
+      }
+
+      public void setPCBS(BigDecimal pCBS) {
+        this.pCBS = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pCBS, "Alíquota da CBS");
+      }
+
+      public CTeTDifCBS getGDif() {
+        return gDif;
+      }
+
+      public void setGDif(CTeTDifCBS gDif) {
+        this.gDif = gDif;
+      }
+
+      public CTeTDevTrib getGDevTrib() {
+        return gDevTrib;
+      }
+
+      public void setGDevTrib(CTeTDevTrib gDevTrib) {
+        this.gDevTrib = gDevTrib;
+      }
+
+      public CTeTRed getGRed() {
+        return gRed;
+      }
+
+      public void setGRed(CTeTRed gRed) {
+        this.gRed = gRed;
+      }
+
+      public String getVCBS() {
+        return vCBS;
+      }
+
+      public void setVCBS(BigDecimal vCBS) {
+        this.vCBS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vCBS, "Valor da CBS");
+      }
+    }
+  }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeTCredPres.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeTCredPres.java
@@ -1,0 +1,66 @@
+package com.fincatto.documentofiscal.cte400.classes.nota;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import java.math.BigDecimal;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+/**
+ * 15/06/2025
+ *
+ * @author Edivaldo Merlo Stens
+ */
+@Root(name = "TCredPres")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeTCredPres extends DFBase {
+
+  private static final long serialVersionUID = -3330020091022345698L;
+
+  @Element(required = true)
+  private String cCredPres;
+
+  @Element(required = true)
+  private String pCredPres;
+
+  @Element()
+  private String vCredPres;
+
+  @Element()
+  private String vCredPresCondSus;
+
+  public String getCCredPres() {
+    return cCredPres;
+  }
+
+  public void setCCredPres(String cCredPres) {
+    this.cCredPres = cCredPres;
+  }
+
+  public String getPCredPres() {
+    return pCredPres;
+  }
+
+  public void setPCredPres(BigDecimal pCredPres) {
+    this.pCredPres = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pCredPres, "Percentual de crédito presumido");
+  }
+
+  public String getVCredPres() {
+    return vCredPres;
+  }
+
+  public void setVCredPres(BigDecimal vCredPres) {
+    this.vCredPres = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vCredPres, "Valor do crédito presumido");
+  }
+
+  public String getVCredPresCondSus() {
+    return vCredPresCondSus;
+  }
+
+  public void setVCredPresCondSus(BigDecimal vCredPresCondSus) {
+    this.vCredPresCondSus = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vCredPresCondSus, "Valor do Crédito Presumido Condição Suspensiva Preencher apenas para cCredPres com indicação de Condição Suspensiva");
+  }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeTDevTrib.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeTDevTrib.java
@@ -1,0 +1,33 @@
+package com.fincatto.documentofiscal.cte400.classes.nota;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import java.math.BigDecimal;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+/**
+ * 15/06/2025
+ *
+ * @author Edivaldo Merlo Stens
+ */
+@Root(name = "TDevTrib")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeTDevTrib extends DFBase {
+
+  private static final long serialVersionUID = -3330020091022569858L;
+
+  @Element(required = true)
+  private String vDevTrib;
+
+  public String getVDevTrib() {
+    return vDevTrib;
+  }
+
+  public void setVDevTrib(BigDecimal vDevTrib) {
+    this.vDevTrib = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vDevTrib, "Valor do tributo devolvido");
+  }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeTDifCBS.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeTDifCBS.java
@@ -1,0 +1,44 @@
+package com.fincatto.documentofiscal.cte400.classes.nota;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import java.math.BigDecimal;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+/**
+ * 15/06/2025
+ *
+ * @author Edivaldo Merlo Stens
+ */
+@Root(name = "TDifCBS")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeTDifCBS extends DFBase {
+
+  private static final long serialVersionUID = -3330020091022569956L;
+
+  @Element(required = true)
+  private String pDif;
+
+  @Element(required = true)
+  private String vDif;
+
+  public String getPDif() {
+    return pDif;
+  }
+
+  public void setPDif(BigDecimal pDif) {
+    this.pDif = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pDif, "Percentual de diferimento");
+  }
+
+  public String getVDif() {
+    return vDif;
+  }
+
+  public void setVDif(BigDecimal vDif) {
+    this.vDif = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vDif, "Valor do diferimento");
+  }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeTDifIBS.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeTDifIBS.java
@@ -1,0 +1,44 @@
+package com.fincatto.documentofiscal.cte400.classes.nota;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import java.math.BigDecimal;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+/**
+ * 15/06/2025
+ *
+ * @author Edivaldo Merlo Stens
+ */
+@Root(name = "TDifIBS")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeTDifIBS extends DFBase {
+
+  private static final long serialVersionUID = -3330020091022569873L;
+
+  @Element(required = true)
+  private String pDif;
+
+  @Element(required = true)
+  private String vDif;
+
+  public String getPDif() {
+    return pDif;
+  }
+
+  public void setPDif(BigDecimal pDif) {
+    this.pDif = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pDif, "Percentual de diferimento");
+  }
+
+  public String getVDif() {
+    return vDif;
+  }
+
+  public void setVDif(BigDecimal vDif) {
+    this.vDif = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vDif, "Calor do diferimento");
+  }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeTRed.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeTRed.java
@@ -1,0 +1,44 @@
+package com.fincatto.documentofiscal.cte400.classes.nota;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import java.math.BigDecimal;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+/**
+ * 15/06/2025
+ *
+ * @author Edivaldo Merlo Stens
+ */
+@Root(name = "TRed")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeTRed extends DFBase {
+
+  private static final long serialVersionUID = -3330020091022569872L;
+
+  @Element(required = true)
+  private String pRedAliq;
+
+  @Element(required = true)
+  private String pAliqEfet;
+
+  public String getPRedAliq() {
+    return pRedAliq;
+  }
+
+  public void setPRedAliq(BigDecimal pRedAliq) {
+    this.pRedAliq = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pRedAliq, "Percentual da redução de Alíquota do cClassTrib");
+  }
+
+  public String getPAliqEfet() {
+    return pAliqEfet;
+  }
+
+  public void setPAliqEfet(BigDecimal pAliqEfet) {
+    this.pAliqEfet = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pAliqEfet, "Alíquota efetiva do IBS de competência das UF que será aplicada a base de cálculo");
+  }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeTTribCompraGov.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeTTribCompraGov.java
@@ -1,0 +1,88 @@
+package com.fincatto.documentofiscal.cte400.classes.nota;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import java.math.BigDecimal;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+/**
+ * 15/06/2025
+ *
+ * @author Edivaldo Merlo Stens
+ */
+@Root(name = "TTribCompraGov")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeTTribCompraGov extends DFBase {
+
+  private static final long serialVersionUID = -3330020091023450254L;
+
+  @Element(required = true)
+  private String pAliqIBSUF;
+
+  @Element(required = true)
+  private String vTribIBSUF;
+
+  @Element(required = true)
+  private String pAliqIBSMun;
+
+  @Element(required = true)
+  private String vTribIBSMun;
+
+  @Element(required = true)
+  private String pAliqCBS;
+
+  @Element(required = true)
+  private String vTribCBS;
+
+  public String getPAliqIBSUF() {
+    return pAliqIBSUF;
+  }
+
+  public void setPAliqIBSUF(BigDecimal pAliqIBSUF) {
+    this.pAliqIBSUF = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pAliqIBSUF, "Alíquota IBS da UF utilizada");
+  }
+
+  public String getVTribIBSUF() {
+    return vTribIBSUF;
+  }
+
+  public void setVTribIBSUF(BigDecimal vTribIBSUF) {
+    this.vTribIBSUF = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vTribIBSUF, "Valor do Tributo do IBS da UF");
+  }
+
+  public String getPAliqIBSMun() {
+    return pAliqIBSMun;
+  }
+
+  public void setPAliqIBSMun(BigDecimal pAliqIBSMun) {
+    this.pAliqIBSMun = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pAliqIBSMun, "Alíquota IBS do Município utilizada");
+  }
+
+  public String getVTribIBSMun() {
+    return vTribIBSMun;
+  }
+
+  public void setVTribIBSMun(BigDecimal vTribIBSMun) {
+    this.vTribIBSMun = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vTribIBSMun, "Valor do Tributo do Município da UF");
+  }
+
+  public String getPAliqCBS() {
+    return pAliqCBS;
+  }
+
+  public void setPAliqCBS(BigDecimal pAliqCBS) {
+    this.pAliqCBS = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pAliqCBS, "Alíquota IBS do CBS utilizada");
+  }
+
+  public String getVTribCBS() {
+    return vTribCBS;
+  }
+
+  public void setVTribCBS(BigDecimal vTribCBS) {
+    this.vTribCBS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vTribCBS, "Valor do Tributo da CBS");
+  }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeTTribRegular.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeTTribRegular.java
@@ -1,0 +1,110 @@
+package com.fincatto.documentofiscal.cte400.classes.nota;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import java.math.BigDecimal;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+/**
+ * 15/06/2025
+ *
+ * @author Edivaldo Merlo Stens
+ */
+@Root(name = "TTribRegular")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeTTribRegular extends DFBase {
+
+  private static final long serialVersionUID = -3330020091021942368L;
+
+  @Element(name = "CSTReg", required = true)
+  private String cstReg;
+
+  @Element(required = true)
+  private String cClassTribReg;
+
+  @Element(required = true)
+  private String pAliqEfetRegIBSUF;
+
+  @Element(required = true)
+  private String vTribRegIBSUF;
+
+  @Element(required = true)
+  private String pAliqEfetRegIBSMun;
+
+  @Element(required = true)
+  private String vTribRegIBSMun;
+
+  @Element(required = true)
+  private String pAliqEfetRegCBS;
+
+  @Element(required = true)
+  private String vTribRegCBS;
+
+  public String getCSTReg() {
+    return cstReg;
+  }
+
+  public void setCSTReg(String cstReg) {
+    this.cstReg = cstReg;
+  }
+
+  public String getCClassTribReg() {
+    return cClassTribReg;
+  }
+
+  public void setCClassTribReg(String cClassTribReg) {
+    this.cClassTribReg = cClassTribReg;
+  }
+
+  public String getPAliqEfetRegIBSUF() {
+    return pAliqEfetRegIBSUF;
+  }
+
+  public void setPAliqEfetRegIBSUF(BigDecimal pAliqEfetRegIBSUF) {
+    this.pAliqEfetRegIBSUF = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pAliqEfetRegIBSUF, "Alíquota efetiva da UF Informado a Alíquota caso não cumprida a condição resolutória/suspensiva");
+  }
+
+  public String getVTribRegIBSUF() {
+    return vTribRegIBSUF;
+  }
+
+  public void setVTribRegIBSUF(BigDecimal vTribRegIBSUF) {
+    this.vTribRegIBSUF = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vTribRegIBSUF, "Informado como seria o valor do Tributo da UF caso não cumprida a condição resolutória/suspensiva");
+  }
+
+  public String getPAliqEfetRegIBSMun() {
+    return pAliqEfetRegIBSMun;
+  }
+
+  public void setPAliqEfetRegIBSMun(BigDecimal pAliqEfetRegIBSMun) {
+    this.pAliqEfetRegIBSMun = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pAliqEfetRegIBSMun, "Alíquota efetiva do Município Informado a Alíquota caso não cumprida a condição resolutória/suspensiva");
+  }
+
+  public String getVTribRegIBSMun() {
+    return vTribRegIBSMun;
+  }
+
+  public void setVTribRegIBSMun(BigDecimal vTribRegIBSMun) {
+    this.vTribRegIBSMun = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vTribRegIBSMun, "Informado como seria o valor do Tributo do Município caso não cumprida a condição resolutória/suspensiva");
+  }
+
+  public String getPAliqEfetRegCBS() {
+    return pAliqEfetRegCBS;
+  }
+
+  public void setPAliqEfetRegCBS(BigDecimal pAliqEfetRegCBS) {
+    this.pAliqEfetRegCBS = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pAliqEfetRegCBS, "Alíquota efetiva da CBS Informado a Alíquota caso não cumprida a condição resolutória/suspensiva");
+  }
+
+  public String getVTribRegCBS() {
+    return vTribRegCBS;
+  }
+
+  public void setVTribRegCBS(BigDecimal vTribRegCBS) {
+    this.vTribRegCBS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vTribRegCBS, "Informado como seria o valor do Tributo CBS caso não cumprida a condição resolutória/suspensiva");
+  }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/NFCredito.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/NFCredito.java
@@ -1,0 +1,37 @@
+package com.fincatto.documentofiscal.nfe400.classes;
+
+public enum NFCredito {
+
+  MULTA_JUROS("01", "Multa e juros"),
+  APROPRIACAO_CREDITO_PRESUMIDO_IBS_SALDO_DEVEDOR_ZFM("02", "Apropriação de crédito presumido de IBS sobre o saldo devedor na ZFM (art. 450, § 1º, LC 214/25)");
+
+  private final String codigo;
+  private final String descricao;
+
+  NFCredito(final String codigo, final String descricao) {
+    this.codigo = codigo;
+    this.descricao = descricao;
+  }
+
+  public String getCodigo() {
+    return this.codigo;
+  }
+
+  public String getDescricao() {
+    return this.descricao;
+  }
+
+  public static NFCredito valueOfCodigo(final String codigo) {
+    for (final NFCredito tipo : NFCredito.values()) {
+      if (tipo.getCodigo().equals(codigo)) {
+        return tipo;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    return codigo + " - " + descricao;
+  }
+}

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/NFDebito.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/NFDebito.java
@@ -1,0 +1,42 @@
+package com.fincatto.documentofiscal.nfe400.classes;
+
+public enum NFDebito {
+
+  TRANSFERENCIA_CREDITO_COOPERATIVA("01", "Transferência de créditos para Cooperativas"),
+  ANULACAO_CREDITO_SAIDA_IMUNE_ISENTA("02", "Anulação de Crédito por Saídas Imunes/Isentas"),
+  DEBITO_NOTAS_NAO_PROCESSADAS_APURACAO("03", "Débitos de notas fiscais não processadas na apuração"),
+  MULTA_JUROS("04", "Multa e juros"),
+  TRANSFERENCIA_CREDITO_SUCESSAO("05", "Transferência de crédito de sucessão"),
+  PAGAMENTO_ANTECIPADO("06", "Pagamento antecipado"),
+  PERDA_ESTOQUE("07", "Perda em estoque");
+
+  private final String codigo;
+  private final String descricao;
+
+  NFDebito(final String codigo, final String descricao) {
+    this.codigo = codigo;
+    this.descricao = descricao;
+  }
+
+  public String getCodigo() {
+    return this.codigo;
+  }
+
+  public String getDescricao() {
+    return this.descricao;
+  }
+
+  public static NFDebito valueOfCodigo(final String codigo) {
+    for (final NFDebito tipo : NFDebito.values()) {
+      if (tipo.getCodigo().equals(codigo)) {
+        return tipo;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    return codigo + " - " + descricao;
+  }
+}

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/NFFinalidade.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/NFFinalidade.java
@@ -5,7 +5,9 @@ public enum NFFinalidade {
     NORMAL("1", "Normal"),
     COMPLEMENTAR("2", "Complementar"),
     AJUSTE("3", "Ajuste"),
-    DEVOLUCAO_OU_RETORNO("4", "Devolu\u00e7\u00e3o ou retorno");
+    DEVOLUCAO_OU_RETORNO("4", "Devolu\u00e7\u00e3o ou retorno"),
+    NOTA_CREDITO("5", "Nota de cr\u00e9dito"),
+    NOTA_DEBITO("6", "Nota de d\u00e9bito");
 
     private final String codigo;
     private final String descricao;

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/NFNotaInfoImpostoTributacaoIBSCBS.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/NFNotaInfoImpostoTributacaoIBSCBS.java
@@ -1,0 +1,36 @@
+package com.fincatto.documentofiscal.nfe400.classes;
+
+public enum NFNotaInfoImpostoTributacaoIBSCBS {
+
+  A_DEFINIR("00", "A Definir");
+
+  private final String codigo;
+  private final String descricao;
+
+  NFNotaInfoImpostoTributacaoIBSCBS(final String codigo, final String descricao) {
+    this.codigo = codigo;
+    this.descricao = descricao;
+  }
+
+  public String getCodigo() {
+    return this.codigo;
+  }
+
+  public String getDescricao() {
+    return this.descricao;
+  }
+
+  public static NFNotaInfoImpostoTributacaoIBSCBS valueOfCodigo(final String codigoICMS) {
+    for (final NFNotaInfoImpostoTributacaoIBSCBS icms : NFNotaInfoImpostoTributacaoIBSCBS.values()) {
+      if (icms.getCodigo().equals(codigoICMS)) {
+        return icms;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    return codigo + " - " + descricao;
+  }
+}

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/NFNotaInfoImpostoTributacaoIS.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/NFNotaInfoImpostoTributacaoIS.java
@@ -1,0 +1,36 @@
+package com.fincatto.documentofiscal.nfe400.classes;
+
+public enum NFNotaInfoImpostoTributacaoIS {
+
+  A_DEFINIR("00", "A Definir");
+
+  private final String codigo;
+  private final String descricao;
+
+  NFNotaInfoImpostoTributacaoIS(final String codigo, final String descricao) {
+    this.codigo = codigo;
+    this.descricao = descricao;
+  }
+
+  public String getCodigo() {
+    return this.codigo;
+  }
+
+  public String getDescricao() {
+    return this.descricao;
+  }
+
+  public static NFNotaInfoImpostoTributacaoIS valueOfCodigo(final String codigoICMS) {
+    for (final NFNotaInfoImpostoTributacaoIS icms : NFNotaInfoImpostoTributacaoIS.values()) {
+      if (icms.getCodigo().equals(codigoICMS)) {
+        return icms;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public String toString() {
+    return codigo + " - " + descricao;
+  }
+}

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoDFeReferenciado.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoDFeReferenciado.java
@@ -1,0 +1,37 @@
+package com.fincatto.documentofiscal.nfe400.classes.nota;
+
+import com.fincatto.documentofiscal.DFBase;
+import org.simpleframework.xml.Element;
+
+/**
+ * VC01
+ *
+ * @author Edivaldo Merlo Stens
+ */
+public class NFNotaInfoDFeReferenciado extends DFBase {
+
+  private static final long serialVersionUID = -2776137091542174568L;
+
+  @Element(required = true)
+  private String chaveAcesso; // VC02
+
+  @Element(required = false)
+  private Integer nItem; // VC03
+
+  public String getChaveAcesso() {
+    return chaveAcesso;
+  }
+
+  public void setChaveAcesso(String chaveAcesso) {
+    this.chaveAcesso = chaveAcesso;
+  }
+
+  public Integer getNItem() {
+    return nItem;
+  }
+
+  public void setNItem(Integer nItem) {
+    this.nItem = nItem;
+  }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoIBSCBSTot.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoIBSCBSTot.java
@@ -1,0 +1,329 @@
+package com.fincatto.documentofiscal.nfe400.classes.nota;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import java.math.BigDecimal;
+import org.simpleframework.xml.Element;
+
+/**
+ * W34
+ *
+ * @author Edivaldo Merlo Stens
+ */
+public class NFNotaInfoIBSCBSTot extends DFBase {
+
+  private static final long serialVersionUID = 1644701343314751237L;
+
+  @Element(name = "vBCIBSCBS")
+  private String vBCIBSCBS; // W35
+
+  @Element(name = "gIBS")
+  private NFNotaInfoIBSCBSTot.GIBS gIBS; // W36
+
+  @Element(name = "gCBS")
+  private NFNotaInfoIBSCBSTot.GCBS gCBS; // W50
+
+  @Element(name = "gMono")
+  private NFNotaInfoIBSCBSTot.GMono gMono; // W57
+
+  public String getVBCIBSCBS() {
+    return vBCIBSCBS;
+  }
+
+  public void setVBCIBSCBS(BigDecimal vBCIBSCBS) {
+    this.vBCIBSCBS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vBCIBSCBS, "Valor total da BC do IBS e da CBS");;
+  }
+
+  public NFNotaInfoIBSCBSTot.GIBS getGIBS() {
+    return gIBS;
+  }
+
+  public void setGIBS(NFNotaInfoIBSCBSTot.GIBS gIBS) {
+    this.gIBS = gIBS;
+  }
+
+  public NFNotaInfoIBSCBSTot.GCBS getGCBS() {
+    return gCBS;
+  }
+
+  public void setGCBS(NFNotaInfoIBSCBSTot.GCBS gCBS) {
+    this.gCBS = gCBS;
+  }
+
+  public NFNotaInfoIBSCBSTot.GMono getGMono() {
+    return gMono;
+  }
+
+  public void setGMono(NFNotaInfoIBSCBSTot.GMono gMono) {
+    this.gMono = gMono;
+  }
+
+  // W36
+  public class GIBS extends DFBase {
+
+    private static final long serialVersionUID = 6387739393518311458L;
+
+    @Element(name = "gIBSUF", required = true)
+    private GIBS.GIBSUF gIBSUF; // W37
+
+    @Element(name = "gIBSMun", required = true)
+    private GIBS.GIBSMun gIBSMun; // W42
+
+    @Element(name = "vIBS", required = true)
+    private String vIBS; // W47
+
+    @Element(name = "vCredPres", required = true)
+    private String vCredPres; // W48
+
+    @Element(name = "vCredPresCondSus", required = true)
+    private String vCredPresCondSus; // W49
+
+    public GIBSUF getGIBSUF() {
+      return gIBSUF;
+    }
+
+    public void setGIBSUF(GIBSUF gIBSUF) {
+      this.gIBSUF = gIBSUF;
+    }
+
+    public GIBSMun getGIBSMun() {
+      return gIBSMun;
+    }
+
+    public void setGIBSMun(GIBSMun gIBSMun) {
+      this.gIBSMun = gIBSMun;
+    }
+
+    public String getVIBS() {
+      return vIBS;
+    }
+
+    public void setVIBS(BigDecimal vIBS) {
+      this.vIBS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vIBS, "Valor total do IBS");
+    }
+
+    public String getVCredPres() {
+      return vCredPres;
+    }
+
+    public void setVCredPres(BigDecimal vCredPres) {
+      this.vCredPres = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vCredPres, "Valor total do crédito presumido");
+    }
+
+    public String getVCredPresCondSus() {
+      return vCredPresCondSus;
+    }
+
+    public void setVCredPresCondSus(BigDecimal vCredPresCondSus) {
+      this.vCredPresCondSus = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vCredPresCondSus, "Valor total do crédito presumido em condição suspensiva");
+    }
+
+    // W37
+    public class GIBSUF extends DFBase {
+
+      @Element(name = "vDif", required = true)
+      private String vDif; // W38
+
+      @Element(name = "vDevTrib", required = true)
+      private String vDevTrib; // W39
+
+      @Element(name = "vIBSUF", required = true)
+      private String vIBSUF; // W41
+
+      public String getVDif() {
+        return vDif;
+      }
+
+      public void setVDif(BigDecimal vDif) {
+        this.vDif = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vDif, "Valor total do diferimento");
+      }
+
+      public String getVDevTrib() {
+        return vDevTrib;
+      }
+
+      public void setVDevTrib(BigDecimal vDevTrib) {
+        this.vDevTrib = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vDevTrib, "Valor total de devolução de tributos");
+      }
+
+      public String getVIBSUF() {
+        return vIBSUF;
+      }
+
+      public void setVIBSUF(BigDecimal vIBSUF) {
+        this.vIBSUF = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vIBSUF, "Valor total do IBS da UF");;
+      }
+
+    }
+
+    // W42
+    public class GIBSMun extends DFBase {
+
+      @Element(required = true)
+      private String vDif; // W43
+
+      @Element(required = true)
+      private String vDevTrib; // W44
+
+      @Element(required = true)
+      private String vIBSMun; // W46
+
+      public String getVDif() {
+        return vDif;
+      }
+
+      public void setVDif(BigDecimal vDif) {
+        this.vDif = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vDif, "Valor total do diferimento");
+      }
+
+      public String getVDevTrib() {
+        return vDevTrib;
+      }
+
+      public void setVDevTrib(BigDecimal vDevTrib) {
+        this.vDevTrib = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vDevTrib, "Valor total de devolução de tributos");
+      }
+
+      public String getVIBSMun() {
+        return vIBSMun;
+      }
+
+      public void setVIBSMun(BigDecimal vIBSMun) {
+        this.vIBSMun = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vIBSMun, "Valor total do IBS do Município");
+      }
+
+    }
+
+  }
+
+  // W50
+  public class GCBS extends DFBase {
+
+    @Element(required = true)
+    private String vDif; // W53
+
+    @Element(required = true)
+    private String vDevTrib; // W54
+
+    @Element(required = true)
+    private String vCBS; // W56
+
+    @Element(required = true)
+    private String vCredPres; // W56a
+
+    @Element(required = true)
+    private String vCredPresCondSus; // W56b
+
+    public String getVDif() {
+      return vDif;
+    }
+
+    public void setVDif(BigDecimal vDif) {
+      this.vDif = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vDif, "Valor total do diferimento");
+    }
+
+    public String getVDevTrib() {
+      return vDevTrib;
+    }
+
+    public void setVDevTrib(BigDecimal vDevTrib) {
+      this.vDevTrib = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vDevTrib, "Valor total de devolução de tributos");
+    }
+
+    public String getVCBS() {
+      return vCBS;
+    }
+
+    public void setVCBS(BigDecimal vCBS) {
+      this.vCBS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vCBS, "Valor total da CBS");
+    }
+
+    public String getVCredPres() {
+      return vCredPres;
+    }
+
+    public void setVCredPres(BigDecimal vCredPres) {
+      this.vCredPres = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vCredPres, "Valor total do crédito presumido");
+    }
+
+    public String getVCredPresCondSus() {
+      return vCredPresCondSus;
+    }
+
+    public void setVCredPresCondSus(BigDecimal vCredPresCondSus) {
+      this.vCredPresCondSus = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vCredPresCondSus, "Valor total do crédito presumido em condição suspensiva");
+    }
+
+  }
+
+  // W57
+  public class GMono extends DFBase {
+
+    @Element(required = true)
+    private String vIBSMono; // W58
+
+    @Element(required = true)
+    private String vCBSMono; // W59
+
+    @Element(required = true)
+    private String vIBSMonoReten; // W59a
+
+    @Element(required = true)
+    private String vCBSMonoReten; // W59b
+
+    @Element(required = true)
+    private String vIBSMonoRet; // W59c
+
+    @Element(required = true)
+    private String vCBSMonoRet; // W59d
+
+    public String getVIBSMono() {
+      return vIBSMono;
+    }
+
+    public void setVIBSMono(BigDecimal vIBSMono) {
+      this.vIBSMono = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vIBSMono, "Valor do IBS monofásico");
+    }
+
+    public String getVCBSMono() {
+      return vCBSMono;
+    }
+
+    public void setVCBSMono(BigDecimal vCBSMono) {
+      this.vCBSMono = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vCBSMono, "Valor da CBS monofásica");
+    }
+
+    public String getVIBSMonoReten() {
+      return vIBSMonoReten;
+    }
+
+    public void setVIBSMonoReten(BigDecimal vIBSMonoReten) {
+      this.vIBSMonoReten = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vIBSMonoReten, "Total do IBS monofásico sujeito a retenção");
+    }
+
+    public String getVCBSMonoReten() {
+      return vCBSMonoReten;
+    }
+
+    public void setVCBSMonoReten(BigDecimal vCBSMonoReten) {
+      this.vCBSMonoReten = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vCBSMonoReten, "Total da CBS monofásica sujeita a retenção");
+    }
+
+    public String getVIBSMonoRet() {
+      return vIBSMonoRet;
+    }
+
+    public void setVIBSMonoRet(BigDecimal vIBSMonoRet) {
+      this.vIBSMonoRet = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vIBSMonoRet, "Total do IBS monofásico retido anteriormente");
+    }
+
+    public String getVCBSMonoRet() {
+      return vCBSMonoRet;
+    }
+
+    public void setVCBSMonoRet(BigDecimal vCBSMonoRet) {
+      this.vCBSMonoRet = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vCBSMonoRet, "Total da CBS monofásica retida anteriormente");
+    }
+
+  }
+}

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoISTot.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoISTot.java
@@ -1,0 +1,28 @@
+package com.fincatto.documentofiscal.nfe400.classes.nota;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import java.math.BigDecimal;
+import org.simpleframework.xml.Element;
+
+/**
+ * W31
+ *
+ * @author Edivaldo Merlo Stens
+ */
+public class NFNotaInfoISTot extends DFBase {
+
+  private static final long serialVersionUID = 1644701343314788458L;
+
+  @Element(name = "vIS")
+  private String vIS; // W33
+
+  public String getVIS() {
+    return vIS;
+  }
+
+  public void setVIS(BigDecimal vIS) {
+    this.vIS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vIS, "Valor Total do Imposto Seletivo");
+  }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoIdentificacao.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoIdentificacao.java
@@ -5,6 +5,8 @@ import com.fincatto.documentofiscal.DFBase;
 import com.fincatto.documentofiscal.DFModelo;
 import com.fincatto.documentofiscal.DFUnidadeFederativa;
 import com.fincatto.documentofiscal.nfe.NFTipoEmissao;
+import com.fincatto.documentofiscal.nfe400.classes.NFCredito;
+import com.fincatto.documentofiscal.nfe400.classes.NFDebito;
 import com.fincatto.documentofiscal.nfe400.classes.NFFinalidade;
 import com.fincatto.documentofiscal.nfe400.classes.NFProcessoEmissor;
 import com.fincatto.documentofiscal.nfe400.classes.NFTipo;
@@ -53,7 +55,10 @@ public class NFNotaInfoIdentificacao extends DFBase {
     private NFIdentificadorLocalDestinoOperacao identificadorLocalDestinoOperacao;
 
     @Element(name = "cMunFG")
-    private String codigoMunicipio;
+    private String codigoMunicipio; // B12
+    
+    @Element(required = false)
+    private String cMunFGIBS; // B12a
 
     @Element(name = "tpImp")
     private NFTipoImpressao tipoImpressao;
@@ -68,16 +73,22 @@ public class NFNotaInfoIdentificacao extends DFBase {
     private DFAmbiente ambiente;
 
     @Element(name = "finNFe")
-    private NFFinalidade finalidade;
+    private NFFinalidade finalidade; // B25
+    
+    @Element(required = false)
+    private NFDebito tpNFDebito; // B25.1
+    
+    @Element(required = false)
+    private NFCredito tpNFCredito; // B25.2
 
     @Element(name = "indFinal")
-    private NFOperacaoConsumidorFinal operacaoConsumidorFinal;
+    private NFOperacaoConsumidorFinal operacaoConsumidorFinal; // B25a
 
     @Element(name = "indPres")
-    private NFIndicadorPresencaComprador indicadorPresencaComprador;
+    private NFIndicadorPresencaComprador indicadorPresencaComprador; // B25b
 
     @Element(name = "indIntermed", required = false)
-    private NFIndicadorIntermediador indIntermed;
+    private NFIndicadorIntermediador indIntermed; // B25c
     
     @Element(name = "procEmi")
     private NFProcessoEmissor programaEmissor;
@@ -94,6 +105,11 @@ public class NFNotaInfoIdentificacao extends DFBase {
     @ElementList(entry = "NFref", inline = true, required = false)
     private List<NFInfoReferenciada> referenciadas;
     
+    @Element(name = "gCompraGov", required = false)
+    private NFNotaInfoIdentificacaoCompraGov gCompraGov; // B31
+    
+    @Element(name = "gPagAntecipado", required = false)
+    private NFNotaInfoIdentificacaoPagAntecipado gPagAntecipado; // BB01
 
     public void setUf(final DFUnidadeFederativa uf) {
         this.uf = uf;
@@ -147,11 +163,23 @@ public class NFNotaInfoIdentificacao extends DFBase {
         this.codigoMunicipio = codigoMunicipio;
     }
 
+    public void setCMunFGIBS(String cMunFGIBS) {
+       this.cMunFGIBS = cMunFGIBS;
+    }
+
     public void setReferenciadas(final List<NFInfoReferenciada> referenciadas) {
         DFListValidador.tamanho500(referenciadas, "Referenciadas");
         this.referenciadas = referenciadas;
     }
 
+    public NFNotaInfoIdentificacaoCompraGov getGCompraGov() {
+        return gCompraGov;
+    }
+
+    public NFNotaInfoIdentificacaoPagAntecipado getGPagAntecipado() {
+       return gPagAntecipado;
+    }
+    
     public void setTipoImpressao(final NFTipoImpressao tipoImpressao) {
         this.tipoImpressao = tipoImpressao;
     }
@@ -171,6 +199,14 @@ public class NFNotaInfoIdentificacao extends DFBase {
 
     public void setFinalidade(final NFFinalidade finalidade) {
         this.finalidade = finalidade;
+    }
+
+    public NFDebito getTpNFDebito() {
+       return tpNFDebito;
+    }
+
+    public NFCredito getTpNFCredito() {
+        return tpNFCredito;
     }
 
     public void setProgramaEmissor(final NFProcessoEmissor programaEmissor) {
@@ -251,6 +287,10 @@ public class NFNotaInfoIdentificacao extends DFBase {
         return this.codigoMunicipio;
     }
 
+    public String getCMunFGIBS() {
+        return cMunFGIBS;
+    }
+    
     public NFTipoImpressao getTipoImpressao() {
         return this.tipoImpressao;
     }
@@ -271,6 +311,14 @@ public class NFNotaInfoIdentificacao extends DFBase {
         return this.finalidade;
     }
 
+    public void setTpNFDebito(NFDebito tpNFDebito) {
+        this.tpNFDebito = tpNFDebito;
+    }
+    
+    public void setTpNFCredito(NFCredito tpNFCredito) {
+        this.tpNFCredito = tpNFCredito;
+    }
+    
     public NFOperacaoConsumidorFinal getOperacaoConsumidorFinal() {
         return this.operacaoConsumidorFinal;
     }
@@ -301,6 +349,14 @@ public class NFNotaInfoIdentificacao extends DFBase {
 
     public List<NFInfoReferenciada> getReferenciadas() {
         return this.referenciadas;
+    }
+    
+    public void setGCompraGov(NFNotaInfoIdentificacaoCompraGov gCompraGov) {
+       this.gCompraGov = gCompraGov;
+    }
+    
+    public void setGPagAntecipado(NFNotaInfoIdentificacaoPagAntecipado gPagAntecipado) {
+        this.gPagAntecipado = gPagAntecipado;
     }
 	
 }

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoIdentificacaoCompraGov.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoIdentificacaoCompraGov.java
@@ -1,0 +1,50 @@
+package com.fincatto.documentofiscal.nfe400.classes.nota;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import java.math.BigDecimal;
+import org.simpleframework.xml.Element;
+
+/**
+ * // B31
+ *
+ * @author Edivaldo Merlo Stens
+ */
+public class NFNotaInfoIdentificacaoCompraGov extends DFBase {
+
+  private static final long serialVersionUID = -2568396066960852196L;
+
+  @Element(required = true)
+  private String tpEnteGov; // B32
+
+  @Element(required = true)
+  private String pRedutor; // B33
+
+  @Element(required = true)
+  private String tpOperGov; // B34
+
+  public String getTpEnteGov() {
+    return tpEnteGov;
+  }
+
+  public void setTpEnteGov(String tpEnteGov) {
+    this.tpEnteGov = tpEnteGov;
+  }
+
+  public String getPRedutor() {
+    return pRedutor;
+  }
+
+  public void setPRedutor(BigDecimal pRedutor) {
+    this.pRedutor = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pRedutor, "Valor total da NF-e com IBS / CBS / IS");
+  }
+
+  public String getTpOperGov() {
+    return tpOperGov;
+  }
+
+  public void setTpOperGov(String tpOperGov) {
+    this.tpOperGov = tpOperGov;
+  }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoIdentificacaoPagAntecipado.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoIdentificacaoPagAntecipado.java
@@ -1,0 +1,24 @@
+package com.fincatto.documentofiscal.nfe400.classes.nota;
+
+import com.fincatto.documentofiscal.DFBase;
+
+/**
+ * // BB01
+ *
+ * @author Edivaldo Merlo Stens
+ */
+public class NFNotaInfoIdentificacaoPagAntecipado extends DFBase {
+
+  private static final long serialVersionUID = -2568396066960857836L;
+
+  private String refNFe; // BB02
+
+  public String getRefNFe() {
+    return refNFe;
+  }
+
+  public void setRefNFe(String refNFe) {
+    this.refNFe = refNFe;
+  }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItem.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItem.java
@@ -1,83 +1,106 @@
 package com.fincatto.documentofiscal.nfe400.classes.nota;
 
 import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
 import com.fincatto.documentofiscal.validadores.DFIntegerValidador;
 import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import java.math.BigDecimal;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
-import org.simpleframework.xml.ElementList;
-
-import java.util.List;
 
 public class NFNotaInfoItem extends DFBase {
-    private static final long serialVersionUID = 362646693945373643L;
-    
-    @Attribute(name = "nItem")
-    private Integer numeroItem;
-    
-    @Element(name = "prod")
-    private NFNotaInfoItemProduto produto;
-    
-    @Element(name = "imposto")
-    private NFNotaInfoItemImposto imposto;
 
-    @Element(name = "impostoDevol", required = false)
-    private NFImpostoDevolvido impostoDevolvido;
+  private static final long serialVersionUID = 362646693945373643L;
 
-    @Element(name = "infAdProd", required = false)
-    private String informacoesAdicionais;
+  @Attribute(name = "nItem")
+  private Integer numeroItem;
 
-    @Element(name = "obsItem", required = false)
-    private NFNotaInfoItemObservacao itemObservacao;
+  @Element(name = "prod")
+  private NFNotaInfoItemProduto produto;
 
-    public void setNumeroItem(final Integer numeroItem) {
-        DFIntegerValidador.tamanho3maximo990(numeroItem, "Numero do Item");
-        this.numeroItem = numeroItem;
-    }
+  @Element(name = "imposto")
+  private NFNotaInfoItemImposto imposto;
 
-    public void setInformacoesAdicionais(final String informacoesAdicionais) {
-        DFStringValidador.tamanho500(informacoesAdicionais, "Informacoes Adicionais do Item");
-        this.informacoesAdicionais = informacoesAdicionais;
-    }
+  @Element(name = "impostoDevol", required = false)
+  private NFImpostoDevolvido impostoDevolvido;
 
-    public void setProduto(final NFNotaInfoItemProduto produto) {
-        this.produto = produto;
-    }
+  @Element(name = "infAdProd", required = false)
+  private String informacoesAdicionais;
 
-    public void setImposto(final NFNotaInfoItemImposto imposto) {
-        this.imposto = imposto;
-    }
+  @Element(name = "obsItem", required = false)
+  private NFNotaInfoItemObservacao itemObservacao;
 
-    public Integer getNumeroItem() {
-        return this.numeroItem;
-    }
+  @Element(name = "vItem", required = false)
+  private String vItem; // VB01
 
-    public NFNotaInfoItemProduto getProduto() {
-        return this.produto;
-    }
+  @Element(name = "dFeReferenciado", required = false)
+  private NFNotaInfoDFeReferenciado dfeReferenciado; // VC01
 
-    public NFNotaInfoItemImposto getImposto() {
-        return this.imposto;
-    }
+  public void setNumeroItem(final Integer numeroItem) {
+    DFIntegerValidador.tamanho3maximo990(numeroItem, "Numero do Item");
+    this.numeroItem = numeroItem;
+  }
 
-    public String getInformacoesAdicionais() {
-        return this.informacoesAdicionais;
-    }
+  public void setInformacoesAdicionais(final String informacoesAdicionais) {
+    DFStringValidador.tamanho500(informacoesAdicionais, "Informacoes Adicionais do Item");
+    this.informacoesAdicionais = informacoesAdicionais;
+  }
 
-    public NFImpostoDevolvido getImpostoDevolvido() {
-        return this.impostoDevolvido;
-    }
+  public void setProduto(final NFNotaInfoItemProduto produto) {
+    this.produto = produto;
+  }
 
-    public void setImpostoDevolvido(final NFImpostoDevolvido impostoDevolvido) {
-        this.impostoDevolvido = impostoDevolvido;
-    }
+  public void setImposto(final NFNotaInfoItemImposto imposto) {
+    this.imposto = imposto;
+  }
 
-    public NFNotaInfoItemObservacao getItemObservacao() {
-        return itemObservacao;
-    }
+  public Integer getNumeroItem() {
+    return this.numeroItem;
+  }
 
-    public void setItemObservacao(
-        final NFNotaInfoItemObservacao itemObservacao) {
-        this.itemObservacao = itemObservacao;
-    }
+  public NFNotaInfoItemProduto getProduto() {
+    return this.produto;
+  }
+
+  public NFNotaInfoItemImposto getImposto() {
+    return this.imposto;
+  }
+
+  public String getInformacoesAdicionais() {
+    return this.informacoesAdicionais;
+  }
+
+  public NFImpostoDevolvido getImpostoDevolvido() {
+    return this.impostoDevolvido;
+  }
+
+  public void setImpostoDevolvido(final NFImpostoDevolvido impostoDevolvido) {
+    this.impostoDevolvido = impostoDevolvido;
+  }
+
+  public NFNotaInfoItemObservacao getItemObservacao() {
+    return itemObservacao;
+  }
+
+  public void setItemObservacao(
+      final NFNotaInfoItemObservacao itemObservacao) {
+    this.itemObservacao = itemObservacao;
+  }
+
+  public String getVItem() {
+    return vItem;
+  }
+
+  public void setVItem(BigDecimal vItem) {
+    this.vItem = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vItem, "Valor do Item do DFe Referenciado");
+  }
+
+  public NFNotaInfoDFeReferenciado getDFeReferenciado() {
+    return dfeReferenciado;
+  }
+
+  public void setDFeReferenciado(NFNotaInfoDFeReferenciado dFeReferenciado) {
+    this.dfeReferenciado = dFeReferenciado;
+  }
+
 }

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemImposto.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemImposto.java
@@ -41,6 +41,12 @@ public class NFNotaInfoItemImposto extends DFBase {
 
     @Element(name = "ICMSUFDest", required = false)
     private NFNotaInfoItemImpostoICMSUFDestino icmsUfDestino;
+    
+    @Element(name = "IS", required = false)
+    private NFNotaInfoItemImpostoIS is; // UB01
+    
+    @Element(name = "IBSCBS", required = false)
+    private NFNotaInfoItemImpostoIBSCBS ibsCbs; // UB12
 
     public void setIcms(final NFNotaInfoItemImpostoICMS icms) {
         if (this.issqn != null) {
@@ -141,6 +147,22 @@ public class NFNotaInfoItemImposto extends DFBase {
 
     public void setIcmsUfDestino(final NFNotaInfoItemImpostoICMSUFDestino icmsUfDestino) {
         this.icmsUfDestino = icmsUfDestino;
+    }
+
+    public NFNotaInfoItemImpostoIS getIs() {
+        return is;
+    }
+
+    public void setIs(NFNotaInfoItemImpostoIS is) {
+        this.is = is;
+    }
+
+    public NFNotaInfoItemImpostoIBSCBS getIbsCbs() {
+        return ibsCbs;
+    }
+
+    public void setIbsCbs(NFNotaInfoItemImpostoIBSCBS ibsCbs) {
+        this.ibsCbs = ibsCbs;
     }
 
 }

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemImpostoIBSCBS.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemImpostoIBSCBS.java
@@ -1,0 +1,83 @@
+package com.fincatto.documentofiscal.nfe400.classes.nota;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.nfe400.classes.NFNotaInfoImpostoTributacaoIBSCBS;
+import org.simpleframework.xml.Element;
+
+/**
+ * UB12
+ *
+ * @author Edivaldo Mero Stens
+ */
+public class NFNotaInfoItemImpostoIBSCBS extends DFBase {
+
+  private static final long serialVersionUID = -366528394939416671L;
+
+  @Element(name = "CST", required = true)
+  private NFNotaInfoImpostoTributacaoIBSCBS cst; // UB13
+
+  @Element(required = true)
+  private String cClassTrib; // UB14
+
+  // UB14a -x- Sequencia XML
+  @Element(required = false)
+  private NFNotaInfoItemImpostoIBSCBSTIBS gIBSCBS; // UB15
+
+  @Element(required = false)
+    private NFNotaInfoItemImpostoIBSCBSMonofasia gIBSCBSMono; // UB84
+
+  @Element(required = false)
+  private NFNotaInfoItemImpostoIBSCBSTransfCred gTransfCred; // UB106
+
+  @Element(required = false)
+  private NFNotaInfoItemImpostoIBSCBSCredPresIBSZFM gCredPresIBSZFM; // UB109
+
+  public NFNotaInfoImpostoTributacaoIBSCBS getCst() {
+    return cst;
+  }
+
+  public void setCst(NFNotaInfoImpostoTributacaoIBSCBS cst) {
+    this.cst = cst;
+  }
+
+  public String getcClassTrib() {
+    return cClassTrib;
+  }
+
+  public void setcClassTrib(String cClassTrib) {
+    this.cClassTrib = cClassTrib;
+  }
+
+  public NFNotaInfoItemImpostoIBSCBSTIBS getGIBSCBS() {
+    return gIBSCBS;
+  }
+
+  public void setGIBSCBS(NFNotaInfoItemImpostoIBSCBSTIBS gIBSCBS) {
+    this.gIBSCBS = gIBSCBS;
+  }
+
+  public NFNotaInfoItemImpostoIBSCBSMonofasia getGIBSCBSMono() {
+    return gIBSCBSMono;
+  }
+
+  public void setGIBSCBSMono(NFNotaInfoItemImpostoIBSCBSMonofasia gIBSCBSMono) {
+    this.gIBSCBSMono = gIBSCBSMono;
+  }
+
+  public NFNotaInfoItemImpostoIBSCBSTransfCred getGTransfCred() {
+    return gTransfCred;
+  }
+
+  public void setGTransfCred(NFNotaInfoItemImpostoIBSCBSTransfCred gTransfCred) {
+    this.gTransfCred = gTransfCred;
+  }
+
+  public NFNotaInfoItemImpostoIBSCBSCredPresIBSZFM getGCredPresIBSZFM() {
+    return gCredPresIBSZFM;
+  }
+
+  public void setGCredPresIBSZFM(NFNotaInfoItemImpostoIBSCBSCredPresIBSZFM gCredPresIBSZFM) {
+    this.gCredPresIBSZFM = gCredPresIBSZFM;
+  }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemImpostoIBSCBSCredPresIBSZFM.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemImpostoIBSCBSCredPresIBSZFM.java
@@ -1,0 +1,39 @@
+package com.fincatto.documentofiscal.nfe400.classes.nota;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import java.math.BigDecimal;
+import org.simpleframework.xml.Element;
+
+/**
+ * UB109
+ *
+ * @author Edivaldo Merlo Stens
+ */
+public class NFNotaInfoItemImpostoIBSCBSCredPresIBSZFM extends DFBase {
+
+  private static final long serialVersionUID = -366528394939245967L;
+
+  @Element(required = true)
+  private String tpCredPresIBSZFM; // UB110
+
+  @Element(required = false)
+  private String vCredPresIBSZFM; // UB111
+
+  public String getTpCredPresIBSZFM() {
+    return tpCredPresIBSZFM;
+  }
+
+  public void setTpCredPresIBSZFM(String tpCredPresIBSZFM) {
+    this.tpCredPresIBSZFM = tpCredPresIBSZFM;
+  }
+
+  public String getVCredPresIBSZFM() {
+    return vCredPresIBSZFM;
+  }
+
+  public void setVCredPresIBSZFM(BigDecimal vCredPresIBSZFM) {
+    this.vCredPresIBSZFM = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vCredPresIBSZFM, "Valor do crédito presumido calculado sobre o saldo devedor apurado");
+  }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemImpostoIBSCBSMonofasia.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemImpostoIBSCBSMonofasia.java
@@ -1,0 +1,253 @@
+package com.fincatto.documentofiscal.nfe400.classes.nota;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import java.math.BigDecimal;
+import org.simpleframework.xml.Element;
+
+/**
+ * UB84
+ *
+ * @author Edivaldo Merlo Stens
+ */
+public class NFNotaInfoItemImpostoIBSCBSMonofasia extends DFBase {
+
+  private static final long serialVersionUID = -366528394939416671L;
+
+  // UB84a -x- Sequência XML
+  @Element(required = false)
+  private String qBCMono; // UB85
+
+  @Element(required = false)
+  private String adRemIBS; // UB86
+
+  @Element(required = false)
+  private String adRemCBS; // UB87
+
+  @Element(required = false)
+  private String vIBSMono; // UB88
+
+  @Element(required = false)
+  private String vCBSMono; // UB89
+
+  // UB90 -x- Sequência XML
+  @Element(required = false)
+  private String qBCMonoReten; // UB91
+
+  @Element(required = false)
+  private String adRemIBSReten; // UB92
+
+  @Element(required = false)
+  private String vIBSMonoReten; // UB93
+
+  @Element(required = false)
+  private String adRemCBSReten; // UB93a
+
+  @Element(required = false)
+  private String vCBSMonoReten; // UB93b
+
+  // UB94 -x- Sequência XML
+  @Element(required = false)
+  private String qBCMonoRet; // UB95
+
+  @Element(required = false)
+  private String adRemIBSRet; // UB96
+
+  @Element(required = false)
+  private String vIBSMonoRet; // UB97
+
+  @Element(required = false)
+  private String adRemCBSRet; // UB98
+
+  @Element(required = false)
+  private String vCBSMonoRet; // UB98a
+
+  // UB99 -x- Sequência XML
+  @Element(required = false)
+  private String pDifIBS; // UB100
+
+  @Element(required = false)
+  private String vIBSMonoDif; // UB101
+
+  @Element(required = false)
+  private String pDifCBS; // UB102
+
+  @Element(required = false)
+  private String vCBSMonoDif; // UB103
+
+  // UB84 -x- Sequência XML
+  @Element(required = true)
+  private String vTotIBSMonoItem; // UB104
+
+  @Element(required = true)
+  private String vTotCBSMonoItem; // UB105
+
+  public String getQBCMono() {
+    return qBCMono;
+  }
+
+  public void setQBCMono(BigDecimal qBCMono) {
+    this.qBCMono = DFBigDecimalValidador.tamanho11Com4CasasDecimais(qBCMono, "Quantidade tributada na monofasia");
+  }
+
+  public String getAdRemIBS() {
+    return adRemIBS;
+  }
+
+  public void setAdRemIBS(BigDecimal adRemIBS) {
+    this.adRemIBS = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(adRemIBS, "Alíquota ad rem do IBS");
+  }
+
+  public String getAdRemCBS() {
+    return adRemCBS;
+  }
+
+  public void setAdRemCBS(BigDecimal adRemCBS) {
+    this.adRemCBS = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(adRemCBS, "Alíquota ad rem da CBS");
+  }
+
+  public String getVIBSMono() {
+    return vIBSMono;
+  }
+
+  public void setVIBSMono(BigDecimal vIBSMono) {
+    this.vIBSMono = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vIBSMono, "Valor do IBS monofásico");
+  }
+
+  public String getVCBSMono() {
+    return vCBSMono;
+  }
+
+  public void setVCBSMono(BigDecimal vCBSMono) {
+    this.vCBSMono = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vCBSMono, "Valor da CBS monofásica");
+  }
+
+  public String getqBCMonoReten() {
+    return qBCMonoReten;
+  }
+
+  public void setqBCMonoReten(BigDecimal qBCMonoReten) {
+    this.qBCMonoReten = DFBigDecimalValidador.tamanho11Com4CasasDecimais(qBCMonoReten, "Quantidade tributada sujeita à retenção na monofasia");
+  }
+
+  public String getAdRemIBSReten() {
+    return adRemIBSReten;
+  }
+
+  public void setAdRemIBSReten(BigDecimal adRemIBSReten) {
+    this.adRemIBSReten = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(adRemIBSReten, "Alíquota ad rem do IBS sujeito a retenção");
+  }
+
+  public String getVIBSMonoReten() {
+    return vIBSMonoReten;
+  }
+
+  public void setVIBSMonoReten(BigDecimal vIBSMonoReten) {
+    this.vIBSMonoReten = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vIBSMonoReten, "Valor do IBS monofásico sujeito a retenção");
+  }
+
+  public String getAdRemCBSReten() {
+    return adRemCBSReten;
+  }
+
+  public void setAdRemCBSReten(BigDecimal adRemCBSReten) {
+    this.adRemCBSReten = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(adRemCBSReten, "Alíquota ad rem da CBS sujeito a retenção");
+  }
+
+  public String getVCBSMonoReten() {
+    return vCBSMonoReten;
+  }
+
+  public void setVCBSMonoReten(BigDecimal vCBSMonoReten) {
+    this.vCBSMonoReten = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vCBSMonoReten, "Valor da CBS monofásica sujeita a retenção");
+  }
+
+  public String getqBCMonoRet() {
+    return qBCMonoRet;
+  }
+
+  public void setqBCMonoRet(BigDecimal qBCMonoRet) {
+    this.qBCMonoRet = DFBigDecimalValidador.tamanho11Com4CasasDecimais(qBCMonoRet, "Quantidade tributada retida anteriormente");
+  }
+
+  public String getAdRemIBSRet() {
+    return adRemIBSRet;
+  }
+
+  public void setAdRemIBSRet(BigDecimal adRemIBSRet) {
+    this.adRemIBSRet = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(adRemIBSRet, "Alíquota ad rem do IBS retido anteriormente");
+  }
+
+  public String getVIBSMonoRet() {
+    return vIBSMonoRet;
+  }
+
+  public void setVIBSMonoRet(BigDecimal vIBSMonoRet) {
+    this.vIBSMonoRet = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vIBSMonoRet, "Valor do IBS retido anteriormente");
+  }
+
+  public String getAdRemCBSRet() {
+    return adRemCBSRet;
+  }
+
+  public void setAdRemCBSRet(BigDecimal adRemCBSRet) {
+    this.adRemCBSRet = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(adRemCBSRet, "Alíquota ad rem da CBS retida anteriormente");
+  }
+
+  public String getVCBSMonoRet() {
+    return vCBSMonoRet;
+  }
+
+  public void setVCBSMonoRet(BigDecimal vCBSMonoRet) {
+    this.vCBSMonoRet = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vCBSMonoRet, "Valor da CBS retida anteriormente");
+  }
+
+  public String getPDifIBS() {
+    return pDifIBS;
+  }
+
+  public void setPDifIBS(BigDecimal pDifIBS) {
+    this.pDifIBS = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pDifIBS, "Percentual do diferimento do imposto monofásico");
+  }
+
+  public String getVIBSMonoDif() {
+    return vIBSMonoDif;
+  }
+
+  public void setVIBSMonoDif(BigDecimal vIBSMonoDif) {
+    this.vIBSMonoDif = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vIBSMonoDif, "Valor do IBS monofásico diferido");
+  }
+
+  public String getPDifCBS() {
+    return pDifCBS;
+  }
+
+  public void setPDifCBS(BigDecimal pDifCBS) {
+    this.pDifCBS = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pDifCBS, "Percentual do diferimento do imposto monofásico");
+  }
+
+  public String getVCBSMonoDif() {
+    return vCBSMonoDif;
+  }
+
+  public void setVCBSMonoDif(BigDecimal vCBSMonoDif) {
+    this.vCBSMonoDif = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vCBSMonoDif, "Valor da CBS Monofásica diferida");
+  }
+
+  public String getVTotIBSMonoItem() {
+    return vTotIBSMonoItem;
+  }
+
+  public void setVTotIBSMonoItem(BigDecimal vTotIBSMonoItem) {
+    this.vTotIBSMonoItem = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vTotIBSMonoItem, "Total de IBS Monofásico");
+  }
+
+  public String getVTotCBSMonoItem() {
+    return vTotCBSMonoItem;
+  }
+
+  public void setVTotCBSMonoItem(BigDecimal vTotCBSMonoItem) {
+    this.vTotCBSMonoItem = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vTotCBSMonoItem, "Total da CBS Monofásica");
+  }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemImpostoIBSCBSTIBS.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemImpostoIBSCBSTIBS.java
@@ -1,0 +1,579 @@
+package com.fincatto.documentofiscal.nfe400.classes.nota;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.nfe400.classes.NFNotaInfoImpostoTributacaoIBSCBS;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import java.math.BigDecimal;
+import org.simpleframework.xml.Element;
+
+// UB15
+public class NFNotaInfoItemImpostoIBSCBSTIBS extends DFBase {
+
+  private static final long serialVersionUID = -366528394939416672L;
+
+  @Element(required = true)
+  private String vBC; // UB16
+
+  @Element(required = true)
+  private GIBSUF gIBSUF; // UB17
+
+  @Element(required = true)
+  private GIBSMun gIBSMun; // UB36
+
+  @Element(required = true)
+  private GCBS gCBS; // UB55
+
+  @Element(required = false)
+  private GTribRegular gTribRegular; // UB68
+
+  @Element(required = false)
+  private GCredPres gIBSCredPres; // UB73
+
+  @Element(required = false)
+  private GCredPres gCBSCredPres; // UB78
+
+  @Element(required = false)
+  private GTribCompraGov gTribCompraGov; // UB82a
+
+  public String getVBC() {
+    return vBC;
+  }
+
+  public void setVBC(BigDecimal vBC) {
+    this.vBC = DFBigDecimalValidador.tamanho15Com4CasasDecimais(vBC, "Base de cálculo do IBS e CBS");
+  }
+
+  public GIBSUF getGIBSUF() {
+    return gIBSUF;
+  }
+
+  public void setGIBSUF(GIBSUF gIBSUF) {
+    this.gIBSUF = gIBSUF;
+  }
+
+  public GIBSMun getGIBSMun() {
+    return gIBSMun;
+  }
+
+  public void setGIBSMun(GIBSMun gIBSMun) {
+    this.gIBSMun = gIBSMun;
+  }
+
+  public GCBS getGCBS() {
+    return gCBS;
+  }
+
+  public void setGCBS(GCBS gCBS) {
+    this.gCBS = gCBS;
+  }
+
+  public GTribRegular getGTribRegular() {
+    return gTribRegular;
+  }
+
+  public void setGTribRegular(GTribRegular gTribRegular) {
+    this.gTribRegular = gTribRegular;
+  }
+
+  public GCredPres getGIBSCredPres() {
+    return gIBSCredPres;
+  }
+
+  public void setGIBSCredPres(GCredPres gIBSCredPres) {
+    this.gIBSCredPres = gIBSCredPres;
+  }
+
+  public GCredPres getGCBSCredPres() {
+    return gCBSCredPres;
+  }
+
+  public void setGCBSCredPres(GCredPres gCBSCredPres) {
+    this.gCBSCredPres = gCBSCredPres;
+  }
+
+  public GTribCompraGov getGTribCompraGov() {
+    return gTribCompraGov;
+  }
+
+  public void setGTribCompraGov(GTribCompraGov gTribCompraGov) {
+    this.gTribCompraGov = gTribCompraGov;
+  }
+
+  // UB17
+  public class GIBSUF extends DFBase {
+
+    @Element(required = true)
+    private String pIBSUF; // UB18
+
+    @Element(required = false)
+    private GDif gDif; // UB21
+
+    @Element(required = false)
+    private GDevTrib gDevTrib; // UB24
+
+    @Element(required = false)
+    private GRed gRed; // UB26
+
+    @Element(required = true)
+    private String vIBSUF; // UB35
+
+    public String getPIBSUF() {
+      return pIBSUF;
+    }
+
+    public void setPIBSUF(BigDecimal pIBSUF) {
+      this.pIBSUF = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pIBSUF, "Alíquota do IBS de competência das UF");
+    }
+
+    public GDif getGDif() {
+      return gDif;
+    }
+
+    public void setGDif(GDif gDif) {
+      this.gDif = gDif;
+    }
+
+    public GDevTrib getGDevTrib() {
+      return gDevTrib;
+    }
+
+    public void setGDevTrib(GDevTrib gDevTrib) {
+      this.gDevTrib = gDevTrib;
+    }
+
+    public GRed getGRed() {
+      return gRed;
+    }
+
+    public void setGRed(GRed gRed) {
+      this.gRed = gRed;
+    }
+
+    public String getVIBSUF() {
+      return vIBSUF;
+    }
+
+    public void setVIBSUF(BigDecimal vIBSUF) {
+      this.vIBSUF = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vIBSUF, "Valor do IBS de competência da UF");
+    }
+
+  }
+
+  // UB36
+  public class GIBSMun extends DFBase {
+
+    private static final long serialVersionUID = -366528394939456789L;
+
+    @Element(required = true)
+    private String pIBSMun; // UB37
+
+    @Element(required = false)
+    private GDif gDif; // UB40
+
+    @Element(required = false)
+    private GDevTrib gDevTrib; // UB43
+
+    @Element(required = false)
+    private GRed gRed; // UB45
+
+    @Element(required = true)
+    private String vIBSMun; // UB54
+
+    public String getPIBSMun() {
+      return pIBSMun;
+    }
+
+    public void setPIBSMun(BigDecimal pIBSMun) {
+      this.pIBSMun = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pIBSMun, "Valor do IBS de competência do Município");
+    }
+
+    public GDif getGDif() {
+      return gDif;
+    }
+
+    public void setGDif(GDif gDif) {
+      this.gDif = gDif;
+    }
+
+    public GDevTrib getGDevTrib() {
+      return gDevTrib;
+    }
+
+    public void setGDevTrib(GDevTrib gDevTrib) {
+      this.gDevTrib = gDevTrib;
+    }
+
+    public GRed getGRed() {
+      return gRed;
+    }
+
+    public void setGRed(GRed gRed) {
+      this.gRed = gRed;
+    }
+
+    public String getVIBSMun() {
+      return vIBSMun;
+    }
+
+    public void setVIBSMun(BigDecimal vIBSMun) {
+      this.vIBSMun = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vIBSMun, "Alíquota do IBS de competência do Município");
+    }
+
+  }
+
+  // UB55
+  public class GCBS extends DFBase {
+
+    private static final long serialVersionUID = -366528394939456790L;
+
+    @Element(required = true)
+    private String pCBS; // UB56
+
+    @Element(required = false)
+    private GDif gDif; // UB59
+
+    @Element(required = false)
+    private GDevTrib gDevTrib; // UB62
+
+    @Element(required = false)
+    private GRed gRed; // UB64
+
+    @Element(required = true)
+    private String vCBS; // UB67
+
+    public String getPCBS() {
+      return pCBS;
+    }
+
+    public void setPCBS(BigDecimal pCBS) {
+      this.pCBS = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pCBS, "Alíquota da CBS");
+    }
+
+    public GDif getGDif() {
+      return gDif;
+    }
+
+    public void setGDif(GDif gDif) {
+      this.gDif = gDif;
+    }
+
+    public GDevTrib getGDevTrib() {
+      return gDevTrib;
+    }
+
+    public void setGDevTrib(GDevTrib gDevTrib) {
+      this.gDevTrib = gDevTrib;
+    }
+
+    public GRed getGRed() {
+      return gRed;
+    }
+
+    public void setGRed(GRed gRed) {
+      this.gRed = gRed;
+    }
+
+    public String getVCBS() {
+      return vCBS;
+    }
+
+    public void setVCBS(BigDecimal vCBS) {
+      this.vCBS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vCBS, "Valor da CBS");
+    }
+  }
+
+  // UB68
+  public class GTribRegular extends DFBase {
+
+    private static final long serialVersionUID = -366528394939456791L;
+
+    @Element(name = "CSTReg", required = true)
+    private NFNotaInfoImpostoTributacaoIBSCBS cstReg; // UB69
+
+    @Element(required = true)
+    private String cClassTribReg; // UB70
+
+    @Element(required = true)
+    private String pAliqEfetRegIBSUF; // UB71
+
+    @Element(required = true)
+    private String vTribRegIBSUF; // UB72
+
+    @Element(required = true)
+    private String pAliqEfetRegIBSMun; // UB72a
+
+    @Element(required = true)
+    private String vTribRegIBSMun; // UB72b
+
+    @Element(required = true)
+    private String pAliqEfetRegCBS; // UB72c
+
+    @Element(required = true)
+    private String vTribRegCBS; // UB72d
+
+    public NFNotaInfoImpostoTributacaoIBSCBS getCstReg() {
+      return cstReg;
+    }
+
+    public void setCstReg(NFNotaInfoImpostoTributacaoIBSCBS cstReg) {
+      this.cstReg = cstReg;
+    }
+
+    public String getCClassTribReg() {
+      return cClassTribReg;
+    }
+
+    public void setCClassTribReg(String cClassTribReg) {
+      this.cClassTribReg = cClassTribReg;
+    }
+
+    public String getPAliqEfetRegIBSUF() {
+      return pAliqEfetRegIBSUF;
+    }
+
+    public void setPAliqEfetRegIBSUF(BigDecimal pAliqEfetRegIBSUF) {
+      this.pAliqEfetRegIBSUF = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pAliqEfetRegIBSUF, "Valor da alíquota do IBS da UF");
+    }
+
+    public String getVTribRegIBSUF() {
+      return vTribRegIBSUF;
+    }
+
+    public void setVTribRegIBSUF(BigDecimal vTribRegIBSUF) {
+      this.vTribRegIBSUF = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vTribRegIBSUF, "Valor do Tributo do IBS da UF");
+    }
+
+    public String getPAliqEfetRegIBSMun() {
+      return pAliqEfetRegIBSMun;
+    }
+
+    public void setPAliqEfetRegIBSMun(BigDecimal pAliqEfetRegIBSMun) {
+      this.pAliqEfetRegIBSMun = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pAliqEfetRegIBSMun, "Valor da alíquota do IBS do Município");
+    }
+
+    public String getVTribRegIBSMun() {
+      return vTribRegIBSMun;
+    }
+
+    public void setVTribRegIBSMun(BigDecimal vTribRegIBSMun) {
+      this.vTribRegIBSMun = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vTribRegIBSMun, "Valor do Tributo do IBS do Município");
+    }
+
+    public String getPAliqEfetRegCBS() {
+      return pAliqEfetRegCBS;
+    }
+
+    public void setPAliqEfetRegCBS(BigDecimal pAliqEfetRegCBS) {
+      this.pAliqEfetRegCBS = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pAliqEfetRegCBS, "Valor da alíquota da CBS");
+    }
+
+    public String getVTribRegCBS() {
+      return vTribRegCBS;
+    }
+
+    public void setVTribRegCBS(BigDecimal vTribRegCBS) {
+      this.vTribRegCBS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vTribRegCBS, "Valor do Tributo da CBS");
+    }
+
+  }
+
+  // UB73 // UB78
+  public class GCredPres extends DFBase {
+
+    private static final long serialVersionUID = -366528394939456792L;
+
+    @Element(required = true)
+    private String cCredPres; // UB74 // UB79
+
+    @Element(required = true)
+    private String pCredPres; // UB75 // UB80
+
+    @Element(required = true)
+    private String vCredPres; // UB76 // UB81
+
+    @Element(required = true)
+    private String vCredPresCondSus; // UB77 // UB82
+
+    public String getcCredPres() {
+      return cCredPres;
+    }
+
+    public void setcCredPres(String cCredPres) {
+      this.cCredPres = cCredPres;
+    }
+
+    public String getPCredPres() {
+      return pCredPres;
+    }
+
+    public void setPCredPres(BigDecimal pCredPres) {
+      this.pCredPres = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pCredPres, "Percentual do Crédito Presumido");
+    }
+
+    public String getVCredPres() {
+      return vCredPres;
+    }
+
+    public void setVCredPres(BigDecimal vCredPres) {
+      this.vCredPres = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vCredPres, "Valor do Crédito Presumido");
+    }
+
+    public String getVCredPresCondSus() {
+      return vCredPresCondSus;
+    }
+
+    public void setVCredPresCondSus(BigDecimal vCredPresCondSus) {
+      this.vCredPresCondSus = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vCredPresCondSus, "Valor do Crédito Presumido em condição suspensiva");
+    }
+
+  }
+
+  // UB82a
+  public class GTribCompraGov extends DFBase {
+
+    private static final long serialVersionUID = -366528394939456794L;
+
+    @Element(required = true)
+    private String pIBSUF; // UB82b
+
+    @Element(required = true)
+    private String vIBSUF; // UB82c
+
+    @Element(required = true)
+    private String pIBSMun; // UB82d
+
+    @Element(required = true)
+    private String vIBSMun; // UB82e
+
+    @Element(required = true)
+    private String pCBS; // UB82f
+
+    @Element(required = true)
+    private String vCBS; // UB82g
+
+    public String getPIBSUF() {
+      return pIBSUF;
+    }
+
+    public void setPIBSUF(BigDecimal pIBSUF) {
+      this.pIBSUF = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pIBSUF, "Alíquota do IBS de competência do Estado");
+    }
+
+    public String getVIBSUF() {
+      return vIBSUF;
+    }
+
+    public void setVIBSUF(BigDecimal vIBSUF) {
+      this.vIBSUF = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vIBSUF, "Valor do Tributo do IBS da UF calculado");
+    }
+
+    public String getPIBSMun() {
+      return pIBSMun;
+    }
+
+    public void setPIBSMun(BigDecimal pIBSMun) {
+      this.pIBSMun = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pIBSMun, "Alíquota do IBS de competência do Município");
+    }
+
+    public String getVIBSMun() {
+      return vIBSMun;
+    }
+
+    public void setVIBSMun(BigDecimal vIBSMun) {
+      this.vIBSMun = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vIBSMun, "Valor do Tributo do IBS do Município calculado");
+    }
+
+    public String getPCBS() {
+      return pCBS;
+    }
+
+    public void setPCBS(BigDecimal pCBS) {
+      this.pCBS = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pCBS, "Alíquota da CBS ");
+    }
+
+    public String getVCBS() {
+      return vCBS;
+    }
+
+    public void setVCBS(BigDecimal vCBS) {
+      this.vCBS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vCBS, "Valor do Tributo da CBS calculado");
+    }
+
+  }
+
+// UB21 // UB40
+  public class GDif extends DFBase {
+
+    private static final long serialVersionUID = -366528394939455687L;
+
+    @Element(required = true)
+    private String pDif; // UB22 // UB41
+
+    @Element(required = true)
+    private String vDif; // UB23 // UB42
+
+    public String getPDif() {
+      return pDif;
+    }
+
+    public void setPDif(BigDecimal pDif) {
+      this.pDif = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pDif, "Percentual do diferimento");
+    }
+
+    public String getVDif() {
+      return vDif;
+    }
+
+    public void setVDif(BigDecimal vDif) {
+      this.vDif = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vDif, "Valor do Diferimento");
+    }
+
+  }
+
+// UB24 // UB43
+  public class GDevTrib extends DFBase {
+
+    private static final long serialVersionUID = -366525684939456789L;
+
+    @Element(required = true)
+    private String vDevTrib; // UB25 // UB44
+
+    public String getVDevTrib() {
+      return vDevTrib;
+    }
+
+    public void setVDevTrib(BigDecimal vDevTrib) {
+      this.vDevTrib = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vDevTrib, "Valor do tributo devolvido");
+    }
+
+  }
+
+// UB26 // UB45
+  public class GRed extends DFBase {
+
+    private static final long serialVersionUID = -366528394939258789L;
+
+    @Element(required = true)
+    private String pRedAliq; // UB27 // UB46
+
+    @Element(required = true)
+    private String pAliqEfet; // UB28 // UB47
+
+    public String getPRedAliq() {
+      return pRedAliq;
+    }
+
+    public void setPRedAliq(BigDecimal pRedAliq) {
+      this.pRedAliq = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pRedAliq, "Percentual da redução de alíquota do cClassTrib");
+    }
+
+    public String getPAliqEfet() {
+      return pAliqEfet;
+    }
+
+    public void setPAliqEfet(BigDecimal pAliqEfet) {
+      this.pAliqEfet = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pAliqEfet, "Alíquota Efetiva do IBS de competência das UF que será aplicada a Base de Cálculo");
+    }
+
+  }
+}

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemImpostoIBSCBSTransfCred.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemImpostoIBSCBSTransfCred.java
@@ -1,0 +1,39 @@
+package com.fincatto.documentofiscal.nfe400.classes.nota;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import java.math.BigDecimal;
+import org.simpleframework.xml.Element;
+
+/**
+ * UB106
+ *
+ * @author Edivaldo Merlo Stens
+ */
+public class NFNotaInfoItemImpostoIBSCBSTransfCred extends DFBase {
+
+  private static final long serialVersionUID = -366528394939245967L;
+
+  @Element(required = true)
+  private String vIBS; // UB107
+
+  @Element(required = true)
+  private String vCBS; // UB108
+
+  public String getVIBS() {
+    return vIBS;
+  }
+
+  public void setVIBS(BigDecimal vIBS) {
+    this.vIBS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vIBS, "Valor do IBS a ser transferido");
+  }
+
+  public String getVCBS() {
+    return vCBS;
+  }
+
+  public void setVCBS(BigDecimal vCBS) {
+    this.vCBS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vCBS, "Valor da CBS a ser transferida");
+  }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemImpostoICMS40.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemImpostoICMS40.java
@@ -10,7 +10,7 @@ import java.math.BigDecimal;
 import org.simpleframework.xml.Element;
 
 public class NFNotaInfoItemImpostoICMS40 extends DFBase {
-    private static final long serialVersionUID = -366528394939416671L;
+    private static final long serialVersionUID = -366528394939416658L;
     
     @Element(name = "orig")
     private NFOrigem origem;

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemImpostoIS.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemImpostoIS.java
@@ -1,0 +1,108 @@
+package com.fincatto.documentofiscal.nfe400.classes.nota;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.nfe400.classes.NFNotaInfoImpostoTributacaoIS;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import java.math.BigDecimal;
+import org.simpleframework.xml.Element;
+
+/**
+ * UB01
+ *
+ * @author Edivaldo Merlo Stens
+ */
+public class NFNotaInfoItemImpostoIS extends DFBase {
+
+  private static final long serialVersionUID = -366528394939416671L;
+
+  @Element(name = "CSTIS", required = true)
+  private NFNotaInfoImpostoTributacaoIS cstIS; // UB02
+
+  @Element(name = "cClassTribIS", required = true)
+  private String cClassTribIS; // UB03
+
+  // UB04 -x- Sequência XML 0-1
+  @Element(required = false)
+  private String vBCIS; // UB05
+
+  @Element(required = false)
+  private String pIS; // UB06
+
+  @Element(required = false)
+  private String pISEspec; // UB07
+
+  // UB08 -x- Sequência XML 0-1
+  @Element(required = false)
+  private String uTrib; // UB09
+
+  @Element(required = false)
+  private String qTrib; // UB10
+
+  @Element(required = false)
+  private String vIS; // UB11
+
+  public NFNotaInfoImpostoTributacaoIS getCstIS() {
+    return cstIS;
+  }
+
+  public void setCstIS(NFNotaInfoImpostoTributacaoIS cstIS) {
+    this.cstIS = cstIS;
+  }
+
+  public String getCClassTribIS() {
+    return cClassTribIS;
+  }
+
+  public void setCClassTribIS(String cClassTribIS) {
+    this.cClassTribIS = cClassTribIS;
+  }
+
+  public String getVBCIS() {
+    return vBCIS;
+  }
+
+  public void getVBCIS(BigDecimal vBCIS) {
+    this.vBCIS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vBCIS, "Valor da Base de Cálculo do Imposto Seletivo");
+  }
+
+  public String getPIS() {
+    return pIS;
+  }
+
+  public void setPIS(BigDecimal pIS) {
+    this.pIS = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pIS, "Alíquota do Imposto Seletivo");
+  }
+
+  public String getPISEspec() {
+    return pISEspec;
+  }
+
+  public void setPISEspec(BigDecimal pISEspec) {
+    this.pISEspec = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(pISEspec, "Alíquota específica por unidade de medida apropriada");
+  }
+
+  public String getuTrib() {
+    return uTrib;
+  }
+
+  public void setuTrib(String uTrib) {
+    this.uTrib = uTrib;
+  }
+
+  public String getQTrib() {
+    return qTrib;
+  }
+
+  public void setQTrib(BigDecimal qTrib) {
+    this.qTrib = DFBigDecimalValidador.tamanho11Com4CasasDecimais(qTrib, "Quantidade Tributável");
+  }
+
+  public String getVIS() {
+    return vIS;
+  }
+
+  public void getVIS(BigDecimal vIS) {
+    this.vIS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vIS, "Valor do Imposto Seletivo");
+  }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoTotal.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoTotal.java
@@ -1,8 +1,13 @@
 package com.fincatto.documentofiscal.nfe400.classes.nota;
 
 import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import java.math.BigDecimal;
 import org.simpleframework.xml.Element;
 
+/**
+ * W01
+ */
 public class NFNotaInfoTotal extends DFBase {
     private static final long serialVersionUID = 4579495471129802055L;
     
@@ -14,6 +19,15 @@ public class NFNotaInfoTotal extends DFBase {
 
     @Element(name = "retTrib", required = false)
     private NFNotaInfoRetencoesTributos retencoesTributos;
+    
+    @Element(name = "ISTot", required = false)
+    private NFNotaInfoISTot isTot; // W31
+    
+    @Element(name = "IBSCBSTot", required = false)
+    private NFNotaInfoIBSCBSTot ibscbsTot; // W34
+    
+    @Element(name = "vNFTot", required = false)
+    private String vNFTot; // W60
 
     public void setIcmsTotal(final NFNotaInfoICMSTotal icmsTotal) {
         this.icmsTotal = icmsTotal;
@@ -38,4 +52,29 @@ public class NFNotaInfoTotal extends DFBase {
     public NFNotaInfoRetencoesTributos getRetencoesTributos() {
         return this.retencoesTributos;
     }
+
+    public NFNotaInfoISTot getIsTot() {
+        return isTot;
+    }
+
+    public void setIsTot(NFNotaInfoISTot isTot) {
+        this.isTot = isTot;
+    }
+
+    public NFNotaInfoIBSCBSTot getIbscbsTot() {
+        return ibscbsTot;
+    }
+
+    public void setIbscbsTot(NFNotaInfoIBSCBSTot ibscbsTot) {
+        this.ibscbsTot = ibscbsTot;
+    }
+
+    public String getVNFTot() {
+        return vNFTot;
+    }
+
+    public void setVNFTot(BigDecimal vNFTot) {
+        this.vNFTot = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vNFTot, "Valor total da NF-e com IBS / CBS / IS");
+    }
+    
 }

--- a/src/main/java/com/fincatto/documentofiscal/validadores/DFBigDecimalValidador.java
+++ b/src/main/java/com/fincatto/documentofiscal/validadores/DFBigDecimalValidador.java
@@ -31,6 +31,10 @@ public abstract class DFBigDecimalValidador {
     public static String tamanho15Com4CasasDecimais(final BigDecimal valor, final String info) {
         return DFBigDecimalValidador.parse(valor, "0.0000", 16, 4, info);
     }
+    
+    public static String tamanho11Com4CasasDecimais(final BigDecimal valor, final String info) {
+        return DFBigDecimalValidador.parse(valor, "0.0000", 11, 4, info);
+    }
 
     public static String tamanho21ComAte10CasasDecimais(final BigDecimal valor, final String info) {
         return DFBigDecimalValidador.parse(valor, "0.##########", 22, 10, info);

--- a/src/main/java/com/fincatto/documentofiscal/validadores/DFXMLValidador.java
+++ b/src/main/java/com/fincatto/documentofiscal/validadores/DFXMLValidador.java
@@ -28,7 +28,7 @@ public final class DFXMLValidador {
     }
 
     public static boolean valida400(final String xml, final String xsd) throws IOException, SAXException, URISyntaxException {
-        final URL xsdPath = DFXMLValidador.class.getClassLoader().getResource(String.format("schemas/PL_009o_NT2024_001_v100/%s", xsd));
+        final URL xsdPath = DFXMLValidador.class.getClassLoader().getResource(String.format("schemas/PL_010b_NT2025_002_v1.00/%s", xsd));
         final SchemaFactory schemaFactory = SchemaFactory.newInstance("http://www.w3.org/2001/XMLSchema");
         final Schema schema = schemaFactory.newSchema(new StreamSource(xsdPath.toURI().toString()));
         schema.newValidator().validate(new StreamSource(new StringReader(xml)));
@@ -142,7 +142,7 @@ public final class DFXMLValidador {
     }
 
     private static boolean validaCTe400(final String xml, final String xsd) throws IOException, SAXException, URISyntaxException {
-        final URL xsdPath = DFXMLValidador.class.getClassLoader().getResource(String.format("schemas/PL_CTe_400/%s", xsd));
+        final URL xsdPath = DFXMLValidador.class.getClassLoader().getResource(String.format("schemas/PL_CTe_400_NT2025.001_RTC_1.05/%s", xsd));
         final SchemaFactory schemaFactory = SchemaFactory.newInstance("http://www.w3.org/2001/XMLSchema");
         final Schema schema = schemaFactory.newSchema(new StreamSource(xsdPath.toURI().toString()));
         schema.newValidator().validate(new StreamSource(new StringReader(xml)));

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/DFeTiposBasicos_v1.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/DFeTiposBasicos_v1.00.xsd
@@ -1,0 +1,1053 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas-softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+	<xs:simpleType name="TStringRTC">
+		<xs:annotation>
+			<xs:documentation> Tipo string genérico</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCST">
+		<xs:annotation>
+			<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="\d{3}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TcClassTrib">
+		<xs:annotation>
+			<xs:documentation>Código de Classificação Tributária do IBS e da CBS</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="\d{6}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec1104">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 11 de corpo e 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{4}|[1-9]{1}[0-9]{0,10}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1104Op">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 11 inteiros, podendo ter 4 decimais (utilizado em tags opcionais)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[1-9]{1}[0-9]{3}|0\.[0-9]{3}[1-9]{1}|0\.[0-9]{2}[1-9]{1}[0-9]{1}|0\.[0-9]{1}[1-9]{1}[0-9]{2}|[1-9]{1}[0-9]{0,10}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec1302">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 13 de corpo e 2 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0302_04">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com até 3 dígitos inteiros, podendo ter de 2 até 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{2,4}|[1-9]{1}[0-9]{0,2}(\.[0-9]{2,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TOperCompraGov">
+		<xs:annotation>
+			<xs:documentation>Tipo da Operação com Ente Governamental</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TEnteGov">
+		<xs:annotation>
+			<xs:documentation>Tipo de Ente Governamental</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+			<xs:enumeration value="3"/>
+			<xs:enumeration value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TTpCredPresIBSZFM">
+		<xs:annotation>
+			<xs:documentation>Tipo de classificação do Crédito Presumido IBS ZFM</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="0"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+			<xs:enumeration value="3"/>
+			<xs:enumeration value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="TTribNFCom">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NFCom</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribNF3e">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NF3e</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribCTe">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação do CTe</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribBPe">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação do BPe</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribNFCe">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NFCe</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:choice minOccurs="0">
+				<xs:element name="gIBSCBS" type="TCIBS"/>
+				<xs:element name="gIBSCBSMono" type="TMonofasia"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribNFe">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NFe</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:choice minOccurs="0">
+				<xs:element name="gIBSCBS" type="TCIBS"/>
+				<xs:element name="gIBSCBSMono" type="TMonofasia">
+					<xs:annotation>
+						<xs:documentation>Informar essa opção da Choice para Monofasia</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="gTransfCred" type="TTransfCred">
+					<xs:annotation>
+						<xs:documentation>Informar essa opção da Choice para o CST 800</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+			<xs:element name="gCredPresIBSZFM" type="TCredPresIBSZFM" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Classificação de acordo com o art. 450, § 1º, da LC 214/25 para o cálculo do crédito presumido na ZFM</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TIS">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações do Imposto Seletivo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CSTIS" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do Imposto Seletivo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTribIS" type="TcClassTrib"/>
+			<xs:sequence minOccurs="0">
+				<xs:element name="vBCIS" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor do BC</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="pIS" type="TDec_0302_04">
+					<xs:annotation>
+						<xs:documentation>Alíquota do Imposto Seletivo (percentual)</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="pISEspec" type="TDec_0302_04" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Alíquota do Imposto Seletivo (por valor)</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:sequence minOccurs="0">
+					<xs:element name="uTrib">
+						<xs:annotation>
+							<xs:documentation>Unidade de medida apropriada especificada em Lei Ordinaria para fins de apuração do Imposto Seletivo</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="TStringRTC">
+								<xs:minLength value="1"/>
+								<xs:maxLength value="6"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:element>
+					<xs:element name="qTrib" type="TDec_1104Op">
+						<xs:annotation>
+							<xs:documentation>Quantidade com abse no campo uTrib informado</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+				</xs:sequence>
+				<xs:element name="vIS" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor do Imposto Seletivo calculado</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TISTot">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações de totais do Imposto Seletivo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vIS" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor Total do Imposto Seletivo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TIBSCBSTot">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações de totais da CBS/IBS</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vBCIBSCBS" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Total Base de Calculo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gIBS">
+				<xs:annotation>
+					<xs:documentation>Totalização do IBS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="gIBSUF">
+							<xs:annotation>
+								<xs:documentation>Totalização do IBS de competência da UF</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vDif" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Total do Diferimento</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vDevTrib" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Total de devoluções de tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vIBSUF" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Valor total do IBS Estadual</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="gIBSMun">
+							<xs:annotation>
+								<xs:documentation>Totalização do IBS de competência Municipal</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vDif" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Total do Diferimento</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vDevTrib" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Total de devoluções de tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vIBSMun" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Valor total do IBS Municipal</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="vIBS" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor total do IBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPres" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPresCondSus" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido Condição Suspensiva</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gCBS">
+				<xs:annotation>
+					<xs:documentation>Totalização da CBS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="vDif" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total do Diferimento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vDevTrib" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total de devoluções de tributos</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBS" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor total da CBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPres" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPresCondSus" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido Condição Suspensiva</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TIBSCBSMonoTot">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações de totais da CBS/IBS com monofasia</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vBCIBSCBS" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Total Base de Calculo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gIBS" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Totalização do IBS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="gIBSUF">
+							<xs:annotation>
+								<xs:documentation>Totalização do IBS de competência da UF</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vDif" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Total do Diferimento</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vDevTrib" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Total de devoluções de tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vIBSUF" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Valor total do IBS Estadual</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="gIBSMun">
+							<xs:annotation>
+								<xs:documentation>Totalização do IBS de competência Municipal</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vDif" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Total do Diferimento</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vDevTrib" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Total de devoluções de tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vIBSMun" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Valor total do IBS Municipal</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="vIBS" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor total do IBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPres" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPresCondSus" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido Condição Suspensiva</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gCBS" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Totalização da CBS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="vDif" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total do Diferimento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vDevTrib" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total de devoluções de tributos</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBS" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor total da CBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPres" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPresCondSus" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido Condição Suspensiva</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gMono" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Totais da Monofasia</xs:documentation>
+					<xs:documentation>Só deverá ser utilizado para DFe modelos 55 e 65</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="vIBSMono" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor total do IBS monofásico</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSMono" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor total da CBS monofásica</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vIBSMonoReten" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor total do IBS monofásico sujeito a retenção</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSMonoReten" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor total da CBS monofásica sujeita a retenção</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vIBSMonoRet" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor do IBS monofásico retido anteriormente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSMonoRet" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor da CBS monofásica retida anteriormente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TMonofasia">
+		<xs:annotation>
+			<xs:documentation>Tipo Monofasia</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:annotation>
+				<xs:documentation>Monofasia</xs:documentation>
+			</xs:annotation>
+			<xs:sequence minOccurs="0">
+				<xs:element name="qBCMono" type="TDec_1104Op">
+					<xs:annotation>
+						<xs:documentation>Quantidade tributada na monofasia</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="adRemIBS" type="TDec_0302_04">
+					<xs:annotation>
+						<xs:documentation>Alíquota ad rem do IBS</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="adRemCBS" type="TDec_0302_04">
+					<xs:annotation>
+						<xs:documentation>Alíquota ad rem da CBS</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vIBSMono" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor do IBS monofásico</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vCBSMono" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor da CBS monofásica</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+			<xs:sequence minOccurs="0">
+				<xs:element name="qBCMonoReten" type="TDec_1104Op">
+					<xs:annotation>
+						<xs:documentation>Quantidade tributada sujeita a retenção.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="adRemIBSReten" type="TDec_0302_04">
+					<xs:annotation>
+						<xs:documentation>Alíquota ad rem do IBS sujeito a retenção</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vIBSMonoReten" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor do IBS monofásico sujeito a retenção</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="adRemCBSReten" type="TDec_0302_04">
+					<xs:annotation>
+						<xs:documentation>Alíquota ad rem da CBS sujeita a retenção</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vCBSMonoReten" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor da CBS monofásica sujeita a retenção</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+			<xs:sequence minOccurs="0">
+				<xs:element name="qBCMonoRet" type="TDec_1104Op">
+					<xs:annotation>
+						<xs:documentation>Quantidade tributada retida anteriormente</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="adRemIBSRet" type="TDec_0302_04">
+					<xs:annotation>
+						<xs:documentation>Alíquota ad rem do IBS retido anteriormente</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vIBSMonoRet" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor do IBS retido anteriormente</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="adRemCBSRet" type="TDec_0302_04">
+					<xs:annotation>
+						<xs:documentation>Alíquota ad rem da CBS retida anteriormente</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vCBSMonoRet" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor da CBS retida anteriormente</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+			<xs:sequence minOccurs="0">
+				<xs:element name="pDifIBS" type="TDec_0302_04">
+					<xs:annotation>
+						<xs:documentation>Percentual do diferimento do imposto monofásico</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vIBSMonoDif" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor do IBS monofásico diferido</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="pDifCBS" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Percentual do diferimento do imposto monofásico</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vCBSMonoDif" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor da CBS monofásica diferida</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+			<xs:element name="vTotIBSMonoItem" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Total de IBS monofásico do item</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vTotCBSMonoItem" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Total da CBS monofásica do item</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCIBS">
+		<xs:annotation>
+			<xs:documentation>Tipo CBS IBS Completo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:annotation>
+				<xs:documentation>IBS / CBS</xs:documentation>
+			</xs:annotation>
+			<xs:element name="vBC" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor do BC</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gIBSUF">
+				<xs:annotation>
+					<xs:documentation>Grupo de informações do IBS na UF</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="pIBSUF" type="TDec_0302_04">
+							<xs:annotation>
+								<xs:documentation>Aliquota do IBS de competência das UF</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gDif" type="TDif" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de campos do Diferimento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gDevTrib" type="TDevTrib" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de Informações da devolução de tributos</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gRed" type="TRed" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de campos da redução de aliquota</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vIBSUF" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor do IBS de competência das UF</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gIBSMun">
+				<xs:annotation>
+					<xs:documentation>Grupo de Informações do IBS no Município</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="pIBSMun" type="TDec_0302_04">
+							<xs:annotation>
+								<xs:documentation>Aliquota do IBS Municipal</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gDif" type="TDif" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de campos do Diferimento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gDevTrib" type="TDevTrib" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de Informações da devolução de tributos</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gRed" type="TRed" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de campos da redução de aliquota</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vIBSMun" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor do IBS Municipal</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gCBS">
+				<xs:annotation>
+					<xs:documentation>Grupo de Tributação da CBS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="pCBS" type="TDec_0302_04">
+							<xs:annotation>
+								<xs:documentation>Aliquota da CBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gDif" type="TDif" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de campos do Diferimento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gDevTrib" type="TDevTrib" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de Informações da devolução de tributos</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gRed" type="TRed" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de campos da redução de aliquota</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBS" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor da CBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gTribRegular" type="TTribRegular" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de informações da Tributação Regular. Informar como seria a tributação caso não cumprida a condição resolutória/suspensiva. Exemplo 1: Art. 442, §4. Operações com ZFM e ALC. Exemplo 2: Operações com suspensão do tributo.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gIBSCredPres" type="TCredPres" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de Informações do Crédito Presumido referente ao IBS, quando aproveitado pelo emitente do documento. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gCBSCredPres" type="TCredPres" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de Informações do Crédito Presumido referente a CBS, quando aproveitado pelo emitente do documento. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gTribCompraGov" type="TTribCompraGov" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de informações da composição do valor do IBS e da CBS em compras governamental</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TRed">
+		<xs:annotation>
+			<xs:documentation>Tipo Redução Base de Cálculo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="pRedAliq" type="TDec_0302_04">
+				<xs:annotation>
+					<xs:documentation>Percentual de redução de aliquota do cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqEfet" type="TDec_0302_04">
+				<xs:annotation>
+					<xs:documentation>Aliquota Efetiva que será aplicada a Base de Calculo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCredPres">
+		<xs:annotation>
+			<xs:documentation>Tipo Crédito Presumido</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="cCredPres">
+				<xs:annotation>
+					<xs:documentation>Usar tabela Cred Presumido, para o emitente da nota.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pCredPres" type="TDec_0302_04">
+				<xs:annotation>
+					<xs:documentation>Percentual do Crédito Presumido</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice>
+				<xs:element name="vCredPres" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor do Crédito Presumido</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vCredPresCondSus" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor do Crédito Presumido Condição Suspensiva, preencher apenas para cCredPres que possui indicação de Condição Suspensiva</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TDif">
+		<xs:annotation>
+			<xs:documentation>Tipo Diferimento</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="pDif" type="TDec_0302_04">
+				<xs:annotation>
+					<xs:documentation>Percentual do diferimento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vDif" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor do diferimento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TDevTrib">
+		<xs:annotation>
+			<xs:documentation>Tipo Devolução Tributo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vDevTrib" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor do tributo devolvido. No fornecimento de energia elétrica, água, esgoto e
+gás natural e em outras hipóteses definidas no regulamento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribRegular">
+		<xs:annotation>
+			<xs:documentation>Tipo Tributação Regular</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CSTReg" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código da Situação Tributária do IBS e CBS</xs:documentation>
+					<xs:documentation>Informar qual seria o CST caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTribReg" type="TcClassTrib">
+				<xs:annotation>
+					<xs:documentation>Informar qual seria o cClassTrib caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqEfetRegIBSUF" type="TDec_0302_04">
+				<xs:annotation>
+					<xs:documentation>Alíquota do IBS da UF</xs:documentation>
+					<xs:documentation>Informar como seria a Alíquota caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vTribRegIBSUF" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor do IBS da UF</xs:documentation>
+					<xs:documentation>Informar como seria o valor do Tributo caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqEfetRegIBSMun" type="TDec_0302_04">
+				<xs:annotation>
+					<xs:documentation>Alíquota do IBS do Município</xs:documentation>
+					<xs:documentation>Informar como seria a Alíquota caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vTribRegIBSMun" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor do IBS do Município</xs:documentation>
+					<xs:documentation>Informar como seria o valor do Tributo caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqEfetRegCBS" type="TDec_0302_04">
+				<xs:annotation>
+					<xs:documentation>Alíquota da CBS</xs:documentation>
+					<xs:documentation>Informar como seria a Alíquota caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vTribRegCBS" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor da CBS</xs:documentation>
+					<xs:documentation>Informar como seria o valor do Tributo caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribCompraGov">
+		<xs:annotation>
+			<xs:documentation>Tipo Tributação Compra Governamental</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="pAliqIBSUF" type="TDec_0302_04"/>
+			<xs:element name="vTribIBSUF" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor que seria devido a UF, sem aplicação do Art. 473. da LC 214/2025</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqIBSMun" type="TDec_0302_04"/>
+			<xs:element name="vTribIBSMun" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor que seria devido ao município, sem aplicação do Art. 473. da LC 214/2025</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqCBS" type="TDec_0302_04"/>
+			<xs:element name="vTribCBS" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor que seria devido a CBS, sem aplicação do Art. 473. da LC 214/2025</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCompraGovReduzido">
+		<xs:annotation>
+			<xs:documentation>Tipo Compras Governamentais</xs:documentation>
+			<xs:documentation>Cada DFe que utilizar deverá utilizar esses tipo no grupo ide</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpEnteGov" type="TEnteGov">
+				<xs:annotation>
+					<xs:documentation>Para administração pública direta e suas autarquias e fundações:
+1=União
+2=Estados
+3=Distrito Federal
+4=Municípios</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pRedutor" type="TDec_0302_04">
+				<xs:annotation>
+					<xs:documentation>Percentual de redução de aliquota em compra goverrnamental</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCompraGov">
+		<xs:annotation>
+			<xs:documentation>Tipo Compras Governamentais</xs:documentation>
+			<xs:documentation>Cada DFe que utilizar deverá utilizar esses tipo no grupo ide</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpEnteGov" type="TEnteGov">
+				<xs:annotation>
+					<xs:documentation>Para administração pública direta e suas autarquias e fundações:
+1=União
+2=Estados
+3=Distrito Federal
+4=Municípios</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pRedutor" type="TDec_0302_04">
+				<xs:annotation>
+					<xs:documentation>Percentual de redução de aliquota em compra goverrnamental</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="tpOperGov" type="TOperCompraGov">
+				<xs:annotation>
+					<xs:documentation>Tipo da operação com ente governamental:
+1 - Fornecimento
+2 - Recebimento do Pagamento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTransfCred">
+		<xs:annotation>
+			<xs:documentation>Tipo Transferência de Crédito</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vIBS" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor do IBS a ser transferido</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vCBS" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor da CBS a ser transferida</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCredPresIBSZFM">
+		<xs:annotation>
+			<xs:documentation>Tipo Informações do crédito presumido de IBS para fornecimentos a partir da ZFM</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpCredPresIBSZFM" type="TTpCredPresIBSZFM">
+				<xs:annotation>
+					<xs:documentation>Classificação de acordo com o art. 450, § 1º, da LC 214/25 para o cálculo do crédito presumido na ZFM</xs:documentation>
+					<xs:documentation>0 - Sem crédito presumido;
+1 - Bens de consumo final (55%);
+2 - Bens de capital (75%);
+3 - Bens intermediários (90,25%);
+4 - Bens de informática e outros definidos em legislação (100%).
+OBS: Percentuais definidos no art. 450, § 1º, da LC 214/25 para o cálculo do crédito presumido
+</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vCredPresIBSZFM" type="TDec1302" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Valor do crédito presumido calculado sobre o saldo devedor apurado</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/consReciNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/consReciNFe_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteNFe_v4.00.xsd"/>
+	<xs:element name="consReciNFe" type="TConsReciNFe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do Pedido de Consulta do Recido do Lote de Notas Fiscais Eletrônicas</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/consSitNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/consSitNFe_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteConsSitNFe_v4.00.xsd"/>
+	<xs:element name="consSitNFe" type="TConsSitNFe">
+		<xs:annotation>
+			<xs:documentation>Schema de validação XML dp Pedido de Consulta da Situação Atual da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/consStatServ_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/consStatServ_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteConsStatServ_v4.00.xsd"/>
+	<xs:element name="consStatServ" type="TConsStatServ">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do Pedido de Consulta do Status do Serviço</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/enviNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/enviNFe_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteNFe_v4.00.xsd"/>
+	<xs:element name="enviNFe" type="TEnviNFe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do Pedido de Concessão de Autorização da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/inutNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/inutNFe_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteInutNFe_v4.00.xsd"/>
+	<xs:element name="inutNFe" type="TInutNFe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do Pedido de Inutilização de Numeração da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/leiauteConsSitNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/leiauteConsSitNFe_v4.00.xsd
@@ -1,0 +1,502 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--  13-05-2011 - correcao do pattern da data para aceitar -4:00 -->
+<!--  03-03-2011 - alteracoes na enumeracao das versoes e no detalhamento do evento -->
+<!--  PL_006eventos versao alterada para consultar eventos 30/08/2010 -->
+<!--  PL_006f versao com correcoes no xServ para tornar a literal CONSULTAR obrigatoria 21/05/2010 -->
+<!--  PL_006c versao com correcoes 24/12/2009 -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposBasico_v4.00.xsd"/>
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v1.01.xsd"/>
+	<xs:complexType name="TConsSitNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Pedido de Consulta da Situação Atual da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xServ">
+				<xs:annotation>
+					<xs:documentation>Serviço Solicitado</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TServ">
+						<xs:enumeration value="CONSULTAR"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="chNFe" type="TChNFe">
+				<xs:annotation>
+					<xs:documentation>Chaves de acesso da NF-e, compostas por: UF do emitente, AAMM da emissão da NFe, CNPJ do emitente, modelo, série e número da NF-e e código numérico + DV.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerConsSitNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetConsSitNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Retorno de Pedido de Consulta da Situação Atual da Nota Fiscal Eletrônica </xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="verAplic" type="TVerAplic">
+				<xs:annotation>
+					<xs:documentation>Versão do Aplicativo que processou a NF-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cStat" type="TStat">
+				<xs:annotation>
+					<xs:documentation>Código do status da mensagem enviada.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMotivo" type="TMotivo">
+				<xs:annotation>
+					<xs:documentation>Descrição literal do status do serviço solicitado.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>código da UF de atendimento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="dhRecbto" type="TDateTimeUTC">
+				<xs:annotation>
+					<xs:documentation>AAAA-MM-DDTHH:MM:SSTZD</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="chNFe" type="TChNFe">
+				<xs:annotation>
+					<xs:documentation>Chaves de acesso da NF-e consultada</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="protNFe" type="TProtNFe" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Protocolo de autorização de uso da NF-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="retCancNFe" type="TRetCancNFe" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Protocolo de homologação de cancelamento de uso da NF-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="procEventoNFe" type="TProcEvento" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Protocolo de registro de evento da NF-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerConsSitNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TProtNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Protocolo de status resultado do processamento da NF-e</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infProt">
+				<xs:annotation>
+					<xs:documentation>Dados do protocolo de status</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="verAplic" type="TVerAplic">
+							<xs:annotation>
+								<xs:documentation>Versão do Aplicativo que processou a NF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="chNFe" type="TChNFe">
+							<xs:annotation>
+								<xs:documentation>Chaves de acesso da NF-e, compostas por: UF do emitente, AAMM da emissão da NFe, CNPJ do emitente, modelo, série e número da NF-e e código numérico+DV.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="dhRecbto" type="xs:dateTime">
+							<xs:annotation>
+								<xs:documentation>Data e hora de processamento, no formato AAAA-MM-DDTHH:MM:SS (ou AAAA-MM-DDTHH:MM:SSTZD, de acordo com versão). Deve ser preenchida com data e hora da gravação no Banco em caso de Confirmação. Em caso de Rejeição, com data e hora do recebimento do Lote de NF-e enviado.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nProt" type="TProt" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número do Protocolo de Status da NF-e. 1 posição (1 – Secretaria de Fazenda Estadual 2 – Receita Federal); 2 - códiga da UF - 2 posições ano; 10 seqüencial no ano.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="digVal" type="ds:DigestValueType" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Digest Value da NF-e processada. Utilizado para conferir a integridade da NF-e original.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cStat" type="TStat">
+							<xs:annotation>
+								<xs:documentation>Código do status da mensagem enviada.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="xMotivo" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Descrição literal do status do serviço solicitado.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" type="xs:ID" use="optional"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetCancNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo retorno Pedido de Cancelamento da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infCanc">
+				<xs:annotation>
+					<xs:documentation>Dados do Resultado do Pedido de Cancelamento da Nota Fiscal Eletrônica</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="verAplic" type="TVerAplic">
+							<xs:annotation>
+								<xs:documentation>Versão do Aplicativo que processou o pedido de cancelamento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cStat" type="TStat">
+							<xs:annotation>
+								<xs:documentation>Código do status da mensagem enviada.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="xMotivo" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Descrição literal do status do serviço solicitado.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cUF" type="TCodUfIBGE">
+							<xs:annotation>
+								<xs:documentation>código da UF de atendimento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="chNFe" type="TChNFe" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Chaves de acesso da NF-e, compostas por: UF do emitente, AAMM da emissão da NFe, CNPJ do emitente, modelo, série e número da NF-e e código numérico + DV.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="dhRecbto" type="xs:dateTime" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Data e hora de recebimento, no formato AAAA-MM-DDTHH:MM:SS. Deve ser preenchida com data e hora da gravação no Banco em caso de Confirmação.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nProt" type="TProt" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número do Protocolo de Status da NF-e. 1 posição (1 – Secretaria de Fazenda Estadual 2 – Receita Federal); 2 - código da UF - 2 posições ano; 10 seqüencial no ano.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" type="xs:ID" use="optional"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerCancNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TEvento">
+		<xs:annotation>
+			<xs:documentation>Tipo Evento</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infEvento">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="cOrgao" type="TCOrgaoIBGE">
+							<xs:annotation>
+								<xs:documentation>Código do órgão de recepção do Evento. Utilizar a Tabela do IBGE extendida, utilizar 90 para identificar o Ambiente Nacional</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:choice>
+							<xs:annotation>
+								<xs:documentation>Identificação do  autor do evento</xs:documentation>
+							</xs:annotation>
+							<xs:element name="CNPJ" type="TCnpjOpc">
+								<xs:annotation>
+									<xs:documentation>CNPJ</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="CPF" type="TCpf">
+								<xs:annotation>
+									<xs:documentation>CPF</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:choice>
+						<xs:element name="chNFe" type="TChNFe">
+							<xs:annotation>
+								<xs:documentation>Chave de Acesso da NF-e vinculada ao evento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="dhEvento" type="TDateTimeUTC">
+							<xs:annotation>
+								<xs:documentation>Data e Hora do Evento, formato UTC (AAAA-MM-DDThh:mm:ssTZD, onde TZD = +hh:mm ou -hh:mm)</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="tpEvento">
+							<xs:annotation>
+								<xs:documentation>Tipo do Evento</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:pattern value="[0-9]{6}"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="nSeqEvento">
+							<xs:annotation>
+								<xs:documentation>Seqüencial do evento para o mesmo tipo de evento.  Para maioria dos eventos será 1, nos casos em que possa existir mais de um evento, como é o caso da carta de correção, o autor do evento deve numerar de forma seqüencial.</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:pattern value="[1-9][0-9]{0,1}"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="verEvento">
+							<xs:annotation>
+								<xs:documentation>Versão do Tipo do Evento</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="detEvento">
+							<xs:annotation>
+								<xs:documentation>Detalhe Específico do Evento</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:any processContents="skip" maxOccurs="unbounded"/>
+								</xs:sequence>
+								<xs:anyAttribute processContents="skip"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" use="required">
+						<xs:annotation>
+							<xs:documentation>Identificador da TAG a ser assinada, a regra de formação do Id é:
+“ID” + tpEvento +  chave da NF-e + nSeqEvento</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:ID">
+								<xs:pattern value="ID[0-9]{52}"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerEvento" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetEvento">
+		<xs:annotation>
+			<xs:documentation>Tipo retorno do Evento</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infEvento">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="verAplic" type="TVerAplic">
+							<xs:annotation>
+								<xs:documentation>Versão do Aplicativo que recebeu o Evento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cOrgao" type="TCOrgaoIBGE">
+							<xs:annotation>
+								<xs:documentation>Código do órgão de recepção do Evento. Utilizar a Tabela do IBGE extendida, utilizar 90 para identificar o Ambiente Nacional</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cStat" type="TStat">
+							<xs:annotation>
+								<xs:documentation>Código do status da registro do Evento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="xMotivo" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Descrição literal do status do registro do Evento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="chNFe" type="TChNFe" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Chave de Acesso NF-e vinculada</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="tpEvento" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Tipo do Evento vinculado</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:pattern value="[0-9]{6}"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="xEvento" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Descrição do Evento</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TString">
+									<xs:minLength value="5"/>
+									<xs:maxLength value="60"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="nSeqEvento" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Seqüencial do evento</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:pattern value="[1-9][0-9]{0,1}"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:choice minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Identificação do  destinatpario da NF-e</xs:documentation>
+							</xs:annotation>
+							<xs:element name="CNPJDest" type="TCnpjOpc">
+								<xs:annotation>
+									<xs:documentation>CNPJ Destinatário</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="CPFDest" type="TCpf">
+								<xs:annotation>
+									<xs:documentation>CPF Destiantário</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:choice>
+						<xs:element name="emailDest" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>email do destinatário</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TString">
+									<xs:minLength value="1"/>
+									<xs:maxLength value="60"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="dhRegEvento" type="TDateTimeUTC">
+							<xs:annotation>
+								<xs:documentation>Data e Hora de registro do evento formato UTC AAAA-MM-DDTHH:MM:SSTZD</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nProt" type="TProt" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número do protocolo de registro do evento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" use="optional">
+						<xs:simpleType>
+							<xs:restriction base="xs:ID">
+								<xs:pattern value="ID[0-9]{15}"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TRetVerEvento" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TProcEvento">
+		<xs:annotation>
+			<xs:documentation>Tipo procEvento</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="evento" type="TEvento"/>
+			<xs:element name="retEvento" type="TRetEvento"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerEvento" use="required"/>
+	</xs:complexType>
+	<xs:simpleType name="TVerNFe">
+		<xs:annotation>
+			<xs:documentation> Tipo Versão da NF-e</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="TString">
+			<xs:pattern value="[1-9]{1}\.[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TVerCancNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Versão do leiaute de Cancelamento de NF-e - 2.00/1.07</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="TString">
+			<xs:pattern value="[1-9]{1}\.[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TVerEvento">
+		<xs:annotation>
+			<xs:documentation>Tipo Versão do Evento 1.00</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="TString">
+			<xs:pattern value="[1-9]{1}\.[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TRetVerEvento">
+		<xs:annotation>
+			<xs:documentation>Tipo Versão do Evento</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="TString">
+			<xs:pattern value="[1-9]{1}\.[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TVerConsSitNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Versão do Leiaute da Cosulta situação NF-e - 4.00</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="4.00"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/leiauteConsStatServ_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/leiauteConsStatServ_v4.00.xsd
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--  PL_006f versao com correcoes no xServ para tornar a literal STATUS obrigatoria 21/05/2010 -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposBasico_v4.00.xsd"/>
+	<xs:complexType name="TConsStatServ">
+		<xs:annotation>
+			<xs:documentation>Tipo Pedido de Consulta do Status do Serviço</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF consultada</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xServ">
+				<xs:annotation>
+					<xs:documentation>Serviço Solicitado</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TServ">
+						<xs:enumeration value="STATUS"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerConsStatServ" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetConsStatServ">
+		<xs:annotation>
+			<xs:documentation>Tipo Resultado da Consulta do Status do Serviço</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="verAplic" type="TVerAplic">
+				<xs:annotation>
+					<xs:documentation>Versão do Aplicativo que processou a NF-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cStat" type="TStat">
+				<xs:annotation>
+					<xs:documentation>Código do status da mensagem enviada.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMotivo" type="TMotivo">
+				<xs:annotation>
+					<xs:documentation>Descrição literal do status do serviço solicitado.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>Código da UF responsável pelo serviço</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="dhRecbto" type="TDateTimeUTC">
+				<xs:annotation>
+					<xs:documentation>Data e hora do recebimento da consulta no formato AAAA-MM-DDTHH:MM:SSTZD</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="tMed" type="TMed" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Tempo médio de resposta do serviço (em segundos) dos últimos 5 minutos</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="dhRetorno" type="TDateTimeUTC" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>AAAA-MM-DDTHH:MM:SSDeve ser preenchida com data e hora previstas para o retorno dos serviços prestados.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xObs" type="TMotivo" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Campo observação utilizado para incluir informações ao contribuinte</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerConsStatServ" use="required"/>
+	</xs:complexType>
+	<xs:simpleType name="TVerConsStatServ">
+		<xs:annotation>
+			<xs:documentation>Tipo versão do leiuate da Consulta Status do Serviço 4.00</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:token">
+			<xs:pattern value="4\.00"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/leiauteInutNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/leiauteInutNFe_v4.00.xsd
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--  PL_006f versao com correcoes no xServ para tornar a literal INUTILIZAR obrigatoria 21/05/2010 -->
+<!--  PL_006c versao com correcoes 24/12/2009 -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v1.01.xsd"/>
+	<xs:include schemaLocation="tiposBasico_v4.00.xsd"/>
+	<xs:complexType name="TInutNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Pedido de Inutilização de Numeração da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infInut">
+				<xs:annotation>
+					<xs:documentation>Dados do Pedido de Inutilização de Numeração da Nota Fiscal Eletrônica</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="xServ">
+							<xs:annotation>
+								<xs:documentation>Serviço Solicitado</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TServ">
+									<xs:enumeration value="INUTILIZAR"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="cUF" type="TCodUfIBGE">
+							<xs:annotation>
+								<xs:documentation>Código da UF do emitente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="ano" type="Tano">
+							<xs:annotation>
+								<xs:documentation>Ano de inutilização da numeração</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="CNPJ" type="TCnpj">
+							<xs:annotation>
+								<xs:documentation>CNPJ do emitente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="mod" type="TMod">
+							<xs:annotation>
+								<xs:documentation>Modelo da NF-e (55, 65 etc.)</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="serie" type="TSerie">
+							<xs:annotation>
+								<xs:documentation>Série da NF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nNFIni" type="TNF">
+							<xs:annotation>
+								<xs:documentation>Número da NF-e inicial</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nNFFin" type="TNF">
+							<xs:annotation>
+								<xs:documentation>Número da NF-e final</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="xJust" type="TJust">
+							<xs:annotation>
+								<xs:documentation>Justificativa do pedido de inutilização</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" use="required">
+						<xs:simpleType>
+							<xs:restriction base="xs:ID">
+								<xs:pattern value="ID[0-9]{41}"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerInutNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetInutNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo retorno do Pedido de Inutilização de Numeração da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infInut">
+				<xs:annotation>
+					<xs:documentation>Dados do Retorno do Pedido de Inutilização de Numeração da Nota Fiscal Eletrônica</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="verAplic" type="TVerAplic">
+							<xs:annotation>
+								<xs:documentation>Versão do Aplicativo que processou a NF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cStat" type="TStat">
+							<xs:annotation>
+								<xs:documentation>Código do status da mensagem enviada.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="xMotivo" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Descrição literal do status do serviço solicitado.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cUF" type="TCodUfIBGE">
+							<xs:annotation>
+								<xs:documentation>Código da UF que atendeu a solicitação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="ano" type="Tano" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Ano de inutilização da numeração</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="CNPJ" type="TCnpj" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>CNPJ do emitente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="mod" type="TMod" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Modelo da NF-e (55, etc.)</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="serie" type="TSerie" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Série da NF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nNFIni" type="TNF" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número da NF-e inicial</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nNFFin" type="TNF" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número da NF-e final</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="dhRecbto" type="TDateTimeUTC">
+							<xs:annotation>
+								<xs:documentation>Data e hora de recebimento, no formato AAAA-MM-DDTHH:MM:SS. Deve ser preenchida com data e hora da gravação no Banco em caso de Confirmação. Em caso de Rejeição, com data e hora do recebimento do Pedido de Inutilização.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nProt" type="TProt" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número do Protocolo de Status da NF-e. 1 posição (1 – Secretaria de Fazenda Estadual 2 – Receita Federal); 2 - código da UF - 2 posições ano; 10 seqüencial no ano.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" type="xs:ID" use="optional"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerInutNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TProcInutNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Pedido de inutilzação de númeração de  NF-e processado</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="inutNFe" type="TInutNFe"/>
+			<xs:element name="retInutNFe" type="TRetInutNFe"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerInutNFe" use="required"/>
+	</xs:complexType>
+	<xs:simpleType name="TVerInutNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Versão do leiaute de Inutilização 4.00</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:token">
+			<xs:pattern value="4\.00"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/leiauteNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/leiauteNFe_v4.00.xsd
@@ -1,0 +1,7557 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas-softwares@procergs.rs.gov.br (PROCERGS) -->
+<!-- PL_009  alterações de esquema decorrentes da - NT2016.002 v1.20 - 31/05/2017 13:14hs-->
+<!-- PL_008g  alterações de esquema decorrentes da - NT2015.002  - 15/07/2015 -->
+<!-- PL_008h  alterações de esquema decorrentes da - NT2015.003 - 17/09/2015 -->
+<!-- PL_008i -->
+<!-- PL_009-v4  alterações de esquema decorrentes da - NT2016.002 - 10/2017 -->
+<!-- PL_009-v4a  alterações de esquema decorrentes da - NT2017.001 - 10/2017 -->
+<!-- PL_009-v4a  alterações de esquema decorrentes da - NT2016.002 v1.60 - 06/2018 -->
+<!-- PL_009-v4a.1  correções de esquema decorrentes da - NT2016.002 v1.60 - 06/2018 -->
+<!-- PL_009-v4a.2  adequação do campo placa para novo padrão do Mercosul - 06/2018 -->
+<!-- PL_009-v4a.3  adequação da lista TCListServ - 10/2018 -->
+<!-- PL_009-v4a.4  implementado alterações da NT 2018.005 -->
+<!-- PL_009-v4b  implementado alterações da NT 2020.006 -->
+<!-- PL_009-v5a  implementado alterações da NT  -->
+<!-- PL_009k_NT2023_001_v100 implementado alterações da NT 2023.001  -->
+<!-- PL_009l_NT2023_002_v100 - Alteração de Schema para evitar caracteres inválidos  -->
+<!-- PL_009m_NT2019_001_v155 - Inclusão de campos para Crédito Presumido e Redução da base de cálculo -->
+<!-- PL_009m_NT2023_004_v101 - Informações de Pagamentos e Outros -->
+<!-- PL_009p_NT2024_003_v103 - Produtos agropecuários -->
+<xs:schema xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:editix="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v1.01.xsd"/>
+	<xs:include schemaLocation="tiposBasico_v4.00.xsd"/>
+	<xs:include schemaLocation="DFeTiposBasicos_v1.00.xsd"/>
+	<xs:complexType name="TNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infNFe">
+				<xs:annotation>
+					<xs:documentation>Informações da Nota Fiscal eletrônica</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ide">
+							<xs:annotation>
+								<xs:documentation>identificação da NF-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="cUF" type="TCodUfIBGE">
+										<xs:annotation>
+											<xs:documentation>Código da UF do emitente do Documento Fiscal. Utilizar a Tabela do IBGE.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="cNF">
+										<xs:annotation>
+											<xs:documentation>Código numérico que compõe a Chave de Acesso. Número aleatório gerado pelo emitente para cada NF-e.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{8}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="natOp">
+										<xs:annotation>
+											<xs:documentation>Descrição da Natureza da Operação</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="mod" type="TMod">
+										<xs:annotation>
+											<xs:documentation>Código do modelo do Documento Fiscal. 55 = NF-e; 65 = NFC-e.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="serie" type="TSerie">
+										<xs:annotation>
+											<xs:documentation>Série do Documento Fiscal
+série normal 0-889
+Avulsa Fisco 890-899
+SCAN 900-999</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="nNF" type="TNF">
+										<xs:annotation>
+											<xs:documentation>Número do Documento Fiscal</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="dhEmi" type="TDateTimeUTC">
+										<xs:annotation>
+											<xs:documentation>Data e Hora de emissão do Documento Fiscal (AAAA-MM-DDThh:mm:ssTZD) ex.: 2012-09-01T13:00:00-03:00</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="dhSaiEnt" type="TDateTimeUTC" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Data e Hora da saída ou de entrada da mercadoria / produto (AAAA-MM-DDTHH:mm:ssTZD)</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpNF">
+										<xs:annotation>
+											<xs:documentation>Tipo do Documento Fiscal (0 - entrada; 1 - saída)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="idDest">
+										<xs:annotation>
+											<xs:documentation>Identificador de Local de destino da operação (1-Interna;2-Interestadual;3-Exterior)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="3"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cMunFG" type="TCodMunIBGE">
+										<xs:annotation>
+											<xs:documentation>Código do Município de Ocorrência do Fato Gerador (utilizar a tabela do IBGE)</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="cMunFGIBS" type="TCodMunIBGE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informar o município de ocorrência do fato gerador do fato gerador do IBS / CBS.
+Campo preenchido somente quando “indPres = 5 (Operação presencial, fora do estabelecimento) ”, e não tiver endereço do destinatário (Grupo: E05) ou local de entrega (Grupo: G01).</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpImp">
+										<xs:annotation>
+											<xs:documentation>Formato de impressão do DANFE (0-sem DANFE;1-DANFe Retrato; 2-DANFe Paisagem;3-DANFe Simplificado;
+											4-DANFe NFC-e;5-DANFe NFC-e em mensagem eletrônica)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="3"/>
+												<xs:enumeration value="4"/>
+												<xs:enumeration value="5"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpEmis">
+										<xs:annotation>
+											<xs:documentation>Forma de emissão da NF-e
+1 - Normal;
+2 - Contingência FS
+3 - Regime Especial NFF (NT 2021.002)
+4 - Contingência DPEC
+5 - Contingência FSDA
+6 - Contingência SVC - AN
+7 - Contingência SVC - RS
+9 - Contingência off-line NFC-e</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="3"/>
+												<xs:enumeration value="4"/>
+												<xs:enumeration value="5"/>
+												<xs:enumeration value="6"/>
+												<xs:enumeration value="7"/>
+												<xs:enumeration value="9"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cDV">
+										<xs:annotation>
+											<xs:documentation>Digito Verificador da Chave de Acesso da NF-e</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{1}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpAmb" type="TAmb">
+										<xs:annotation>
+											<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="finNFe" type="TFinNFe">
+										<xs:annotation>
+											<xs:documentation>Finalidade da emissão da NF-e:
+1 - NFe normal
+2 - NFe complementar
+3 - NFe de ajuste
+4 - Devolução/Retorno
+5 - Nota de crédito
+6 - Nota de débito</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpNFDebito" type="TTpNFDebito" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Tipo de Nota de Débito:
+01=Transferência de créditos para Cooperativas; 
+02=Anulação de Crédito por Saídas Imunes/Isentas; 
+03=Débitos de notas fiscais não processadas na apuração; 
+04=Multa e juros; 
+05=Transferência de crédito de sucessão.
+											</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpNFCredito" type="TTpNFCredito" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Tipo de Nota de Crédito</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="indFinal">
+										<xs:annotation>
+											<xs:documentation>Indica operação com consumidor final (0-Não;1-Consumidor Final)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="indPres">
+										<xs:annotation>
+											<xs:documentation>Indicador de presença do comprador no estabelecimento comercial no momento da oepração
+											(0-Não se aplica (ex.: Nota Fiscal complementar ou de ajuste;1-Operação presencial;2-Não presencial, internet;3-Não presencial, teleatendimento;4-NFC-e entrega em domicílio;5-Operação presencial, fora do estabelecimento;9-Não presencial, outros)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="3"/>
+												<xs:enumeration value="4"/>
+												<xs:enumeration value="5"/>
+												<xs:enumeration value="9"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="indIntermed" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Indicador de intermediador/marketplace 
+											0=Operação sem intermediador (em site ou plataforma própria) 
+											1=Operação em site ou plataforma de terceiros (intermediadores/marketplace)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="procEmi" type="TProcEmi">
+										<xs:annotation>
+											<xs:documentation>Processo de emissão utilizado com a seguinte codificação:
+0 - emissão de NF-e com aplicativo do contribuinte;
+1 - emissão de NF-e avulsa pelo Fisco;
+2 - emissão de NF-e avulsa, pelo contribuinte com seu certificado digital, através do site
+do Fisco;
+3- emissão de NF-e pelo contribuinte com aplicativo fornecido pelo Fisco.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="verProc">
+										<xs:annotation>
+											<xs:documentation>versão do aplicativo utilizado no processo de
+emissão</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="20"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:sequence minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informar apenas
+para tpEmis diferente de 1</xs:documentation>
+										</xs:annotation>
+										<xs:element name="dhCont" type="TDateTimeUTC">
+											<xs:annotation>
+												<xs:documentation>Informar a data e hora de entrada em contingência contingência no formato  (AAAA-MM-DDThh:mm:ssTZD) ex.: 2012-09-01T13:00:00-03:00.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="xJust">
+											<xs:annotation>
+												<xs:documentation>Informar a Justificativa da entrada</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="15"/>
+													<xs:maxLength value="256"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+									<xs:element name="NFref" minOccurs="0" maxOccurs="999">
+										<xs:annotation>
+											<xs:documentation>Grupo de infromações da NF referenciada</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:choice>
+												<xs:element name="refNFe" type="TChNFe">
+													<xs:annotation>
+														<xs:documentation>Chave de acesso das NF-e referenciadas. Chave de acesso compostas por Código da UF (tabela do IBGE) + AAMM da emissão + CNPJ do Emitente + modelo, série e número da NF-e Referenciada + Código Numérico + DV.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="refNFeSig" type="TChNFe">
+													<xs:annotation>
+														<xs:documentation>Referencia uma NF-e (modelo 55) emitida anteriormente pela sua Chave de Acesso com código numérico zerado, permitindo manter o sigilo da NF-e referenciada.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="refNF">
+													<xs:annotation>
+														<xs:documentation>Dados da NF modelo 1/1A referenciada ou NF modelo 2 referenciada</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="cUF" type="TCodUfIBGE">
+																<xs:annotation>
+																	<xs:documentation>Código da UF do emitente do Documento Fiscal. Utilizar a Tabela do IBGE.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="AAMM">
+																<xs:annotation>
+																	<xs:documentation>AAMM da emissão</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:pattern value="[0-9]{2}[0]{1}[1-9]{1}|[0-9]{2}[1]{1}[0-2]{1}"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="CNPJ" type="TCnpj">
+																<xs:annotation>
+																	<xs:documentation>CNPJ do emitente do documento fiscal referenciado</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="mod">
+																<xs:annotation>
+																	<xs:documentation>Código do modelo do Documento Fiscal. Utilizar 01 para NF modelo 1/1A e 02 para NF modelo 02</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:enumeration value="01"/>
+																		<xs:enumeration value="02"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="serie" type="TSerie">
+																<xs:annotation>
+																	<xs:documentation>Série do Documento Fiscal, informar zero se inexistente</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="nNF" type="TNF">
+																<xs:annotation>
+																	<xs:documentation>Número do Documento Fiscal</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="refNFP">
+													<xs:annotation>
+														<xs:documentation>Grupo com as informações NF de produtor referenciada</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="cUF" type="TCodUfIBGE">
+																<xs:annotation>
+																	<xs:documentation>Código da UF do emitente do Documento FiscalUtilizar a Tabela do IBGE (Anexo IV - Tabela de UF, Município e País)</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="AAMM">
+																<xs:annotation>
+																	<xs:documentation>AAMM da emissão da NF de produtor</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:pattern value="[0-9]{2}[0]{1}[1-9]{1}|[0-9]{2}[1]{1}[0-2]{1}"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:choice>
+																<xs:element name="CNPJ" type="TCnpj">
+																	<xs:annotation>
+																		<xs:documentation>CNPJ do emitente da NF de produtor</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="CPF" type="TCpf">
+																	<xs:annotation>
+																		<xs:documentation>CPF do emitente da NF de produtor</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:choice>
+															<xs:element name="IE" type="TIeDest">
+																<xs:annotation>
+																	<xs:documentation>IE do emitente da NF de Produtor</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="mod">
+																<xs:annotation>
+																	<xs:documentation>Código do modelo do Documento Fiscal - utilizar 04 para NF de produtor  ou 01 para NF Avulsa</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:enumeration value="01"/>
+																		<xs:enumeration value="04"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="serie" type="TSerie">
+																<xs:annotation>
+																	<xs:documentation>Série do Documento Fiscal, informar zero se inexistentesérie</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="nNF" type="TNF">
+																<xs:annotation>
+																	<xs:documentation>Número do Documento Fiscal - 1 – 999999999</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="refCTe" type="TChNFe">
+													<xs:annotation>
+														<xs:documentation>Utilizar esta TAG para referenciar um CT-e emitido anteriormente, vinculada a NF-e atual</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="refECF">
+													<xs:annotation>
+														<xs:documentation>Grupo do Cupom Fiscal vinculado à NF-e</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="mod">
+																<xs:annotation>
+																	<xs:documentation>Código do modelo do Documento Fiscal 
+Preencher com &quot;2B&quot;, quando se tratar de Cupom Fiscal emitido por máquina registradora (não ECF), com &quot;2C&quot;, quando se tratar de Cupom Fiscal PDV, ou &quot;2D&quot;, quando se tratar de Cupom Fiscal (emitido por ECF)</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:enumeration value="2B"/>
+																		<xs:enumeration value="2C"/>
+																		<xs:enumeration value="2D"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="nECF">
+																<xs:annotation>
+																	<xs:documentation>Informar o número de ordem seqüencial do ECF que emitiu o Cupom Fiscal vinculado à NF-e</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:pattern value="[0-9]{1,3}"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="nCOO">
+																<xs:annotation>
+																	<xs:documentation>Informar o Número do Contador de Ordem de Operação - COO vinculado à NF-e</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:pattern value="[0-9]{1,6}"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+											</xs:choice>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="gCompraGov" type="TCompraGov" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Grupo de Compras Governamentais</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="gPagAntecipado" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informado para abater as parcelas de antecipação de pagamento, conforme Art. 10. § 4º</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="refNFe" type="TChNFe" minOccurs="1" maxOccurs="99">
+													<xs:annotation>
+														<xs:documentation>Chave de acesso da NF-e de antecipação de pagamento</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="emit">
+							<xs:annotation>
+								<xs:documentation>Identificação do emitente</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpj">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ do emitente</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>Número do CPF do emitente</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão Social ou Nome do emitente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xFant" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Nome fantasia</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="enderEmit" type="TEnderEmi">
+										<xs:annotation>
+											<xs:documentation>Endereço do emitente</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="IE" type="TIe">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual do Emitente</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="IEST" type="TIeST" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscricao Estadual do Substituto Tributário</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:sequence minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Grupo de informações de interesse da Prefeitura</xs:documentation>
+										</xs:annotation>
+										<xs:element name="IM">
+											<xs:annotation>
+												<xs:documentation>Inscrição Municipal</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="1"/>
+													<xs:maxLength value="15"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="CNAE" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>CNAE Fiscal</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:whiteSpace value="preserve"/>
+													<xs:pattern value="[0-9]{7}"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+									<xs:element name="CRT">
+										<xs:annotation>
+											<xs:documentation>Código de Regime Tributário. 
+Este campo será obrigatoriamente preenchido com:
+1 – Simples Nacional;
+2 – Simples Nacional – excesso de sublimite de receita bruta;
+3 – Regime Normal.
+4 - Simples Nacional - Microempreendedor individual - MEI</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="3"/>
+												<xs:enumeration value="4"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="avulsa" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Emissão de avulsa, informar os dados do Fisco emitente</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="CNPJ" type="TCnpj">
+										<xs:annotation>
+											<xs:documentation>CNPJ do Órgão emissor</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="xOrgao">
+										<xs:annotation>
+											<xs:documentation>Órgão emitente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="matr">
+										<xs:annotation>
+											<xs:documentation>Matrícula do agente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xAgente">
+										<xs:annotation>
+											<xs:documentation>Nome do agente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fone" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Telefone</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{6,14}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="UF" type="TUfEmi">
+										<xs:annotation>
+											<xs:documentation>Sigla da Unidade da Federação</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="nDAR" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Número do Documento de Arrecadação de Receita</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="dEmi" type="TData" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Data de emissão do DAR (AAAA-MM-DD)</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vDAR" type="TDec_1302" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor Total constante no DAR</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="repEmi">
+										<xs:annotation>
+											<xs:documentation>Repartição Fiscal emitente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="dPag" type="TData" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Data de pagamento do DAR (AAAA-MM-DD)</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="dest" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Identificação do Destinatário</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpj">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>Número do CPF</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="idEstrangeiro">
+											<xs:annotation>
+												<xs:documentation>Identificador do destinatário, em caso de comprador estrangeiro</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:whiteSpace value="preserve"/>
+													<xs:pattern value="([!-ÿ]{0}|[!-ÿ]{5,20})?"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="xNome" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Razão Social ou nome do destinatário</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="enderDest" type="TEndereco" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Dados do endereço</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="indIEDest">
+										<xs:annotation>
+											<xs:documentation>Indicador da IE do destinatário:
+1 – Contribuinte ICMSpagamento à vista;
+2 – Contribuinte isento de inscrição;
+9 – Não Contribuinte</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="9"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="IE" type="TIeDestNaoIsento" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual (obrigatório nas operações com contribuintes do ICMS)</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="ISUF" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição na SUFRAMA (Obrigatório nas operações com as áreas com benefícios de incentivos fiscais sob controle da SUFRAMA) PL_005d - 11/08/09 - alterado para aceitar 8 ou 9 dígitos</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{8,9}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="IM" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Municipal do tomador do serviço</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="15"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="email" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informar o e-mail do destinatário. O campo pode ser utilizado para informar o e-mail
+de recepção da NF-e indicada pelo destinatário</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:whiteSpace value="preserve"/>
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="retirada" type="TLocal" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Identificação do Local de Retirada (informar apenas quando for diferente do endereço do remetente)</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="entrega" type="TLocal" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Identificação do Local de Entrega (informar apenas quando for diferente do endereço do destinatário)</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="autXML" minOccurs="0" maxOccurs="10">
+							<xs:annotation>
+								<xs:documentation>Pessoas autorizadas para o download do XML da NF-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:choice>
+									<xs:element name="CNPJ" type="TCnpj">
+										<xs:annotation>
+											<xs:documentation>CNPJ Autorizado</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="CPF" type="TCpf">
+										<xs:annotation>
+											<xs:documentation>CPF Autorizado</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:choice>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="det" maxOccurs="990">
+							<xs:annotation>
+								<xs:documentation>Dados dos detalhes da NF-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="prod">
+										<xs:annotation>
+											<xs:documentation>Dados dos produtos e serviços da NF-e</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="cProd">
+													<xs:annotation>
+														<xs:documentation>Código do produto ou serviço. Preencher com CFOP caso se trate de itens não relacionados com mercadorias/produto e que o contribuinte não possua codificação própria
+Formato ”CFOP9999”.</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="60"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="cEAN">
+													<xs:annotation>
+														<xs:documentation>GTIN (Global Trade Item Number) do produto, antigo código EAN ou código de barras</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="SEM GTIN|[0-9]{0}|[0-9]{8}|[0-9]{12,14}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="cBarra" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Codigo de barras diferente do padrão GTIN</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="30"/>
+															<xs:minLength value="3"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="xProd">
+													<xs:annotation>
+														<xs:documentation>Descrição do produto ou serviço</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="120"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="NCM">
+													<xs:annotation>
+														<xs:documentation>Código NCM (8 posições), será permitida a informação do gênero (posição do capítulo do NCM) quando a operação não for de comércio exterior (importação/exportação) ou o produto não seja tributado pelo IPI. Em caso de item de serviço ou item que não tenham produto (Ex. transferência de crédito, crédito do ativo imobilizado, etc.), informar o código 00 (zeros) (v2.0)</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="[0-9]{2}|[0-9]{8}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="NVE" minOccurs="0" maxOccurs="8">
+													<xs:annotation>
+														<xs:documentation>Nomenclatura de Valor aduaneio e Estatístico</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="[A-Z]{2}[0-9]{4}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:sequence minOccurs="0">
+													<xs:element name="CEST">
+														<xs:annotation>
+															<xs:documentation>Codigo especificador da Substuicao Tributaria - CEST, que identifica a mercadoria sujeita aos regimes de  substituicao tributária e de antecipação do recolhimento  do imposto</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:whiteSpace value="preserve"/>
+																<xs:pattern value="[0-9]{7}"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="indEscala" minOccurs="0">
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:enumeration value="S"/>
+																<xs:enumeration value="N"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CNPJFab" type="TCnpj" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>CNPJ do Fabricante da Mercadoria, obrigatório para produto em escala NÃO relevante.</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+												<xs:element name="cBenef" minOccurs="0">
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="([!-ÿ]{8}|[!-ÿ]{10}|SEM CBENEF)?"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="gCred" minOccurs="0" maxOccurs="4">
+													<xs:annotation>
+														<xs:documentation>Grupo de informações sobre o CréditoPresumido </xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="cCredPresumido">
+																<xs:annotation>
+																	<xs:documentation>Código de Benefício Fiscal de Crédito Presumido na UF aplicado ao item</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:pattern value="[!-ÿ]{8}|[!-ÿ]{10}"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="pCredPresumido" type="TDec_0302a04">
+																<xs:annotation>
+																	<xs:documentation>Percentual do Crédito Presumido</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="vCredPresumido" type="TDec_1302">
+																<xs:annotation>
+																	<xs:documentation>Valor do Crédito Presumido</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="EXTIPI" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Código EX TIPI (3 posições)</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="[0-9]{2,3}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="CFOP">
+													<xs:annotation>
+														<xs:documentation>Cfop</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="[1,2,3,5,6,7]{1}[0-9]{3}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="uCom">
+													<xs:annotation>
+														<xs:documentation>Unidade comercial</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="6"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="qCom" type="TDec_1104v">
+													<xs:annotation>
+														<xs:documentation>Quantidade Comercial  do produto, alterado para aceitar de 0 a 4 casas decimais e 11 inteiros.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vUnCom" type="TDec_1110v">
+													<xs:annotation>
+														<xs:documentation>Valor unitário de comercialização  - alterado para aceitar 0 a 10 casas decimais e 11 inteiros</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vProd" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor bruto do produto ou serviço.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="cEANTrib">
+													<xs:annotation>
+														<xs:documentation>GTIN (Global Trade Item Number) da unidade tributável, antigo código EAN ou código de barras</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="SEM GTIN|[0-9]{0}|[0-9]{8}|[0-9]{12,14}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="cBarraTrib" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Código de barras da unidade tributável diferente do padrão GTIN</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="30"/>
+															<xs:minLength value="3"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="uTrib">
+													<xs:annotation>
+														<xs:documentation>Unidade Tributável</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="6"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="qTrib" type="TDec_1104v">
+													<xs:annotation>
+														<xs:documentation>Quantidade Tributável - alterado para aceitar de 0 a 4 casas decimais e 11 inteiros</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vUnTrib" type="TDec_1110v">
+													<xs:annotation>
+														<xs:documentation>Valor unitário de tributação - alterado para aceitar 0 a 10 casas decimais e 11 inteiros</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vFrete" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor Total do Frete</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vSeg" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor Total do Seguro</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vDesc" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor do Desconto</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vOutro" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Outras despesas acessórias</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="indTot">
+													<xs:annotation>
+														<xs:documentation>Este campo deverá ser preenchido com:
+ 0 – o valor do item (vProd) não compõe o valor total da NF-e (vProd)
+ 1  – o valor do item (vProd) compõe o valor total da NF-e (vProd)</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:enumeration value="0"/>
+															<xs:enumeration value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="indBemMovelUsado" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Indicador de fornecimento de bem móvel usado: 1-Bem Móvel Usado</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:enumeration value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="DI" minOccurs="0" maxOccurs="100">
+													<xs:annotation>
+														<xs:documentation>Declaração de Importação (NT 2011/004)</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="nDI">
+																<xs:annotation>
+																	<xs:documentation>Número do Documento de Importação (DI, DSI, DIRE, DUImp) (NT2011/004)</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="15"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="dDI" type="TData">
+																<xs:annotation>
+																	<xs:documentation>Data de registro da DI/DSI/DA (AAAA-MM-DD)</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="xLocDesemb">
+																<xs:annotation>
+																	<xs:documentation>Local do desembaraço aduaneiro</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="60"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="UFDesemb" type="TUfEmi">
+																<xs:annotation>
+																	<xs:documentation>UF onde ocorreu o desembaraço aduaneiro</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="dDesemb" type="TData">
+																<xs:annotation>
+																	<xs:documentation>Data do desembaraço aduaneiro (AAAA-MM-DD)</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="tpViaTransp">
+																<xs:annotation>
+																	<xs:documentation>Via de transporte internacional informada na DI ou na Declaração Única de Importação (DUImp):
+																	1-Maritima;2-Fluvial;3-Lacustre;4-Aerea;5-Postal;6-Ferroviaria;7-Rodoviaria;8-Conduto;9-Meios Proprios;10-Entrada/Saida Ficta;
+																	11-Courier;12-Em maos;13-Por reboque.</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:enumeration value="1"/>
+																		<xs:enumeration value="2"/>
+																		<xs:enumeration value="3"/>
+																		<xs:enumeration value="4"/>
+																		<xs:enumeration value="5"/>
+																		<xs:enumeration value="6"/>
+																		<xs:enumeration value="7"/>
+																		<xs:enumeration value="8"/>
+																		<xs:enumeration value="9"/>
+																		<xs:enumeration value="10"/>
+																		<xs:enumeration value="11"/>
+																		<xs:enumeration value="12"/>
+																		<xs:enumeration value="13"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="vAFRMM" type="TDec_1302" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Valor Adicional ao frete para renovação de marinha mercante</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="tpIntermedio">
+																<xs:annotation>
+																	<xs:documentation>Forma de Importação quanto a intermediação 
+																	1-por conta propria;2-por conta e ordem;3-encomenda</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:enumeration value="1"/>
+																		<xs:enumeration value="2"/>
+																		<xs:enumeration value="3"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:choice minOccurs="0">
+																<xs:element name="CNPJ" type="TCnpj">
+																	<xs:annotation>
+																		<xs:documentation>CNPJ do adquirente ou do encomendante</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="CPF" type="TCpf">
+																	<xs:annotation>
+																		<xs:documentation>CPF do adquirente ou do encomendante</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:choice>
+															<xs:element name="UFTerceiro" type="TUfEmi" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Sigla da UF do adquirente ou do encomendante</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="cExportador">
+																<xs:annotation>
+																	<xs:documentation>Código do exportador (usado nos sistemas internos de informação do emitente da NF-e)</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="60"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="adi" maxOccurs="999">
+																<xs:annotation>
+																	<xs:documentation>Adições (NT 2011/004)</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="nAdicao" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>Número da Adição</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:whiteSpace value="preserve"/>
+																					<xs:pattern value="[1-9]{1}[0-9]{0,2}"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																		<xs:element name="nSeqAdic">
+																			<xs:annotation>
+																				<xs:documentation>Número seqüencial do item</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:whiteSpace value="preserve"/>
+																					<xs:pattern value="[1-9]{1}[0-9]{0,4}"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																		<xs:element name="cFabricante">
+																			<xs:annotation>
+																				<xs:documentation>Código do fabricante estrangeiro (usado nos sistemas internos de informação do emitente da NF-e)</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="TString">
+																					<xs:minLength value="1"/>
+																					<xs:maxLength value="60"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																		<xs:element name="vDescDI" type="TDec_1302Opc" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>Valor do desconto do item</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="nDraw" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>Número do ato concessório de Drawback</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="TString">
+																					<xs:minLength value="1"/>
+																					<xs:maxLength value="20"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="detExport" minOccurs="0" maxOccurs="500">
+													<xs:annotation>
+														<xs:documentation>Detalhe da exportação</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="nDraw" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Número do ato concessório de Drawback</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="20"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="exportInd" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Exportação indireta</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="nRE">
+																			<xs:annotation>
+																				<xs:documentation>Registro de exportação</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:whiteSpace value="preserve"/>
+																					<xs:pattern value="[0-9]{0,12}"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																		<xs:element name="chNFe" type="TChNFe">
+																			<xs:annotation>
+																				<xs:documentation>Chave de acesso da NF-e recebida para exportação</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="qExport" type="TDec_1104v">
+																			<xs:annotation>
+																				<xs:documentation>Quantidade do item efetivamente exportado</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="xPed" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>pedido de compra - Informação de interesse do emissor para controle do B2B.</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="15"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="nItemPed" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Número do Item do Pedido de Compra - Identificação do número do item do pedido de Compra</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="[0-9]{1,6}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="nFCI" type="TGuid" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Número de controle da FCI - Ficha de Conteúdo de Importação.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="rastro" minOccurs="0" maxOccurs="500">
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="nLote">
+																<xs:annotation>
+																	<xs:documentation>Número do lote do produto.</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="20"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="qLote" type="TDec_0803v">
+																<xs:annotation>
+																	<xs:documentation>Quantidade de produto no lote.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="dFab" type="TData">
+																<xs:annotation>
+																	<xs:documentation>Data de fabricação/produção. Formato &quot;AAAA-MM-DD&quot;.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="dVal" type="TData">
+																<xs:annotation>
+																	<xs:documentation>Data de validade. Informar o último dia do mês caso a validade não especifique o dia. Formato &quot;AAAA-MM-DD&quot;.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="cAgreg" minOccurs="0">
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="20"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="infProdNFF" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Informações mais detalhadas do produto (usada na NFF)</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="cProdFisco">
+																<xs:annotation>
+																	<xs:documentation>Código Fiscal do Produto</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:length value="14"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="cOperNFF">
+																<xs:annotation>
+																	<xs:documentation>Código da operação selecionada na NFF e relacionada ao item</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:pattern value="[0-9]{1,5}"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="infProdEmb" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Informações mais detalhadas do produto (usada na NFF)</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="xEmb">
+																<xs:annotation>
+																	<xs:documentation>Embalagem do produto</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:maxLength value="8"/>
+																		<xs:minLength value="1"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="qVolEmb" type="TDec_0803v">
+																<xs:annotation>
+																	<xs:documentation>Volume do produto na embalagem</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="uEmb">
+																<xs:annotation>
+																	<xs:documentation>Unidade de Medida da Embalagem</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:maxLength value="8"/>
+																		<xs:minLength value="1"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:choice minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Informações específicas de produtos e serviços</xs:documentation>
+													</xs:annotation>
+													<xs:element name="veicProd">
+														<xs:annotation>
+															<xs:documentation>Veículos novos</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="tpOp">
+																	<xs:annotation>
+																		<xs:documentation>Tipo da Operação (1 - Venda concessionária; 2 - Faturamento direto; 3 - Venda direta; 0 - Outros)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="0"/>
+																			<xs:enumeration value="1"/>
+																			<xs:enumeration value="2"/>
+																			<xs:enumeration value="3"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="chassi">
+																	<xs:annotation>
+																		<xs:documentation>Chassi do veículo - VIN (código-identificação-veículo)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:length value="17"/>
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:pattern value="[A-Z0-9]+"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="cCor">
+																	<xs:annotation>
+																		<xs:documentation>Cor do veículo (código de cada montadora)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="4"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="xCor">
+																	<xs:annotation>
+																		<xs:documentation>Descrição da cor</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="40"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="pot">
+																	<xs:annotation>
+																		<xs:documentation>Potência máxima do motor do veículo em cavalo vapor (CV). (potência-veículo)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="4"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="cilin">
+																	<xs:annotation>
+																		<xs:documentation>Capacidade voluntária do motor expressa em centímetros cúbicos (CC). (cilindradas)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="4"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="pesoL">
+																	<xs:annotation>
+																		<xs:documentation>Peso líquido</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="9"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="pesoB">
+																	<xs:annotation>
+																		<xs:documentation>Peso bruto</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="9"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="nSerie">
+																	<xs:annotation>
+																		<xs:documentation>Serial (série)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="9"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="tpComb">
+																	<xs:annotation>
+																		<xs:documentation>Tipo de combustível-Tabela RENAVAM: 01-Álcool; 02-Gasolina; 03-Diesel; 16-Álcool/Gas.; 17-Gas./Álcool/GNV; 18-Gasolina/Elétrico</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="2"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="nMotor">
+																	<xs:annotation>
+																		<xs:documentation>Número do motor</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="21"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="CMT">
+																	<xs:annotation>
+																		<xs:documentation>CMT-Capacidade Máxima de Tração - em Toneladas 4 casas decimais</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="9"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="dist">
+																	<xs:annotation>
+																		<xs:documentation>Distância entre eixos</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="4"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="anoMod">
+																	<xs:annotation>
+																		<xs:documentation>Ano Modelo de Fabricação</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:pattern value="[0-9]{4}"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="anoFab">
+																	<xs:annotation>
+																		<xs:documentation>Ano de Fabricação</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:pattern value="[0-9]{4}"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="tpPint">
+																	<xs:annotation>
+																		<xs:documentation>Tipo de pintura</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:length value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="tpVeic">
+																	<xs:annotation>
+																		<xs:documentation>Tipo de veículo (utilizar tabela RENAVAM)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:pattern value="[0-9]{1,2}"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="espVeic">
+																	<xs:annotation>
+																		<xs:documentation>Espécie de veículo (utilizar tabela RENAVAM)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:pattern value="[0-9]{1}"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="VIN">
+																	<xs:annotation>
+																		<xs:documentation>Informa-se o veículo tem VIN (chassi) remarcado.
+R-Remarcado
+N-NormalVIN</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:length value="1"/>
+																			<xs:enumeration value="R"/>
+																			<xs:enumeration value="N"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="condVeic">
+																	<xs:annotation>
+																		<xs:documentation>Condição do veículo (1 - acabado; 2 - inacabado; 3 - semi-acabado)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="1"/>
+																			<xs:enumeration value="2"/>
+																			<xs:enumeration value="3"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="cMod">
+																	<xs:annotation>
+																		<xs:documentation>Código Marca Modelo (utilizar tabela RENAVAM)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:pattern value="[0-9]{1,6}"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="cCorDENATRAN">
+																	<xs:annotation>
+																		<xs:documentation>Código da Cor Segundo as regras de pré-cadastro do DENATRAN: 01-AMARELO;02-AZUL;03-BEGE;04-BRANCA;05-CINZA;06-DOURADA;07-GRENA 
+08-LARANJA;09-MARROM;10-PRATA;11-PRETA;12-ROSA;13-ROXA;14-VERDE;15-VERMELHA;16-FANTASIA</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="2"/>
+																			<xs:pattern value="[0-9]{1,2}"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="lota">
+																	<xs:annotation>
+																		<xs:documentation>Quantidade máxima de permitida de passageiros sentados, inclusive motorista.</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="3"/>
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:pattern value="[0-9]{1,3}"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="tpRest">
+																	<xs:annotation>
+																		<xs:documentation>Restrição
+0 - Não há;
+1 - Alienação Fiduciária;
+2 - Arrendamento Mercantil;
+3 - Reserva de Domínio;
+4 - Penhor de Veículos;
+9 - outras.</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="0"/>
+																			<xs:enumeration value="1"/>
+																			<xs:enumeration value="2"/>
+																			<xs:enumeration value="3"/>
+																			<xs:enumeration value="4"/>
+																			<xs:enumeration value="9"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="med">
+														<xs:annotation>
+															<xs:documentation>grupo do detalhamento de Medicamentos e de matérias-primas farmacêuticas</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="cProdANVISA">
+																	<xs:annotation>
+																		<xs:documentation>Utilizar o número do registro ANVISA  ou preencher com o literal “ISENTO”, no caso de medicamento isento de registro na ANVISA.</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:pattern value="[0-9]{11}|[0-9]{13}|ISENTO"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="xMotivoIsencao" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Obs.: Para medicamento isento de registro na ANVISA, informar o número da decisão que o isenta, como por exemplo o número da Resolução da Diretoria Colegiada da ANVISA (RDC).</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="255"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="vPMC" type="TDec_1302">
+																	<xs:annotation>
+																		<xs:documentation>Preço Máximo ao Consumidor.</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="arma" maxOccurs="500">
+														<xs:annotation>
+															<xs:documentation>Armamentos</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="tpArma">
+																	<xs:annotation>
+																		<xs:documentation>Indicador do tipo de arma de fogo (0 - Uso permitido; 1 - Uso restrito)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="0"/>
+																			<xs:enumeration value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="nSerie">
+																	<xs:annotation>
+																		<xs:documentation>Número de série da arma</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="15"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="nCano">
+																	<xs:annotation>
+																		<xs:documentation>Número de série do cano</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="15"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="descr">
+																	<xs:annotation>
+																		<xs:documentation>Descrição completa da arma, compreendendo: calibre, marca, capacidade, tipo de funcionamento, comprimento e demais elementos que permitam a sua perfeita identificação.</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="256"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="comb">
+														<xs:annotation>
+															<xs:documentation>Informar apenas para operações com combustíveis líquidos</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="cProdANP">
+																	<xs:annotation>
+																		<xs:documentation>Código de produto da ANP. codificação de produtos do SIMP (http://www.anp.gov.br)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:pattern value="[0-9]{9}"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="descANP">
+																	<xs:annotation>
+																		<xs:documentation>Descrição do Produto conforme ANP. Utilizar a descrição de produtos do Sistema de Informações de Movimentação de Produtos - SIMP (http://www.anp.gov.br/simp/).</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="2"/>
+																			<xs:maxLength value="95"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="pGLP" type="TDec_0302a04Max100" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Percentual do GLP derivado do petróleo no produto GLP (cProdANP=210203001). Informar em número decimal o percentual do GLP derivado de petróleo no produto GLP. Valores 0 a 100.</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="pGNn" type="TDec_0302a04Max100" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Percentual de gás natural nacional - GLGNn para o produto GLP (cProdANP=210203001). Informar em número decimal o percentual do Gás Natural Nacional - GLGNn para o produto GLP. Valores de 0 a 100.</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="pGNi" type="TDec_0302a04Max100" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Percentual de gás natural importado GLGNi para o produto GLP (cProdANP=210203001). Informar em número deciaml o percentual do Gás Natural Importado - GLGNi para o produto GLP. Valores de 0 a 100.</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="vPart" type="TDec_1302" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor de partida (cProdANP=210203001). Deve ser informado neste campo o valor por quilograma sem ICMS.</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="CODIF" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código de autorização / registro do CODIF. Informar apenas quando a UF utilizar o CODIF (Sistema de Controle do 			Diferimento do Imposto nas Operações com AEAC - Álcool Etílico Anidro Combustível).</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:pattern value="[0-9]{1,21}"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="qTemp" type="TDec_1204temperatura" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Quantidade de combustível
+faturada à temperatura ambiente.
+Informar quando a quantidade
+faturada informada no campo
+qCom (I10) tiver sido ajustada para
+uma temperatura diferente da
+ambiente.</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="UFCons" type="TUf">
+																	<xs:annotation>
+																		<xs:documentation>Sigla da UF de Consumo</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="CIDE" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>CIDE Combustíveis</xs:documentation>
+																	</xs:annotation>
+																	<xs:complexType>
+																		<xs:sequence>
+																			<xs:element name="qBCProd" type="TDec_1204v">
+																				<xs:annotation>
+																					<xs:documentation>BC do CIDE ( Quantidade comercializada)</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																			<xs:element name="vAliqProd" type="TDec_1104">
+																				<xs:annotation>
+																					<xs:documentation>Alíquota do CIDE  (em reais)</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																			<xs:element name="vCIDE" type="TDec_1302">
+																				<xs:annotation>
+																					<xs:documentation>Valor do CIDE</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																		</xs:sequence>
+																	</xs:complexType>
+																</xs:element>
+																<xs:element name="encerrante" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Informações do grupo de &quot;encerrante&quot;</xs:documentation>
+																	</xs:annotation>
+																	<xs:complexType>
+																		<xs:sequence>
+																			<xs:element name="nBico">
+																				<xs:annotation>
+																					<xs:documentation>Numero de identificação do Bico utilizado no abastecimento</xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:string">
+																						<xs:whiteSpace value="preserve"/>
+																						<xs:pattern value="[0-9]{1,3}"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																			<xs:element name="nBomba" minOccurs="0">
+																				<xs:annotation>
+																					<xs:documentation>Numero de identificação da bomba ao qual o bico está interligado</xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:string">
+																						<xs:whiteSpace value="preserve"/>
+																						<xs:pattern value="[0-9]{1,3}"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																			<xs:element name="nTanque">
+																				<xs:annotation>
+																					<xs:documentation>Numero de identificação do tanque ao qual o bico está interligado</xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:string">
+																						<xs:whiteSpace value="preserve"/>
+																						<xs:pattern value="[0-9]{1,3}"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																			<xs:element name="vEncIni" type="TDec_1203">
+																				<xs:annotation>
+																					<xs:documentation>Valor do Encerrante no ínicio do abastecimento</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																			<xs:element name="vEncFin" type="TDec_1203">
+																				<xs:annotation>
+																					<xs:documentation>Valor do Encerrante no final do abastecimento</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																		</xs:sequence>
+																	</xs:complexType>
+																</xs:element>
+																<xs:element name="pBio" type="TDec_03v00a04Max100Opc" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Percentual do índice de mistura do Biodiesel (B100) no Óleo Diesel B instituído pelo órgão regulamentador</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="origComb" minOccurs="0" maxOccurs="30">
+																	<xs:annotation>
+																		<xs:documentation>Grupo indicador da origem do combustível</xs:documentation>
+																	</xs:annotation>
+																	<xs:complexType>
+																		<xs:sequence>
+																			<xs:element name="indImport">
+																				<xs:annotation>
+																					<xs:documentation>Indicador de importação 0=Nacional; 1=Importado;</xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:string">
+																						<xs:whiteSpace value="preserve"/>
+																						<xs:enumeration value="0"/>
+																						<xs:enumeration value="1"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																			<xs:element name="cUFOrig" type="TCodUfIBGE">
+																				<xs:annotation>
+																					<xs:documentation>UF de origem do produtor ou do importado</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																			<xs:element name="pOrig" type="TDec_03v00a04Max100Opc">
+																				<xs:annotation>
+																					<xs:documentation>Percentual originário para a UF</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																		</xs:sequence>
+																	</xs:complexType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="nRECOPI">
+														<xs:annotation>
+															<xs:documentation>Número do RECOPI</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:whiteSpace value="preserve"/>
+																<xs:maxLength value="20"/>
+																<xs:pattern value="[0-9]{20}"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:choice>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="imposto">
+										<xs:annotation>
+											<xs:documentation>Tributos incidentes nos produtos ou serviços da NF-e</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="vTotTrib" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor estimado total de impostos federais, estaduais e municipais</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:choice minOccurs="0">
+													<xs:sequence>
+														<xs:element name="ICMS">
+															<xs:annotation>
+																<xs:documentation>Dados do ICMS Normal e ST</xs:documentation>
+															</xs:annotation>
+															<xs:complexType>
+																<xs:choice>
+																	<xs:element name="ICMS00">
+																		<xs:annotation>
+																			<xs:documentation>Tributação pelo ICMS
+00 - Tributada integralmente</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributção pelo ICMS
+00 - Tributada integralmente</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="00"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="modBC">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS:
+0 - Margem Valor Agregado (%);
+1 - Pauta (valor);
+2 - Preço Tabelado Máximo (valor);
+3 - Valor da Operação.</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="vBC" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMS" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMS" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="pFCP" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCP" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS02">
+																		<xs:annotation>
+																			<xs:documentation>Tributação monofásica própria sobre combustíveis</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributção pelo ICMS
+02= Tributação monofásica própria sobre combustíveis;</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="02"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="qBCMono" type="TDec_1104v" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Quantidade tributada.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="adRemICMS" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota ad rem do imposto.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSMono" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS própri</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS10">
+																		<xs:annotation>
+																			<xs:documentation>Tributação pelo ICMS
+10 - Tributada e com cobrança do ICMS por substituição tributária</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>10 - Tributada e com cobrança do ICMS por substituição tributária</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="10"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="modBC">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS:
+0 - Margem Valor Agregado (%);
+1 - Pauta (valor);
+2 - Preço Tabelado Máximo (valor);
+3 - Valor da Operação.</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="vBC" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMS" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMS" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCP" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCP" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCP" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:element name="modBCST">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS ST:
+0 – Preço tabelado ou máximo  sugerido;
+1 - Lista Negativa (valor);
+2 - Lista Positiva (valor);
+3 - Lista Neutra (valor);
+4 - Margem Valor Agregado (%);
+5 - Pauta (valor)
+6-Valor da Operação;</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																							<xs:enumeration value="4"/>
+																							<xs:enumeration value="5"/>
+																							<xs:enumeration value="6"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="pMVAST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual da Margem de Valor Adicionado ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pRedBCST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual de redução da BC ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vBCST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMSST" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP retido por substituicao tributaria.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCPST" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vICMSSTDeson" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS-ST desonerado.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="motDesICMSST">
+																						<xs:annotation>
+																							<xs:documentation>Motivo da desoneração do ICMS-ST: 3-Uso na agropecuária; 9-Outros; 12-Fomento agropecuário.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="3"/>
+																								<xs:enumeration value="9"/>
+																								<xs:enumeration value="12"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS15">
+																		<xs:annotation>
+																			<xs:documentation>Tributação monofásica própria e com responsabilidade pela retenção sobre combustíveis</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributção pelo ICMS
+15= Tributação monofásica própria e com responsabilidade pela retenção sobre combustíveis;</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="15"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="qBCMono" type="TDec_1104v" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Quantidade tributada.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="adRemICMS" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota ad rem do imposto.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSMono" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS próprio</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="qBCMonoReten" type="TDec_1104v" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Quantidade tributada sujeita a retenção.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="adRemICMSReten" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota ad rem do imposto com retenção.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSMonoReten" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS com retenção</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="pRedAdRem" type="TDec_0302Max100">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de redução do valor da alíquota ad rem do ICMS.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="motRedAdRem">
+																						<xs:annotation>
+																							<xs:documentation>Motivo da redução do adrem
+																							1= Transporte coletivo de passageiros; 9=Outros; 
+																						</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="1"/>
+																								<xs:enumeration value="9"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS20">
+																		<xs:annotation>
+																			<xs:documentation>Tributção pelo ICMS
+20 - Com redução de base de cálculo</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributção pelo ICMS
+20 - Com redução de base de cálculo</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="20"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="modBC">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS:
+0 - Margem Valor Agregado (%);
+1 - Pauta (valor);
+2 - Preço Tabelado Máximo (valor);
+3 - Valor da Operação.</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="pRedBC" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Percentual de redução da BC</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vBC" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMS" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMS" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCP" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCP" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCP" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Grupo desoneração</xs:documentation>
+																					</xs:annotation>
+																					<xs:element name="vICMSDeson" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="motDesICMS">
+																						<xs:annotation>
+																							<xs:documentation>Motivo da desoneração do ICMS:3-Uso na agropecuária;9-Outros;12-Fomento agropecuário</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="3"/>
+																								<xs:enumeration value="9"/>
+																								<xs:enumeration value="12"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="indDeduzDeson" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Indica se o valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd):
+0=Valor do ICMS desonerado (vICMSDeson) não deduz do valor do item (vProd) / total da NF-e;
+1=Valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd) / total da NF-e.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS30">
+																		<xs:annotation>
+																			<xs:documentation>Tributação pelo ICMS
+30 - Isenta ou não tributada e com cobrança do ICMS por substituição tributária</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributção pelo ICMS
+30 - Isenta ou não tributada e com cobrança do ICMS por substituição tributária</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="30"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="modBCST">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS ST:
+0 – Preço tabelado ou máximo  sugerido;
+1 - Lista Negativa (valor);
+2 - Lista Positiva (valor);
+3 - Lista Neutra (valor);
+4 - Margem Valor Agregado (%);
+5 - Pauta (valor).
+6 - Valor da Operação</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																							<xs:enumeration value="4"/>
+																							<xs:enumeration value="5"/>
+																							<xs:enumeration value="6"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="pMVAST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual da Margem de Valor Adicionado ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pRedBCST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual de redução da BC ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vBCST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMSST" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCPST" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Grupo desoneração</xs:documentation>
+																					</xs:annotation>
+																					<xs:element name="vICMSDeson" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="motDesICMS">
+																						<xs:annotation>
+																							<xs:documentation>Motivo da desoneração do ICMS:6-Utilitários Motocicleta AÁrea Livre;7-SUFRAMA;9-Outros</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="6"/>
+																								<xs:enumeration value="7"/>
+																								<xs:enumeration value="9"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="indDeduzDeson" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Indica se o valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd):
+0=Valor do ICMS desonerado (vICMSDeson) não deduz do valor do item (vProd) / total da NF-e;
+1=Valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd) / total da NF-e.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS40">
+																		<xs:annotation>
+																			<xs:documentation>Tributação pelo ICMS
+40 - Isenta 
+41 - Não tributada 
+50 - Suspensão</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributação pelo ICMS 
+40 - Isenta 
+41 - Não tributada 
+50 - Suspensão 
+51 - Diferimento</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="40"/>
+																							<xs:enumeration value="41"/>
+																							<xs:enumeration value="50"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vICMSDeson" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>O valor do ICMS será informado apenas nas operações com veículos beneficiados com a desoneração condicional do ICMS.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="motDesICMS">
+																						<xs:annotation>
+																							<xs:documentation>Este campo será preenchido quando o campo anterior estiver preenchido.
+Informar o motivo da desoneração:
+1 – Táxi;
+3 – Produtor Agropecuário;
+4 – Frotista/Locadora;
+5 – Diplomático/Consular;
+6 – Utilitários e Motocicletas da Amazônia Ocidental e Áreas de Livre Comércio (Resolução 714/88 e 790/94 – CONTRAN e suas alterações);
+7 – SUFRAMA;
+8 - Venda a órgão Público;
+9 – Outros
+10- Deficiente Condutor
+11- Deficiente não condutor
+16 - Olimpíadas Rio 2016
+90 - Solicitado pelo Fisco</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="1"/>
+																								<xs:enumeration value="3"/>
+																								<xs:enumeration value="4"/>
+																								<xs:enumeration value="5"/>
+																								<xs:enumeration value="6"/>
+																								<xs:enumeration value="7"/>
+																								<xs:enumeration value="8"/>
+																								<xs:enumeration value="9"/>
+																								<xs:enumeration value="10"/>
+																								<xs:enumeration value="11"/>
+																								<xs:enumeration value="16"/>
+																								<xs:enumeration value="90"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="indDeduzDeson" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Indica se o valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd):
+0=Valor do ICMS desonerado (vICMSDeson) não deduz do valor do item (vProd) / total da NF-e;
+1=Valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd) / total da NF-e.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS51">
+																		<xs:annotation>
+																			<xs:documentation>Tributção pelo ICMS 51 - Diferimento. A exigência do preenchimento das informações do ICMS diferido fica à critério de cada UF.</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+																						1 - Estrangeira - Importação direta 
+																						2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributação pelo ICMS 51 - Tributação com Diferimento</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="51"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="modBC" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS:
+																						0 - Margem Valor Agregado (%);
+																						1 - Pauta (valor);
+																						2 - Preço Tabelado Máximo (valor);
+																						3 - Valor da Operação.</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="pRedBC" type="TDec_0302a04" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual de redução da BC</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="cBenefRBC" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Código de Benefício Fiscal na UF aplicado ao item quando houver RBC.</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:pattern value="[!-ÿ]{8}|[!-ÿ]{10}"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="vBC" type="TDec_1302" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMS" type="TDec_0302a04" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do imposto</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSOp" type="TDec_1302" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS da Operação</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pDif" type="TDec_0302a04Max100" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual do diferemento</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSDif" type="TDec_1302" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS da diferido</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMS" type="TDec_1302" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCP" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCP" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCP" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="pFCPDif" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual do diferimento do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPDif" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP) diferido.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPEfet" type="TDec_1302" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Valor efetivo do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS53">
+																		<xs:annotation>
+																			<xs:documentation>Tributação monofásica sobre combustíveis com recolhimento diferido</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributção pelo ICMS
+53= Tributação monofásica sobre combustíveis com recolhimento diferido;</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="53"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="qBCMono" type="TDec_1104v" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Quantidade tributada.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="adRemICMS" type="TDec_0302a04" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota ad rem do imposto.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSMonoOp" type="TDec_1302" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS da operação</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pDif" type="TDec_0302a04Max100" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual do diferemento</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSMonoDif" type="TDec_1302" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS diferido</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSMono" type="TDec_1302" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS próprio devido</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="qBCMonoDif" type="TDec_1104v" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Quantidade tributada diferida.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="adRemICMSDif" type="TDec_0302a04" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota ad rem do imposto diferido</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS60">
+																		<xs:annotation>
+																			<xs:documentation>Tributação pelo ICMS
+60 - ICMS cobrado anteriormente por substituição tributária</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributação pelo ICMS 
+60 - ICMS cobrado anteriormente por substituição tributária</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="60"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>NT2010/004</xs:documentation>
+																					</xs:annotation>
+																					<xs:element name="vBCSTRet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da BC do ICMS ST retido anteriormente</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pST" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Aliquota suportada pelo consumidor final.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMSSubstituto" type="TDec_1302" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS Próprio do Substituto cobrado em operação anterior</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMSSTRet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS ST retido anteriormente</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCPSTRet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP retido anteriormente por ST.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCPSTRet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de FCP retido anteriormente por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPSTRet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="pRedBCEfet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de redução da base de cálculo efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vBCEfet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da base de cálculo efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pICMSEfet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Alíquota do ICMS efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMSEfet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS efetivo.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS61">
+																		<xs:annotation>
+																			<xs:documentation>Tributação monofásica sobre combustíveis cobrada anteriormente;</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributção pelo ICMS
+61= Tributação monofásica sobre combustíveis cobrada anteriormente</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="61"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="qBCMonoRet" type="TDec_1104v" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Quantidade tributada retida anteriormente</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="adRemICMSRet" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota ad rem do imposto retido anteriormente</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSMonoRet" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS retido anteriormente</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS70">
+																		<xs:annotation>
+																			<xs:documentation>Tributação pelo ICMS 
+70 - Com redução de base de cálculo e cobrança do ICMS por substituição tributária</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributção pelo ICMS
+70 - Com redução de base de cálculo e cobrança do ICMS por substituição tributária</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="70"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="modBC">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS:
+0 - Margem Valor Agregado (%);
+1 - Pauta (valor);
+2 - Preço Tabelado Máximo (valor);
+3 - Valor da Operação.</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="pRedBC" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Percentual de redução da BC</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vBC" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMS" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMS" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCP" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCP" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCP" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:element name="modBCST">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS ST:
+0 – Preço tabelado ou máximo  sugerido;
+1 - Lista Negativa (valor);
+2 - Lista Positiva (valor);
+3 - Lista Neutra (valor);
+4 - Margem Valor Agregado (%);
+5 - Pauta (valor);
+6 - Valor da Operação.</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																							<xs:enumeration value="4"/>
+																							<xs:enumeration value="5"/>
+																							<xs:enumeration value="6"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="pMVAST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual da Margem de Valor Adicionado ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pRedBCST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual de redução da BC ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vBCST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMSST" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCPST" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Grupo desoneração</xs:documentation>
+																					</xs:annotation>
+																					<xs:element name="vICMSDeson" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="motDesICMS">
+																						<xs:annotation>
+																							<xs:documentation>Motivo da desoneração do ICMS:3-Uso na agropecuária;9-Outros;12-Fomento agropecuário</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="3"/>
+																								<xs:enumeration value="9"/>
+																								<xs:enumeration value="12"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="indDeduzDeson" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Indica se o valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd):
+0=Valor do ICMS desonerado (vICMSDeson) não deduz do valor do item (vProd) / total da NF-e;
+1=Valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd) / total da NF-e.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vICMSSTDeson" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS-ST desonerado.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="motDesICMSST">
+																						<xs:annotation>
+																							<xs:documentation>Motivo da desoneração do ICMS-ST: 3-Uso na agropecuária; 9-Outros; 12-Fomento agropecuário.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="3"/>
+																								<xs:enumeration value="9"/>
+																								<xs:enumeration value="12"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS90">
+																		<xs:annotation>
+																			<xs:documentation>Tributação pelo ICMS
+90 - Outras</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributção pelo ICMS
+90 - Outras</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="90"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="modBC">
+																						<xs:annotation>
+																							<xs:documentation>Modalidade de determinação da BC do ICMS: 
+0 - Margem Valor Agregado (%);
+1 - Pauta (valor);
+2 - Preço Tabelado Máximo (valor);
+3 - Valor da Operação.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																								<xs:enumeration value="2"/>
+																								<xs:enumeration value="3"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="vBC" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da BC do ICMS</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pRedBC" type="TDec_0302a04Opc" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de redução da BC</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pICMS" type="TDec_0302a04">
+																						<xs:annotation>
+																							<xs:documentation>Alíquota do ICMS</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMS" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:sequence minOccurs="0">
+																						<xs:element name="vBCFCP" type="TDec_1302">
+																							<xs:annotation>
+																								<xs:documentation>Valor da Base de cálculo do FCP.</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="pFCP" type="TDec_0302a04Opc">
+																							<xs:annotation>
+																								<xs:documentation>Percentual de ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="vFCP" type="TDec_1302">
+																							<xs:annotation>
+																								<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																					</xs:sequence>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="modBCST">
+																						<xs:annotation>
+																							<xs:documentation>Modalidade de determinação da BC do ICMS ST:
+0 – Preço tabelado ou máximo  sugerido;
+1 - Lista Negativa (valor);
+2 - Lista Positiva (valor);
+3 - Lista Neutra (valor);
+4 - Margem Valor Agregado (%);
+5 - Pauta (valor);
+6 - Valor da Operação.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																								<xs:enumeration value="2"/>
+																								<xs:enumeration value="3"/>
+																								<xs:enumeration value="4"/>
+																								<xs:enumeration value="5"/>
+																								<xs:enumeration value="6"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="pMVAST" type="TDec_0302a04Opc" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Percentual da Margem de Valor Adicionado ICMS ST</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pRedBCST" type="TDec_0302a04Opc" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de redução da BC ICMS ST</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vBCST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da BC do ICMS ST</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pICMSST" type="TDec_0302a04">
+																						<xs:annotation>
+																							<xs:documentation>Alíquota do ICMS ST</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMSST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS ST</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:sequence minOccurs="0">
+																						<xs:element name="vBCFCPST" type="TDec_1302">
+																							<xs:annotation>
+																								<xs:documentation>Valor da Base de cálculo do FCP.</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="pFCPST" type="TDec_0302a04Opc">
+																							<xs:annotation>
+																								<xs:documentation>Percentual de FCP retido por substituição tributária.</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="vFCPST" type="TDec_1302">
+																							<xs:annotation>
+																								<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																					</xs:sequence>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Grupo desoneração</xs:documentation>
+																					</xs:annotation>
+																					<xs:element name="vICMSDeson" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="motDesICMS">
+																						<xs:annotation>
+																							<xs:documentation>Motivo da desoneração do ICMS:3-Uso na agropecuária;9-Outros;12-Fomento agropecuário</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="3"/>
+																								<xs:enumeration value="9"/>
+																								<xs:enumeration value="12"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="indDeduzDeson" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Indica se o valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd):
+0=Valor do ICMS desonerado (vICMSDeson) não deduz do valor do item (vProd) / total da NF-e;
+1=Valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd) / total da NF-e.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vICMSSTDeson" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS-ST desonerado.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="motDesICMSST">
+																						<xs:annotation>
+																							<xs:documentation>Motivo da desoneração do ICMS-ST: 3-Uso na agropecuária; 9-Outros; 12-Fomento agropecuário.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="3"/>
+																								<xs:enumeration value="9"/>
+																								<xs:enumeration value="12"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMSPart">
+																		<xs:annotation>
+																			<xs:documentation>Partilha do ICMS entre a UF de origem e UF de destino ou a UF definida na legislação
+Operação interestadual para consumidor final com partilha do ICMS  devido na operação entre a UF de origem e a UF do destinatário ou ou a UF definida na legislação. (Ex. UF da concessionária de entrega do  veículos)</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributação pelo ICMS 
+10 - Tributada e com cobrança do ICMS por substituição tributária;
+90 – Outros.</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="10"/>
+																							<xs:enumeration value="90"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="modBC">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS: 
+0 - Margem Valor Agregado (%);
+1 - Pauta (valor);
+2 - Preço Tabelado Máximo (valor);
+3 - Valor da Operação.</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="vBC" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pRedBC" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual de redução da BC</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMS" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMS" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="modBCST">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS ST:
+0 – Preço tabelado ou máximo  sugerido;
+1 - Lista Negativa (valor);
+2 - Lista Positiva (valor);
+3 - Lista Neutra (valor);
+4 - Margem Valor Agregado (%);
+5 - Pauta (valor).
+6 - Valor da Operação</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																							<xs:enumeration value="4"/>
+																							<xs:enumeration value="5"/>
+																							<xs:enumeration value="6"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="pMVAST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual da Margem de Valor Adicionado ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pRedBCST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual de redução da BC ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vBCST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMSST" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP retido por substituicao tributaria.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCPST" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:element name="pBCOp" type="TDec_0302a04Opc">
+																					<xs:annotation>
+																						<xs:documentation>Percentual para determinação do valor  da Base de Cálculo da operação própria.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="UFST" type="TUf">
+																					<xs:annotation>
+																						<xs:documentation>Sigla da UF para qual é devido o ICMS ST da operação.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMSST">
+																		<xs:annotation>
+																			<xs:documentation>Grupo de informação do ICMSST devido para a UF de destino, nas operações interestaduais de produtos que tiveram retenção antecipada de ICMS por ST na UF do remetente. Repasse via Substituto Tributário.</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributção pelo ICMS
+41-Não Tributado.
+60-Cobrado anteriormente por substituição tributária.</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="41"/>
+																							<xs:enumeration value="60"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="vBCSTRet" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Informar o valor da BC do ICMS ST retido na UF remetente</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Aliquota suportada pelo consumidor final.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSSubstituto" type="TDec_1302" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS Próprio do Substituto cobrado em operação anterior</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSSTRet" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation> Informar o valor do ICMS ST retido na UF remetente (iv2.0))</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCPSTRet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Informar o valor da Base de Cálculo do FCP retido anteriormente por ST.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCPSTRet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual relativo ao Fundo de Combate à Pobreza (FCP) retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPSTRet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP) retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:element name="vBCSTDest" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation> Informar o valor da BC do ICMS ST da UF destino</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSSTDest" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Informar o valor da BC do ICMS ST da UF destino (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="pRedBCEfet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de redução da base de cálculo efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vBCEfet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da base de cálculo efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pICMSEfet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Alíquota do ICMS efetivo.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMSEfet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS efetivo.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMSSN101">
+																		<xs:annotation>
+																			<xs:documentation>Tributação do ICMS pelo SIMPLES NACIONAL e CSOSN=101 (v.2.0)</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno 
+(v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CSOSN">
+																					<xs:annotation>
+																						<xs:documentation>101- Tributada pelo Simples Nacional com permissão de crédito. (v.2.0)</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="101"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="pCredSN" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota aplicável de cálculo do crédito (Simples Nacional). (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vCredICMSSN" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor crédito do ICMS que pode ser aproveitado nos termos do art. 23 da LC 123 (Simples Nacional) (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMSSN102">
+																		<xs:annotation>
+																			<xs:documentation>Tributação do ICMS pelo SIMPLES NACIONAL e CSOSN=102, 103, 300 ou 400 (v.2.0))</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno 
+(v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CSOSN">
+																					<xs:annotation>
+																						<xs:documentation>102- Tributada pelo Simples Nacional sem permissão de crédito. 
+103 – Isenção do ICMS  no Simples Nacional para faixa de receita bruta.
+300 – Imune.
+400 – Não tributda pelo Simples Nacional (v.2.0) (v.2.0)</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="102"/>
+																							<xs:enumeration value="103"/>
+																							<xs:enumeration value="300"/>
+																							<xs:enumeration value="400"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMSSN201">
+																		<xs:annotation>
+																			<xs:documentation>Tributação do ICMS pelo SIMPLES NACIONAL e CSOSN=201 (v.2.0)</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>Origem da mercadoria:
+0 – Nacional;
+1 – Estrangeira – Importação direta;
+2 – Estrangeira – Adquirida no mercado interno. (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CSOSN">
+																					<xs:annotation>
+																						<xs:documentation>201- Tributada pelo Simples Nacional com permissão de crédito e com cobrança do ICMS por Substituição Tributária (v.2.0)</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="201"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="modBCST">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS ST:
+0 – Preço tabelado ou máximo  sugerido;
+1 - Lista Negativa (valor);
+2 - Lista Positiva (valor);
+3 - Lista Neutra (valor);
+4 - Margem Valor Agregado (%);
+5 - Pauta (valor). (v2.0)
+6 - Valor da Operação</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																							<xs:enumeration value="4"/>
+																							<xs:enumeration value="5"/>
+																							<xs:enumeration value="6"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="pMVAST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual da Margem de Valor Adicionado ICMS ST (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pRedBCST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual de redução da BC ICMS ST  (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vBCST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS ST (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMSST" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS ST (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS ST (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCPST" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:element name="pCredSN" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota aplicável de cálculo do crédito (Simples Nacional). (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vCredICMSSN" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor crédito do ICMS que pode ser aproveitado nos termos do art. 23 da LC 123 (Simples Nacional) (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMSSN202">
+																		<xs:annotation>
+																			<xs:documentation>Tributação do ICMS pelo SIMPLES NACIONAL e CSOSN=202 ou 203 (v.2.0)</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>Origem da mercadoria:
+0 – Nacional;
+1 – Estrangeira – Importação direta;
+2 – Estrangeira – Adquirida no mercado interno. (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CSOSN">
+																					<xs:annotation>
+																						<xs:documentation>202- Tributada pelo Simples Nacional sem permissão de crédito e com cobrança do ICMS por Substituição Tributária;
+203-  Isenção do ICMS nos Simples Nacional para faixa de receita bruta e com cobrança do ICMS por Substituição Tributária (v.2.0)</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="202"/>
+																							<xs:enumeration value="203"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="modBCST">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS ST:
+0 – Preço tabelado ou máximo  sugerido;
+1 - Lista Negativa (valor);
+2 - Lista Positiva (valor);
+3 - Lista Neutra (valor);
+4 - Margem Valor Agregado (%);
+5 - Pauta (valor). (v2.0)
+6 - Valor da Operação</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																							<xs:enumeration value="4"/>
+																							<xs:enumeration value="5"/>
+																							<xs:enumeration value="6"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="pMVAST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual da Margem de Valor Adicionado ICMS ST (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pRedBCST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual de redução da BC ICMS ST  (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vBCST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS ST (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMSST" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS ST (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS ST (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCPST" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMSSN500">
+																		<xs:annotation>
+																			<xs:documentation>Tributação do ICMS pelo SIMPLES NACIONAL,CRT=1 – Simples Nacional e CSOSN=500 (v.2.0)</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CSOSN">
+																					<xs:annotation>
+																						<xs:documentation>500 – ICMS cobrado anterirmente por substituição tributária (substituído) ou por antecipação
+(v.2.0)</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="500"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCSTRet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da BC do ICMS ST retido anteriormente (v2.0)</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pST" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Aliquota suportada pelo consumidor final.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMSSubstituto" type="TDec_1302" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS próprio do substituto</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMSSTRet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS ST retido anteriormente  (v2.0)</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCPSTRet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP retido anteriormente.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCPSTRet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de FCP retido anteriormente por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPSTRet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="pRedBCEfet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de redução da base de cálculo efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vBCEfet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da base de cálculo efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pICMSEfet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Alíquota do ICMS efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMSEfet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS efetivo.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMSSN900">
+																		<xs:annotation>
+																			<xs:documentation>Tributação do ICMS pelo SIMPLES NACIONAL, CRT=1 – Simples Nacional, CRT=4 - MEI e CSOSN=900 (v2.0)</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CSOSN">
+																					<xs:annotation>
+																						<xs:documentation>Tributação pelo ICMS 900 - Outros(v2.0)</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="900"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="modBC">
+																						<xs:annotation>
+																							<xs:documentation>Modalidade de determinação da BC do ICMS: 
+0 - Margem Valor Agregado (%);
+1 - Pauta (valor);
+2 - Preço Tabelado Máximo (valor);
+3 - Valor da Operação.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																								<xs:enumeration value="2"/>
+																								<xs:enumeration value="3"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="vBC" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da BC do ICMS</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pRedBC" type="TDec_0302a04Opc" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de redução da BC</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pICMS" type="TDec_0302a04">
+																						<xs:annotation>
+																							<xs:documentation>Alíquota do ICMS</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMS" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="modBCST">
+																						<xs:annotation>
+																							<xs:documentation>Modalidade de determinação da BC do ICMS ST:
+0 – Preço tabelado ou máximo  sugerido;
+1 - Lista Negativa (valor);
+2 - Lista Positiva (valor);
+3 - Lista Neutra (valor);
+4 - Margem Valor Agregado (%);
+5 - Pauta (valor).
+6 - Valor da Operação</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																								<xs:enumeration value="2"/>
+																								<xs:enumeration value="3"/>
+																								<xs:enumeration value="4"/>
+																								<xs:enumeration value="5"/>
+																								<xs:enumeration value="6"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="pMVAST" type="TDec_0302a04Opc" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Percentual da Margem de Valor Adicionado ICMS ST</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pRedBCST" type="TDec_0302a04Opc" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de redução da BC ICMS ST</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vBCST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da BC do ICMS ST</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pICMSST" type="TDec_0302a04">
+																						<xs:annotation>
+																							<xs:documentation>Alíquota do ICMS ST</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMSST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS ST</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:sequence minOccurs="0">
+																						<xs:element name="vBCFCPST" type="TDec_1302">
+																							<xs:annotation>
+																								<xs:documentation>Valor da Base de cálculo do FCP.</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="pFCPST" type="TDec_0302a04Opc">
+																							<xs:annotation>
+																								<xs:documentation>Percentual de FCP retido por substituição tributária.</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="vFCPST" type="TDec_1302">
+																							<xs:annotation>
+																								<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																					</xs:sequence>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="pCredSN" type="TDec_0302a04">
+																						<xs:annotation>
+																							<xs:documentation>Alíquota aplicável de cálculo do crédito (Simples Nacional). (v2.0)</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vCredICMSSN" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor crédito do ICMS que pode ser aproveitado nos termos do art. 23 da LC 123 (Simples Nacional) (v2.0)</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																</xs:choice>
+															</xs:complexType>
+														</xs:element>
+														<xs:element name="IPI" type="TIpi" minOccurs="0"/>
+														<xs:element name="II" minOccurs="0">
+															<xs:annotation>
+																<xs:documentation>Dados do Imposto de Importação</xs:documentation>
+															</xs:annotation>
+															<xs:complexType>
+																<xs:sequence>
+																	<xs:element name="vBC" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Base da BC do Imposto de Importação</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vDespAdu" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor das despesas aduaneiras</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vII" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor do Imposto de Importação</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vIOF" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor do Imposto sobre Operações Financeiras</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																</xs:sequence>
+															</xs:complexType>
+														</xs:element>
+													</xs:sequence>
+													<xs:sequence>
+														<xs:element name="IPI" type="TIpi" minOccurs="0"/>
+														<xs:element name="ISSQN">
+															<xs:annotation>
+																<xs:documentation>ISSQN</xs:documentation>
+															</xs:annotation>
+															<xs:complexType>
+																<xs:sequence>
+																	<xs:element name="vBC" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor da BC do ISSQN</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vAliq" type="TDec_0302a04">
+																		<xs:annotation>
+																			<xs:documentation>Alíquota do ISSQN</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vISSQN" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor da do ISSQN</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="cMunFG" type="TCodMunIBGE">
+																		<xs:annotation>
+																			<xs:documentation>Informar o município de ocorrência do fato gerador do ISSQN. Utilizar a Tabela do IBGE (Anexo VII - Tabela de UF, Município e País). “Atenção, não vincular com os campos B12, C10 ou E10” v2.0</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="cListServ" type="TCListServ">
+																		<xs:annotation>
+																			<xs:documentation>Informar o Item da lista de serviços da LC 116/03 em que se classifica o serviço.</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vDeducao" type="TDec_1302Opc" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Valor dedução para redução da base de cálculo</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vOutro" type="TDec_1302Opc" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Valor outras retenções</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vDescIncond" type="TDec_1302Opc" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Valor desconto incondicionado</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vDescCond" type="TDec_1302Opc" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Valor desconto condicionado</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vISSRet" type="TDec_1302Opc" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Valor Retenção ISS</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="indISS">
+																		<xs:annotation>
+																			<xs:documentation>Exibilidade do ISS:1-Exigível;2-Não incidente;3-Isenção;4-Exportação;5-Imunidade;6-Exig.Susp. Judicial;7-Exig.Susp. ADM</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="xs:string">
+																				<xs:whiteSpace value="preserve"/>
+																				<xs:enumeration value="1"/>
+																				<xs:enumeration value="2"/>
+																				<xs:enumeration value="3"/>
+																				<xs:enumeration value="4"/>
+																				<xs:enumeration value="5"/>
+																				<xs:enumeration value="6"/>
+																				<xs:enumeration value="7"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="cServico" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Código do serviço prestado dentro do município</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="TString">
+																				<xs:whiteSpace value="preserve"/>
+																				<xs:minLength value="1"/>
+																				<xs:maxLength value="20"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="cMun" type="TCodMunIBGE" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Código do Município de Incidência do Imposto</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="cPais" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Código de Pais</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="xs:string">
+																				<xs:whiteSpace value="preserve"/>
+																				<xs:pattern value="[0-9]{1,4}"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="nProcesso" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Número do Processo administrativo ou judicial de suspenção do processo</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="TString">
+																				<xs:whiteSpace value="preserve"/>
+																				<xs:minLength value="1"/>
+																				<xs:maxLength value="30"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="indIncentivo">
+																		<xs:annotation>
+																			<xs:documentation>Indicador de Incentivo Fiscal. 1=Sim; 2=Não</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="xs:string">
+																				<xs:whiteSpace value="preserve"/>
+																				<xs:enumeration value="1"/>
+																				<xs:enumeration value="2"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																</xs:sequence>
+															</xs:complexType>
+														</xs:element>
+													</xs:sequence>
+												</xs:choice>
+												<xs:element name="PIS" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Dados do PIS</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:choice>
+															<xs:element name="PISAliq">
+																<xs:annotation>
+																	<xs:documentation>Código de Situação Tributária do PIS.
+ 01 – Operação Tributável - Base de Cálculo = Valor da Operação Alíquota Normal (Cumulativo/Não Cumulativo);
+02 - Operação Tributável - Base de Calculo = Valor da Operação (Alíquota Diferenciada);</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="CST">
+																			<xs:annotation>
+																				<xs:documentation>Código de Situação Tributária do PIS.
+ 01 – Operação Tributável - Base de Cálculo = Valor da Operação Alíquota Normal (Cumulativo/Não Cumulativo);
+02 - Operação Tributável - Base de Calculo = Valor da Operação (Alíquota Diferenciada);</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:whiteSpace value="preserve"/>
+																					<xs:enumeration value="01"/>
+																					<xs:enumeration value="02"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																		<xs:element name="vBC" type="TDec_1302">
+																			<xs:annotation>
+																				<xs:documentation>Valor da BC do PIS</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="pPIS" type="TDec_0302a04">
+																			<xs:annotation>
+																				<xs:documentation>Alíquota do PIS (em percentual)</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="vPIS" type="TDec_1302">
+																			<xs:annotation>
+																				<xs:documentation>Valor do PIS</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="PISQtde">
+																<xs:annotation>
+																	<xs:documentation>Código de Situação Tributária do PIS.
+03 - Operação Tributável - Base de Calculo = Quantidade Vendida x Alíquota por Unidade de Produto;</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="CST">
+																			<xs:annotation>
+																				<xs:documentation>Código de Situação Tributária do PIS.
+03 - Operação Tributável - Base de Calculo = Quantidade Vendida x Alíquota por Unidade de Produto;</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:whiteSpace value="preserve"/>
+																					<xs:enumeration value="03"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																		<xs:element name="qBCProd" type="TDec_1204v">
+																			<xs:annotation>
+																				<xs:documentation>Quantidade Vendida  (NT2011/004)</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="vAliqProd" type="TDec_1104v">
+																			<xs:annotation>
+																				<xs:documentation>Alíquota do PIS (em reais) (NT2011/004)</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="vPIS" type="TDec_1302">
+																			<xs:annotation>
+																				<xs:documentation>Valor do PIS</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="PISNT">
+																<xs:annotation>
+																	<xs:documentation>Código de Situação Tributária do PIS.
+04 - Operação Tributável - Tributação Monofásica - (Alíquota Zero);
+06 - Operação Tributável - Alíquota Zero;
+07 - Operação Isenta da contribuição;
+08 - Operação Sem Incidência da contribuição;
+09 - Operação com suspensão da contribuição;</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="CST">
+																			<xs:annotation>
+																				<xs:documentation>Código de Situação Tributária do PIS.
+04 - Operação Tributável - Tributação Monofásica - (Alíquota Zero);
+05 - Operação Tributável (ST);
+06 - Operação Tributável - Alíquota Zero;
+07 - Operação Isenta da contribuição;
+08 - Operação Sem Incidência da contribuição;
+09 - Operação com suspensão da contribuição;</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:whiteSpace value="preserve"/>
+																					<xs:enumeration value="04"/>
+																					<xs:enumeration value="05"/>
+																					<xs:enumeration value="06"/>
+																					<xs:enumeration value="07"/>
+																					<xs:enumeration value="08"/>
+																					<xs:enumeration value="09"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="PISOutr">
+																<xs:annotation>
+																	<xs:documentation>Código de Situação Tributária do PIS.
+99 - Outras Operações.</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="CST">
+																			<xs:annotation>
+																				<xs:documentation>Código de Situação Tributária do PIS.
+99 - Outras Operações.</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:whiteSpace value="preserve"/>
+																					<xs:enumeration value="49"/>
+																					<xs:enumeration value="50"/>
+																					<xs:enumeration value="51"/>
+																					<xs:enumeration value="52"/>
+																					<xs:enumeration value="53"/>
+																					<xs:enumeration value="54"/>
+																					<xs:enumeration value="55"/>
+																					<xs:enumeration value="56"/>
+																					<xs:enumeration value="60"/>
+																					<xs:enumeration value="61"/>
+																					<xs:enumeration value="62"/>
+																					<xs:enumeration value="63"/>
+																					<xs:enumeration value="64"/>
+																					<xs:enumeration value="65"/>
+																					<xs:enumeration value="66"/>
+																					<xs:enumeration value="67"/>
+																					<xs:enumeration value="70"/>
+																					<xs:enumeration value="71"/>
+																					<xs:enumeration value="72"/>
+																					<xs:enumeration value="73"/>
+																					<xs:enumeration value="74"/>
+																					<xs:enumeration value="75"/>
+																					<xs:enumeration value="98"/>
+																					<xs:enumeration value="99"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																		<xs:choice>
+																			<xs:sequence>
+																				<xs:element name="vBC" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do PIS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pPIS" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do PIS (em percentual)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																			</xs:sequence>
+																			<xs:sequence>
+																				<xs:element name="qBCProd" type="TDec_1204v">
+																					<xs:annotation>
+																						<xs:documentation>Quantidade Vendida (NT2011/004)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vAliqProd" type="TDec_1104v">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do PIS (em reais) (NT2011/004)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																			</xs:sequence>
+																		</xs:choice>
+																		<xs:element name="vPIS" type="TDec_1302">
+																			<xs:annotation>
+																				<xs:documentation>Valor do PIS</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+														</xs:choice>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="PISST" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Dados do PIS Substituição Tributária</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:choice>
+																<xs:sequence>
+																	<xs:element name="vBC" type="TDec_1302Opc">
+																		<xs:annotation>
+																			<xs:documentation>Valor da BC do PIS ST</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="pPIS" type="TDec_0302a04">
+																		<xs:annotation>
+																			<xs:documentation>Alíquota do PIS ST (em percentual)</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																</xs:sequence>
+																<xs:sequence>
+																	<xs:element name="qBCProd" type="TDec_1204">
+																		<xs:annotation>
+																			<xs:documentation>Quantidade Vendida</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vAliqProd" type="TDec_1104">
+																		<xs:annotation>
+																			<xs:documentation>Alíquota do PIS ST (em reais)</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																</xs:sequence>
+															</xs:choice>
+															<xs:element name="vPIS" type="TDec_1302">
+																<xs:annotation>
+																	<xs:documentation>Valor do PIS ST</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="indSomaPISST" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Indica se o valor do PISST compõe o valor total da NF-e</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:enumeration value="0"/>
+																		<xs:enumeration value="1"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="COFINS" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Dados do COFINS</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:choice>
+															<xs:element name="COFINSAliq">
+																<xs:annotation>
+																	<xs:documentation>Código de Situação Tributária do COFINS.
+ 01 – Operação Tributável - Base de Cálculo = Valor da Operação Alíquota Normal (Cumulativo/Não Cumulativo);
+02 - Operação Tributável - Base de Calculo = Valor da Operação (Alíquota Diferenciada);</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="CST">
+																			<xs:annotation>
+																				<xs:documentation>Código de Situação Tributária do COFINS.
+ 01 – Operação Tributável - Base de Cálculo = Valor da Operação Alíquota Normal (Cumulativo/Não Cumulativo);
+02 - Operação Tributável - Base de Calculo = Valor da Operação (Alíquota Diferenciada);</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:whiteSpace value="preserve"/>
+																					<xs:enumeration value="01"/>
+																					<xs:enumeration value="02"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																		<xs:element name="vBC" type="TDec_1302">
+																			<xs:annotation>
+																				<xs:documentation>Valor da BC do COFINS</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="pCOFINS" type="TDec_0302a04">
+																			<xs:annotation>
+																				<xs:documentation>Alíquota do COFINS (em percentual)</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="vCOFINS" type="TDec_1302">
+																			<xs:annotation>
+																				<xs:documentation>Valor do COFINS</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="COFINSQtde">
+																<xs:annotation>
+																	<xs:documentation>Código de Situação Tributária do COFINS.
+03 - Operação Tributável - Base de Calculo = Quantidade Vendida x Alíquota por Unidade de Produto;</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="CST">
+																			<xs:annotation>
+																				<xs:documentation>Código de Situação Tributária do COFINS.
+03 - Operação Tributável - Base de Calculo = Quantidade Vendida x Alíquota por Unidade de Produto;</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:enumeration value="03"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																		<xs:element name="qBCProd" type="TDec_1204v">
+																			<xs:annotation>
+																				<xs:documentation>Quantidade Vendida (NT2011/004)</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="vAliqProd" type="TDec_1104v">
+																			<xs:annotation>
+																				<xs:documentation>Alíquota do COFINS (em reais) (NT2011/004)</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="vCOFINS" type="TDec_1302">
+																			<xs:annotation>
+																				<xs:documentation>Valor do COFINS</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="COFINSNT">
+																<xs:annotation>
+																	<xs:documentation>Código de Situação Tributária do COFINS:
+04 - Operação Tributável - Tributação Monofásica - (Alíquota Zero);
+06 - Operação Tributável - Alíquota Zero;
+07 - Operação Isenta da contribuição;
+08 - Operação Sem Incidência da contribuição;
+09 - Operação com suspensão da contribuição;</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="CST">
+																			<xs:annotation>
+																				<xs:documentation>Código de Situação Tributária do COFINS:
+04 - Operação Tributável - Tributação Monofásica - (Alíquota Zero);
+05 - Operação Tributável (ST);
+06 - Operação Tributável - Alíquota Zero;
+07 - Operação Isenta da contribuição;
+08 - Operação Sem Incidência da contribuição;
+09 - Operação com suspensão da contribuição;</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:whiteSpace value="preserve"/>
+																					<xs:enumeration value="04"/>
+																					<xs:enumeration value="05"/>
+																					<xs:enumeration value="06"/>
+																					<xs:enumeration value="07"/>
+																					<xs:enumeration value="08"/>
+																					<xs:enumeration value="09"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="COFINSOutr">
+																<xs:annotation>
+																	<xs:documentation>Código de Situação Tributária do COFINS:
+49 - Outras Operações de Saída
+50 - Operação com Direito a Crédito - Vinculada Exclusivamente a Receita Tributada no Mercado Interno
+51 - Operação com Direito a Crédito – Vinculada Exclusivamente a Receita Não Tributada no Mercado Interno
+52 - Operação com Direito a Crédito - Vinculada Exclusivamente a Receita de Exportação
+53 - Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno
+54 - Operação com Direito a Crédito - Vinculada a Receitas Tributadas no Mercado Interno e de Exportação
+55 - Operação com Direito a Crédito - Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação
+56 - Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno, e de Exportação
+60 - Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Tributada no Mercado Interno
+61 - Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno
+62 - Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita de Exportação
+63 - Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno
+64 - Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas no Mercado Interno e de Exportação
+65 - Crédito Presumido - Operação de Aquisição Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação
+66 - Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno, e de Exportação
+67 - Crédito Presumido - Outras Operações
+70 - Operação de Aquisição sem Direito a Crédito
+71 - Operação de Aquisição com Isenção
+72 - Operação de Aquisição com Suspensão
+73 - Operação de Aquisição a Alíquota Zero
+74 - Operação de Aquisição sem Incidência da Contribuição
+75 - Operação de Aquisição por Substituição Tributária
+98 - Outras Operações de Entrada
+99 - Outras Operações.</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="CST">
+																			<xs:annotation>
+																				<xs:documentation>Código de Situação Tributária do COFINS:
+49 - Outras Operações de Saída
+50 - Operação com Direito a Crédito - Vinculada Exclusivamente a Receita Tributada no Mercado Interno
+51 - Operação com Direito a Crédito – Vinculada Exclusivamente a Receita Não Tributada no Mercado Interno
+52 - Operação com Direito a Crédito - Vinculada Exclusivamente a Receita de Exportação
+53 - Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno
+54 - Operação com Direito a Crédito - Vinculada a Receitas Tributadas no Mercado Interno e de Exportação
+55 - Operação com Direito a Crédito - Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação
+56 - Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno, e de Exportação
+60 - Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Tributada no Mercado Interno
+61 - Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno
+62 - Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita de Exportação
+63 - Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno
+64 - Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas no Mercado Interno e de Exportação
+65 - Crédito Presumido - Operação de Aquisição Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação
+66 - Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno, e de Exportação
+67 - Crédito Presumido - Outras Operações
+70 - Operação de Aquisição sem Direito a Crédito
+71 - Operação de Aquisição com Isenção
+72 - Operação de Aquisição com Suspensão
+73 - Operação de Aquisição a Alíquota Zero
+74 - Operação de Aquisição sem Incidência da Contribuição
+75 - Operação de Aquisição por Substituição Tributária
+98 - Outras Operações de Entrada
+99 - Outras Operações.</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:whiteSpace value="preserve"/>
+																					<xs:enumeration value="49"/>
+																					<xs:enumeration value="50"/>
+																					<xs:enumeration value="51"/>
+																					<xs:enumeration value="52"/>
+																					<xs:enumeration value="53"/>
+																					<xs:enumeration value="54"/>
+																					<xs:enumeration value="55"/>
+																					<xs:enumeration value="56"/>
+																					<xs:enumeration value="60"/>
+																					<xs:enumeration value="61"/>
+																					<xs:enumeration value="62"/>
+																					<xs:enumeration value="63"/>
+																					<xs:enumeration value="64"/>
+																					<xs:enumeration value="65"/>
+																					<xs:enumeration value="66"/>
+																					<xs:enumeration value="67"/>
+																					<xs:enumeration value="70"/>
+																					<xs:enumeration value="71"/>
+																					<xs:enumeration value="72"/>
+																					<xs:enumeration value="73"/>
+																					<xs:enumeration value="74"/>
+																					<xs:enumeration value="75"/>
+																					<xs:enumeration value="98"/>
+																					<xs:enumeration value="99"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																		<xs:choice>
+																			<xs:sequence>
+																				<xs:element name="vBC" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do COFINS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pCOFINS" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do COFINS (em percentual)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																			</xs:sequence>
+																			<xs:sequence>
+																				<xs:element name="qBCProd" type="TDec_1204v">
+																					<xs:annotation>
+																						<xs:documentation>Quantidade Vendida (NT2011/004)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vAliqProd" type="TDec_1104v">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do COFINS (em reais) (NT2011/004)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																			</xs:sequence>
+																		</xs:choice>
+																		<xs:element name="vCOFINS" type="TDec_1302">
+																			<xs:annotation>
+																				<xs:documentation>Valor do COFINS</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+														</xs:choice>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="COFINSST" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Dados do COFINS da
+Substituição Tributaria;</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:choice>
+																<xs:sequence>
+																	<xs:element name="vBC" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor da BC do COFINS ST</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="pCOFINS" type="TDec_0302a04">
+																		<xs:annotation>
+																			<xs:documentation>Alíquota do COFINS ST(em percentual)</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																</xs:sequence>
+																<xs:sequence>
+																	<xs:element name="qBCProd" type="TDec_1204">
+																		<xs:annotation>
+																			<xs:documentation>Quantidade Vendida</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vAliqProd" type="TDec_1104">
+																		<xs:annotation>
+																			<xs:documentation>Alíquota do COFINS ST(em reais)</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																</xs:sequence>
+															</xs:choice>
+															<xs:element name="vCOFINS" type="TDec_1302">
+																<xs:annotation>
+																	<xs:documentation>Valor do COFINS ST</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="indSomaCOFINSST" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Indica se o valor da COFINS ST compõe o valor total da NFe</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:enumeration value="0"/>
+																		<xs:enumeration value="1"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="ICMSUFDest" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Grupo a ser informado nas vendas interestarduais para consumidor final, não contribuinte de ICMS</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="vBCUFDest" type="TDec_1302">
+																<xs:annotation>
+																	<xs:documentation>Valor da Base de Cálculo do ICMS na UF do destinatário.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="vBCFCPUFDest" type="TDec_1302" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Valor da Base de Cálculo do FCP na UF do destinatário.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="pFCPUFDest" type="TDec_0302a04" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Percentual adicional inserido na alíquota interna da UF de destino, relativo ao Fundo de Combate à Pobreza (FCP) naquela UF.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="pICMSUFDest" type="TDec_0302a04">
+																<xs:annotation>
+																	<xs:documentation>Alíquota adotada nas operações internas na UF do destinatário para o produto / mercadoria.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="pICMSInter">
+																<xs:annotation>
+																	<xs:documentation>Alíquota interestadual das UF envolvidas: - 4% alíquota interestadual para produtos importados; - 7% para os Estados de origem do Sul e Sudeste (exceto ES), destinado para os Estados do Norte e Nordeste  ou ES; - 12% para os demais casos.</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:enumeration value="4.00"/>
+																		<xs:enumeration value="7.00"/>
+																		<xs:enumeration value="12.00"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="pICMSInterPart" type="TDec_0302a04">
+																<xs:annotation>
+																	<xs:documentation>Percentual de partilha para a UF do destinatário: - 40% em 2016; - 60% em 2017; - 80% em 2018; - 100% a partir de 2019.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="vFCPUFDest" type="TDec_1302" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP) da UF de destino.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="vICMSUFDest" type="TDec_1302">
+																<xs:annotation>
+																	<xs:documentation>Valor do ICMS de partilha para a UF do destinatário.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="vICMSUFRemet" type="TDec_1302">
+																<xs:annotation>
+																	<xs:documentation>Valor do ICMS de partilha para a UF do remetente. Nota: A partir de 2019, este valor será zero.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="IS" type="TIS" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Grupo de informações do Imposto Seletivo</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="IBSCBS" type="TTribNFe" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Grupo de informações dos tributos IBS, CBS e Imposto Seletivo</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="impostoDevol" minOccurs="0">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="pDevol" type="TDec_0302Max100">
+													<xs:annotation>
+														<xs:documentation>Percentual de mercadoria devolvida</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="IPI">
+													<xs:annotation>
+														<xs:documentation>Informação de IPI devolvido</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="vIPIDevol" type="TDec_1302">
+																<xs:annotation>
+																	<xs:documentation>Valor do IPI devolvido</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="infAdProd" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações adicionais do produto (norma referenciada, informações complementares, etc)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="500"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="obsItem" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Grupo de observações de uso livre (para o item da NF-e) </xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="obsCont" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Grupo de observações de uso livre (para o item da NF-e) </xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="xTexto">
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="60"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+														<xs:attribute name="xCampo" use="required">
+															<xs:simpleType>
+																<xs:restriction base="TString">
+																	<xs:minLength value="1"/>
+																	<xs:maxLength value="20"/>
+																</xs:restriction>
+															</xs:simpleType>
+														</xs:attribute>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="obsFisco" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Grupo de observações de uso livre (para o item da NF-e) </xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="xTexto">
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="60"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+														<xs:attribute name="xCampo" use="required">
+															<xs:simpleType>
+																<xs:restriction base="TString">
+																	<xs:minLength value="1"/>
+																	<xs:maxLength value="20"/>
+																</xs:restriction>
+															</xs:simpleType>
+														</xs:attribute>
+													</xs:complexType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="vItem" type="TDec_1302" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor total do Item, correspondente à sua participação no total da nota. A soma dos itens deverá corresponder ao total da nota.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="DFeReferenciado" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Referenciamento de item de outros DFe</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="chaveAcesso" type="TChNFe">
+													<xs:annotation>
+														<xs:documentation>Chave de Acesso do DFe referenciado</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="nItem" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Número do item do documento referenciado. Corresponde ao atributo nItem do elemento det do documento original.</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="[1-9]{1}[0-9]{0,1}|[1-8]{1}[0-9]{2}|[9]{1}[0-8]{1}[0-9]{1}|[9]{1}[9]{1}[0]{1}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+								<xs:attribute name="nItem" use="required">
+									<xs:annotation>
+										<xs:documentation>Número do item do NF</xs:documentation>
+									</xs:annotation>
+									<xs:simpleType>
+										<xs:restriction base="xs:string">
+											<xs:whiteSpace value="preserve"/>
+											<xs:pattern value="[1-9]{1}[0-9]{0,1}|[1-8]{1}[0-9]{2}|[9]{1}[0-8]{1}[0-9]{1}|[9]{1}[9]{1}[0]{1}"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="total">
+							<xs:annotation>
+								<xs:documentation>Dados dos totais da NF-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="ICMSTot">
+										<xs:annotation>
+											<xs:documentation>Totais referentes ao ICMS</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="vBC" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>BC do ICMS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMS" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do ICMS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSDeson" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do ICMS desonerado</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vFCPUFDest" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor total do ICMS relativo ao Fundo de Combate à Pobreza (FCP) para a UF de destino.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSUFDest" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor total do ICMS de partilha para a UF do destinatário</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSUFRemet" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor total do ICMS de partilha para a UF do remetente</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vFCP" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do FCP (Fundo de Combate à Pobreza).</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vBCST" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>BC do ICMS ST</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vST" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do ICMS ST</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vFCPST" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do FCP (Fundo de Combate à Pobreza) retido por substituição tributária.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vFCPSTRet" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do FCP (Fundo de Combate à Pobreza) retido anteriormente por substituição tributária.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="qBCMono" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor total da quantidade tributada do ICMS monofásico próprio</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSMono" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor total do ICMS monofásico próprio</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="qBCMonoReten" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor total da quantidade tributada do ICMS monofásico sujeito a retenção</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSMonoReten" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor total do ICMS monofásico sujeito a retenção</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="qBCMonoRet" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor total da quantidade tributada do ICMS monofásico retido anteriormente</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSMonoRet" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS monofásico retido anteriormente</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vProd" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total dos produtos e serviços</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vFrete" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do Frete</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vSeg" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do Seguro</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vDesc" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do Desconto</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vII" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do II</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vIPI" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do IPI</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vIPIDevol" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do IPI devolvido. Deve ser informado quando preenchido o Grupo Tributos Devolvidos na emissão de nota finNFe=4 (devolução) nas operações com não contribuintes do IPI. Corresponde ao total da soma dos campos id: UA04.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vPIS" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do PIS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vCOFINS" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do COFINS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vOutro" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Outras Despesas acessórias</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vNF" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total da NF-e</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vTotTrib" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor estimado total de impostos federais, estaduais e municipais</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="ISSQNtot" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Totais referentes ao ISSQN</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="vServ" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor Total dos Serviços sob não-incidência ou não tributados pelo ICMS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vBC" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Base de Cálculo do ISS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vISS" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor Total do ISS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vPIS" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor do PIS sobre serviços</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vCOFINS" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor do COFINS sobre serviços</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="dCompet" type="TData">
+													<xs:annotation>
+														<xs:documentation>Data da prestação do serviço  (AAAA-MM-DD)</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vDeducao" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor dedução para redução da base de cálculo</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vOutro" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor outras retenções</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vDescIncond" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor desconto incondicionado</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vDescCond" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor desconto condicionado</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vISSRet" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor Total Retenção ISS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="cRegTrib" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Código do regime especial de tributação</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:enumeration value="1"/>
+															<xs:enumeration value="2"/>
+															<xs:enumeration value="3"/>
+															<xs:enumeration value="4"/>
+															<xs:enumeration value="5"/>
+															<xs:enumeration value="6"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="retTrib" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Retenção de Tributos Federais</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="vRetPIS" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor Retido de PIS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vRetCOFINS" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor Retido de COFINS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vRetCSLL" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor Retido de CSLL</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vBCIRRF" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Base de Cálculo do IRRF</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vIRRF" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor Retido de IRRF</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vBCRetPrev" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Base de Cálculo da Retenção da Previdêncica Social</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vRetPrev" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor da Retenção da Previdêncica Social</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="ISTot" type="TISTot" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valores totais da NF com Imposto Seletivo</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="IBSCBSTot" type="TIBSCBSMonoTot" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valores totais da NF com IBS / CBS</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vNFTot" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor Total da NF considerando os impostos por fora IBS, CBS e IS</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="transp">
+							<xs:annotation>
+								<xs:documentation>Dados dos transportes da NF-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="modFrete">
+										<xs:annotation>
+											<xs:documentation>Modalidade do frete
+0- Contratação do Frete por conta do Remetente (CIF);
+1- Contratação do Frete por conta do destinatário/remetente (FOB);
+2- Contratação do Frete por conta de terceiros;
+3- Transporte próprio por conta do remetente;
+4- Transporte próprio por conta do destinatário;
+9- Sem Ocorrência de transporte.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="3"/>
+												<xs:enumeration value="4"/>
+												<xs:enumeration value="9"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="transporta" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Dados do transportador</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:choice minOccurs="0">
+													<xs:element name="CNPJ" type="TCnpj">
+														<xs:annotation>
+															<xs:documentation>CNPJ do transportador</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="CPF" type="TCpf">
+														<xs:annotation>
+															<xs:documentation>CPF do transportador</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:choice>
+												<xs:element name="xNome" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Razão Social ou nome do transportador</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="60"/>
+															<xs:minLength value="2"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="IE" type="TIeDest" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Inscrição Estadual (v2.0)</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="xEnder" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Endereço completo</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="xMun" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Nome do munícipio</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="60"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="UF" type="TUf" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Sigla da UF</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="retTransp" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Dados da retenção  ICMS do Transporte</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="vServ" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do Serviço</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vBCRet" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>BC da Retenção do ICMS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pICMSRet" type="TDec_0302a04">
+													<xs:annotation>
+														<xs:documentation>Alíquota da Retenção</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSRet" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS Retido</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="CFOP">
+													<xs:annotation>
+														<xs:documentation>Código Fiscal de Operações e Prestações</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="[1,2,3,5,6,7]{1}[0-9]{3}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="cMunFG" type="TCodMunIBGE">
+													<xs:annotation>
+														<xs:documentation>Código do Município de Ocorrência do Fato Gerador (utilizar a tabela do IBGE)</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:choice>
+										<xs:sequence minOccurs="0">
+											<xs:element name="veicTransp" type="TVeiculo" minOccurs="0">
+												<xs:annotation>
+													<xs:documentation>Dados do veículo</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+											<xs:element name="reboque" type="TVeiculo" minOccurs="0" maxOccurs="5">
+												<xs:annotation>
+													<xs:documentation>Dados do reboque/Dolly (v2.0)</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+										</xs:sequence>
+										<xs:element name="vagao" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Identificação do vagão (v2.0)</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="1"/>
+													<xs:maxLength value="20"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="balsa" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Identificação da balsa (v2.0)</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="1"/>
+													<xs:maxLength value="20"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="vol" minOccurs="0" maxOccurs="5000">
+										<xs:annotation>
+											<xs:documentation>Dados dos volumes</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="qVol" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Quantidade de volumes transportados</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="[0-9]{1,15}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="esp" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Espécie dos volumes transportados</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="marca" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Marca dos volumes transportados</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="nVol" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Numeração dos volumes transportados</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="pesoL" type="TDec_1203" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Peso líquido (em kg)</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pesoB" type="TDec_1203" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Peso bruto (em kg)</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="lacres" minOccurs="0" maxOccurs="5000">
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="nLacre">
+																<xs:annotation>
+																	<xs:documentation>Número dos Lacres</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="60"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="cobr" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Dados da cobrança da NF-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="fat" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Dados da fatura</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="nFat" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Número da fatura</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="vOrig" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor original da fatura</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vDesc" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor do desconto da fatura</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vLiq" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor líquido da fatura</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="dup" minOccurs="0" maxOccurs="120">
+										<xs:annotation>
+											<xs:documentation>Dados das duplicatas NT 2011/004</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="nDup" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Número da duplicata</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="60"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="dVenc" type="TData" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Data de vencimento da duplicata (AAAA-MM-DD)</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vDup" type="TDec_1302Opc">
+													<xs:annotation>
+														<xs:documentation>Valor da duplicata</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="pag">
+							<xs:annotation>
+								<xs:documentation>Dados de Pagamento. Obrigatório apenas para (NFC-e) NT 2012/004</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="detPag" maxOccurs="100">
+										<xs:annotation>
+											<xs:documentation>Grupo de detalhamento da forma de pagamento.</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="indPag" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Indicador da Forma de Pagamento:0-Pagamento à Vista;1-Pagamento à Prazo;</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:enumeration value="0"/>
+															<xs:enumeration value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="tPag">
+													<xs:annotation>
+														<xs:documentation>Forma de Pagamento:</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="[0-9]{2}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="xPag" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Descrição do Meio de Pagamento</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="2"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="vPag" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do Pagamento. Esta tag poderá ser omitida quando a tag tPag=90 (Sem Pagamento), caso contrário deverá ser preenchida.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="dPag" type="TData" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Data do Pagamento</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:sequence minOccurs="0">
+													<xs:element name="CNPJPag" type="TCnpj">
+														<xs:annotation>
+															<xs:documentation>CNPJ transacional do pagamento - Preencher informando o CNPJ do estabelecimento onde o pagamento foi processado/transacionado/recebido quando a emissão do documento fiscal ocorrer em estabelecimento distinto</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="UFPag" type="TUfEmi">
+														<xs:annotation>
+															<xs:documentation>UF do CNPJ do estabelecimento onde o pagamento foi processado/transacionado/recebido.</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+												<xs:element name="card" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Grupo de Cartões, PIX, Boletos e outros Pagamentos Eletrônicos</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="tpIntegra">
+																<xs:annotation>
+																	<xs:documentation>Tipo de Integração do processo de pagamento com o sistema de automação da empresa:
+1 - Pagamento integrado com o sistema de automação da empresa (Ex.: equipamento TEF, Comércio Eletrônico, POS Integrado);
+2 - Pagamento não integrado com o sistema de automação da empresa (Ex.: equipamento POS Simples).</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:enumeration value="1"/>
+																		<xs:enumeration value="2"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="CNPJ" type="TCnpj" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>CNPJ da instituição de pagamento</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="tBand" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Bandeira da operadora de cartão</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:pattern value="[0-9]{2}"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="cAut" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Número de autorização da operação com cartões, PIX, boletos e outros pagamentos eletrônicos</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="128"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="CNPJReceb" type="TCnpj" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>CNPJ do beneficiário do pagamento</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="idTermPag" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Identificador do terminal de pagamento</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="40"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="vTroco" type="TDec_1302" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor do Troco.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infIntermed" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de Informações do Intermediador da Transação</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="CNPJ" type="TCnpj">
+										<xs:annotation>
+											<xs:documentation>CNPJ do Intermediador da Transação (agenciador, plataforma de delivery, marketplace e similar) de serviços e de negócios.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="idCadIntTran">
+										<xs:annotation>
+											<xs:documentation>Identificador cadastrado no intermediador</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infAdic" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações adicionais da NF-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="infAdFisco" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações adicionais de interesse do Fisco (v2.0)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="2000"/>
+												<xs:minLength value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="infCpl" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações complementares de interesse do Contribuinte</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="5000"/>
+												<xs:minLength value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="obsCont" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Campo de uso livre do contribuinte
+informar o nome do campo no atributo xCampo
+e o conteúdo do campo no xTexto</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xTexto">
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="xCampo" use="required">
+												<xs:simpleType>
+													<xs:restriction base="TString">
+														<xs:minLength value="1"/>
+														<xs:maxLength value="20"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="obsFisco" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Campo de uso exclusivo do Fisco
+informar o nome do campo no atributo xCampo
+e o conteúdo do campo no xTexto</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xTexto">
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="xCampo" use="required">
+												<xs:simpleType>
+													<xs:restriction base="TString">
+														<xs:minLength value="1"/>
+														<xs:maxLength value="20"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="procRef" minOccurs="0" maxOccurs="100">
+										<xs:annotation>
+											<xs:documentation>Grupo de informações do  processo referenciado</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="nProc">
+													<xs:annotation>
+														<xs:documentation>Indentificador do processo ou ato
+concessório</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="indProc">
+													<xs:annotation>
+														<xs:documentation>Origem do processo, informar com:
+0 - SEFAZ;
+1 - Justiça Federal;
+2 - Justiça Estadual;
+3 - Secex/RFB;
+4 - CONFAZ;
+9 - Outros.</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:enumeration value="0"/>
+															<xs:enumeration value="1"/>
+															<xs:enumeration value="2"/>
+															<xs:enumeration value="3"/>
+															<xs:enumeration value="4"/>
+															<xs:enumeration value="9"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="tpAto" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Tipo do ato concessório
+														Para origem do Processo na SEFAZ (indProc=0), informar o
+tipo de ato concessório:
+08 - Termo de Acordo;
+10 - Regime Especial;
+12 - Autorização específica;
+14 - Ajuste SINIEF;
+15 - Convênio ICMS.</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:enumeration value="08"/>
+															<xs:enumeration value="10"/>
+															<xs:enumeration value="12"/>
+															<xs:enumeration value="14"/>
+															<xs:enumeration value="15"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="exporta" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações de exportação</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="UFSaidaPais" type="TUfEmi">
+										<xs:annotation>
+											<xs:documentation>Sigla da UF de Embarque ou de transposição de fronteira</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="xLocExporta">
+										<xs:annotation>
+											<xs:documentation>Local de Embarque ou de transposição de fronteira</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xLocDespacho" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Descrição do local de despacho</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="compra" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações de compras  (Nota de Empenho, Pedido e Contrato)</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="xNEmp" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informação da Nota de Empenho de compras públicas (NT2011/004)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="22"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xPed" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informação do pedido</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xCont" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informação do contrato</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="cana" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações de registro aquisições de cana</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="safra">
+										<xs:annotation>
+											<xs:documentation>Identificação da safra</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="4"/>
+												<xs:maxLength value="9"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="ref">
+										<xs:annotation>
+											<xs:documentation>Mês e Ano de Referência, formato: MM/AAAA</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="(0[1-9]|1[0-2])([/][2][0-9][0-9][0-9])"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="forDia" maxOccurs="31">
+										<xs:annotation>
+											<xs:documentation>Fornecimentos diários</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="qtde" type="TDec_1110v">
+													<xs:annotation>
+														<xs:documentation>Quantidade em quilogramas - peso líquido</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="dia" use="required">
+												<xs:annotation>
+													<xs:documentation>Número do dia</xs:documentation>
+												</xs:annotation>
+												<xs:simpleType>
+													<xs:restriction base="xs:string">
+														<xs:whiteSpace value="preserve"/>
+														<xs:pattern value="[1-9]|[1][0-9]|[2][0-9]|[3][0-1]"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+										<xs:unique name="pk_Dia">
+											<xs:selector xpath="./*"/>
+											<xs:field xpath="@dia"/>
+										</xs:unique>
+									</xs:element>
+									<xs:element name="qTotMes" type="TDec_1110v">
+										<xs:annotation>
+											<xs:documentation>Total do mês</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="qTotAnt" type="TDec_1110v">
+										<xs:annotation>
+											<xs:documentation>Total Anterior</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="qTotGer" type="TDec_1110v">
+										<xs:annotation>
+											<xs:documentation>Total Geral</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="deduc" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Deduções - Taxas e Contribuições</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xDed">
+													<xs:annotation>
+														<xs:documentation>Descrição da Dedução</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="vDed" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>valor da dedução</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="vFor" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor  dos fornecimentos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vTotDed" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor Total das Deduções</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vLiqFor" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor Líquido dos fornecimentos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infRespTec" type="TInfRespTec" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do Responsável Técnico pela emissão do DF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="infSolicNFF" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo para informações da solicitação da NFF</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="xSolic">
+										<xs:annotation>
+											<xs:documentation>Solicitação do pedido de emissão da NFF</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="5000"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="agropecuario" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Produtos Agropecurários Animais, Vegetais e Florestais</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:choice>
+									<xs:element name="defensivo" maxOccurs="20">
+										<xs:annotation>
+											<xs:documentation>Defensivo Agrícola / Agrotóxico</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="nReceituario">
+													<xs:annotation>
+														<xs:documentation>Número do Receituário ou Receita do Defensivo / Agrotóxico</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="30"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="CPFRespTec" type="TCpf">
+													<xs:annotation>
+														<xs:documentation>CPF do Responsável Técnico pelo receituário</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="guiaTransito">
+										<xs:annotation>
+											<xs:documentation>Guias De Trânsito de produtos agropecurários animais, vegetais e de origem florestal.</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="tpGuia">
+													<xs:annotation>
+														<xs:documentation>Tipo da Guia: 1 - GTA; 2 - TTA; 3 - DTA; 4 - ATV; 5 - PTV; 6 - GTV; 7 - Guia Florestal (DOF, SisFlora - PA e MT, SIAM - MG)</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:enumeration value="1"/>
+															<xs:enumeration value="2"/>
+															<xs:enumeration value="3"/>
+															<xs:enumeration value="4"/>
+															<xs:enumeration value="5"/>
+															<xs:enumeration value="6"/>
+															<xs:enumeration value="7"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="UFGuia" type="TUfEmi"/>
+												<xs:element name="serieGuia" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Série da Guia</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="9"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="nGuia">
+													<xs:annotation>
+														<xs:documentation>Número da Guia</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:pattern value="[0-9]{1,9}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:choice>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="versao" type="TVerNFe" use="required">
+						<xs:annotation>
+							<xs:documentation>Versão do leiaute (v4.00)</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="Id" use="required">
+						<xs:annotation>
+							<xs:documentation>PL_005d - 11/08/09 - validação do Id</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:ID">
+								<xs:pattern value="NFe[0-9]{44}"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+				<xs:unique name="pk_nItem">
+					<xs:selector xpath="./*"/>
+					<xs:field xpath="@nItem"/>
+				</xs:unique>
+			</xs:element>
+			<xs:element name="infNFeSupl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informações suplementares Nota Fiscal</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="qrCode">
+							<xs:annotation>
+								<xs:documentation>Texto com o QR-Code impresso no DANFE NFC-e</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:minLength value="60"/>
+									<xs:maxLength value="1000"/>
+									<!--QRCODE V1-->
+									<xs:pattern value="((HTTPS?|https?)://.*\?chNFe=[0-9]{44}&amp;nVersao=100&amp;tpAmb=[1-2](&amp;cDest=([A-Za-z0-9.:+-/)(]{0}|[A-Za-z0-9.:+-/)(]{5,20})?)?&amp;dhEmi=[A-Fa-f0-9]{50}&amp;vNF=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;vICMS=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;digVal=[A-Fa-f0-9]{56}&amp;cIdToken=[0-9]{6}&amp;cHashQRCode=[A-Fa-f0-9]{40})"/>
+									<!--QRCODE V2 ONLINE-->
+									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{34}(1|3|4)[0-9]{9})\|[2]\|[1-2]\|(0|[1-9]{1}([0-9]{1,5})?)\|[A-Fa-f0-9]{40})"/>
+									<!--QRCODE V2 OFFLINE-->
+									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{34}9[0-9]{9})\|[2]\|[1-2]\|([0]{1}[1-9]{1}|[1-2]{1}[0-9]{1}|[3]{1}[0-1]{1})\|(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)\|[A-Fa-f0-9]{56}\|(0|[1-9]{1}([0-9]{1,5})?)\|[A-Fa-f0-9]{40})"/>
+									<!--QRCODE V3 ONLINE-->
+									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{34}(1|3|4)[0-9]{9})\|[3]\|[1-2])"/>
+									<!--QRCODE V3 OFFLINE-->
+									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{34}(9)[0-9]{9})\|[3]\|[1-2]\|([0]{1}[1-9]{1}|[1-2]{1}[0-9]{1}|[3]{1}[0-1]{1})\|(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)\|((1|2|3)?)\|(([0-9]{3,14})?)\|([a-zA-Z0-9+/]+[=]{0,2}))"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="urlChave">
+							<xs:annotation>
+								<xs:documentation>Informar a URL da &quot;Consulta por chave de acesso da NFC-e&quot;. A mesma URL que deve estar informada no DANFE NFC-e para consulta por chave de acesso.</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TString">
+									<xs:minLength value="21"/>
+									<xs:maxLength value="85"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TProtNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Protocolo de status resultado do processamento da NF-e</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infProt">
+				<xs:annotation>
+					<xs:documentation>Dados do protocolo de status</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="verAplic" type="TVerAplic">
+							<xs:annotation>
+								<xs:documentation>Versão do Aplicativo que processou a NF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="chNFe" type="TChNFe">
+							<xs:annotation>
+								<xs:documentation>Chaves de acesso da NF-e, compostas por: UF do emitente, AAMM da emissão da NFe, CNPJ do emitente, modelo, série e número da NF-e e código numérico+DV.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="dhRecbto" type="TDateTimeUTC">
+							<xs:annotation>
+								<xs:documentation>Data e hora de processamento, no formato AAAA-MM-DDTHH:MM:SSTZD. Deve ser preenchida com data e hora da gravação no Banco em caso de Confirmação. Em caso de Rejeição, com data e hora do recebimento do Lote de NF-e enviado.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nProt" type="TProt" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número do Protocolo de Status da NF-e. 1 posição (1 – Secretaria de Fazenda Estadual 2 – Receita Federal); 2 - códiga da UF - 2 posições ano; 10 seqüencial no ano.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="digVal" type="ds:DigestValueType" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Digest Value da NF-e processada. Utilizado para conferir a integridade da NF-e original.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cStat" type="TStat">
+							<xs:annotation>
+								<xs:documentation>Código do status da mensagem enviada.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="xMotivo" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Descrição literal do status do serviço solicitado.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:sequence minOccurs="0">
+							<xs:element name="cMsg">
+								<xs:annotation>
+									<xs:documentation>Código da Mensagem.</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:pattern value="[0-9]{1,4}"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="xMsg">
+								<xs:annotation>
+									<xs:documentation>Mensagem da SEFAZ para o emissor.</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="200"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:sequence>
+					<xs:attribute name="Id" type="xs:ID" use="optional"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TEnviNFe">
+		<xs:annotation>
+			<xs:documentation> Tipo Pedido de Concessão de Autorização da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="idLote" type="TIdLote"/>
+			<xs:element name="indSinc">
+				<xs:annotation>
+					<xs:documentation>Indicador de processamento síncrono. 0=NÃO; 1=SIM=Síncrono</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:enumeration value="0"/>
+						<xs:enumeration value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="NFe" type="TNFe" maxOccurs="50"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetEnviNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Retorno do Pedido de Autorização da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="verAplic" type="TVerAplic">
+				<xs:annotation>
+					<xs:documentation>Versão do Aplicativo que recebeu o Lote.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cStat" type="TStat">
+				<xs:annotation>
+					<xs:documentation>Código do status da mensagem enviada.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMotivo" type="TMotivo">
+				<xs:annotation>
+					<xs:documentation>Descrição literal do status do serviço solicitado.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>código da UF de atendimento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="dhRecbto" type="TDateTimeUTC">
+				<xs:annotation>
+					<xs:documentation>Data e hora do recebimento, no formato AAAA-MM-DDTHH:MM:SSTZD</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice>
+				<xs:element name="infRec" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Dados do Recibo do Lote</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="nRec" type="TRec">
+								<xs:annotation>
+									<xs:documentation>Número do Recibo</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="tMed" type="TMed">
+								<xs:annotation>
+									<xs:documentation>Tempo médio de resposta do serviço (em segundos) dos últimos 5 minutos</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="protNFe" type="TProtNFe" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Protocolo de status resultado do processamento sincrono da NFC-e</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TConsReciNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Pedido de Consulta do Recido do Lote de Notas Fiscais Eletrônicas</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="nRec" type="TRec">
+				<xs:annotation>
+					<xs:documentation>Número do Recibo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetConsReciNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Retorno do Pedido de  Consulta do Recido do Lote de Notas Fiscais Eletrônicas</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="verAplic" type="TVerAplic">
+				<xs:annotation>
+					<xs:documentation>Versão do Aplicativo que processou a NF-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="nRec" type="TRec">
+				<xs:annotation>
+					<xs:documentation>Número do Recibo Consultado</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cStat" type="TStat">
+				<xs:annotation>
+					<xs:documentation>Código do status da mensagem enviada.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMotivo" type="TMotivo">
+				<xs:annotation>
+					<xs:documentation>Descrição literal do status do serviço solicitado.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>código da UF de atendimento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="dhRecbto" type="TDateTimeUTC">
+				<xs:annotation>
+					<xs:documentation>Data e hora de processamento, no formato AAAA-MM-DDTHH:MM:SSTZD. Em caso de Rejeição, com data e hora do recebimento do Lote de NF-e enviado.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:sequence minOccurs="0">
+				<xs:element name="cMsg">
+					<xs:annotation>
+						<xs:documentation>Código da Mensagem (v2.0) 
+alterado para tamanho variavel 1-4. (NT2011/004)</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:pattern value="[0-9]{1,4}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="xMsg">
+					<xs:annotation>
+						<xs:documentation>Mensagem da SEFAZ para o emissor. (v2.0)</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TString">
+							<xs:minLength value="1"/>
+							<xs:maxLength value="200"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+			<xs:element name="protNFe" type="TProtNFe" minOccurs="0" maxOccurs="50">
+				<xs:annotation>
+					<xs:documentation>Protocolo de status resultado do processamento da NF-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TNfeProc">
+		<xs:annotation>
+			<xs:documentation> Tipo da NF-e processada</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="NFe" type="TNFe"/>
+			<xs:element name="protNFe" type="TProtNFe"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TEndereco">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Endereço  // 24/10/08 - tamanho mínimo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="xLgr">
+				<xs:annotation>
+					<xs:documentation>Logradouro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="nro">
+				<xs:annotation>
+					<xs:documentation>Número</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xCpl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Complemento</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xBairro">
+				<xs:annotation>
+					<xs:documentation>Bairro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cMun" type="TCodMunIBGE">
+				<xs:annotation>
+					<xs:documentation>Código do município (utilizar a tabela do IBGE), informar 9999999 para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMun">
+				<xs:annotation>
+					<xs:documentation>Nome do município, informar EXTERIOR para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUf">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF, informar EX para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CEP" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>CEP</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{8}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cPais" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Código de Pais</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{1,4}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xPais" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Nome do país</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="fone" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Telefone, preencher com Código DDD + número do telefone , nas operações com exterior é permtido informar o código do país + código da localidade + número do telefone</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{6,14}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TEnderEmi">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Endereço do Emitente  // 24/10/08 - desmembrado / tamanho mínimo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="xLgr">
+				<xs:annotation>
+					<xs:documentation>Logradouro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="nro">
+				<xs:annotation>
+					<xs:documentation>Número</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xCpl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Complemento</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xBairro">
+				<xs:annotation>
+					<xs:documentation>Bairro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cMun" type="TCodMunIBGE">
+				<xs:annotation>
+					<xs:documentation>Código do município</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMun">
+				<xs:annotation>
+					<xs:documentation>Nome do município</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUfEmi">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CEP">
+				<xs:annotation>
+					<xs:documentation>CEP - NT 2011/004</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{8}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cPais" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Código do país</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:enumeration value="1058"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xPais" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Nome do país</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:enumeration value="Brasil"/>
+						<xs:enumeration value="BRASIL"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="fone" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Preencher com Código DDD + número do telefone (v.2.0)</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{6,14}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TLocal">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Local de Retirada ou Entrega // 24/10/08 - tamanho mínimo // v2.0</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="CNPJ" type="TCnpjOpc">
+					<xs:annotation>
+						<xs:documentation>CNPJ</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="CPF" type="TCpf">
+					<xs:annotation>
+						<xs:documentation>CPF (v2.0)</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+			<xs:element name="xNome" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Razão Social ou Nome do Expedidor/Recebedor</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xLgr">
+				<xs:annotation>
+					<xs:documentation>Logradouro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="nro">
+				<xs:annotation>
+					<xs:documentation>Número</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xCpl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Complemento</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xBairro">
+				<xs:annotation>
+					<xs:documentation>Bairro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cMun" type="TCodMunIBGE">
+				<xs:annotation>
+					<xs:documentation>Código do município (utilizar a tabela do IBGE)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMun">
+				<xs:annotation>
+					<xs:documentation>Nome do município</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUf">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CEP" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>CEP</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{8}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cPais" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Código de Pais</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{1,4}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xPais" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Nome do país</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="fone" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Telefone, preencher com Código DDD + número do telefone , nas operações com exterior é permtido informar o código do país + código da localidade + número do telefone</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{6,14}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="email" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informar o e-mail do expedidor/Recebedor. O campo pode ser utilizado para informar o e-mail de recepção da NF-e indicada pelo expedidor</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:whiteSpace value="preserve"/>
+						<xs:minLength value="1"/>
+						<xs:maxLength value="60"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="IE" type="TIe" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Inscrição Estadual (v2.0)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TInfRespTec">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações do responsável técnico pelo sistema de emissão de DF-e</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CNPJ" type="TCnpjOpc">
+				<xs:annotation>
+					<xs:documentation>CNPJ</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xContato">
+				<xs:annotation>
+					<xs:documentation>Informar o nome da pessoa a ser contatada na empresa desenvolvedora do sistema utilizado na emissão do documento fiscal eletrônico.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="email">
+				<xs:annotation>
+					<xs:documentation>Informar o e-mail da pessoa a ser contatada na empresa desenvolvedora do sistema.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:whiteSpace value="preserve"/>
+						<xs:minLength value="6"/>
+						<xs:maxLength value="60"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="fone">
+				<xs:annotation>
+					<xs:documentation>Informar o telefone da pessoa a ser contatada na empresa desenvolvedora do sistema. Preencher com o Código DDD + número do telefone.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{6,14}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:sequence minOccurs="0">
+				<xs:element name="idCSRT">
+					<xs:annotation>
+						<xs:documentation>Identificador do CSRT utilizado para montar o hash do CSRT</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:pattern value="[0-9]{2}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="hashCSRT">
+					<xs:annotation>
+						<xs:documentation>O hashCSRT é o resultado da função hash (SHA-1 – Base64) do CSRT fornecido pelo fisco mais a Chave de Acesso da NFe.</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:base64Binary">
+							<xs:length value="20"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TVeiculo">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Veículo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="placa">
+				<xs:annotation>
+					<xs:documentation>Placa do veículo (NT2011/004)</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[A-Z]{2,3}[0-9]{4}|[A-Z]{3,4}[0-9]{3}|[A-Z0-9]{7}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUf" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="RNTC" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Registro Nacional de Transportador de Carga (ANTT)</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:minLength value="1"/>
+						<xs:maxLength value="20"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="Torig">
+		<xs:annotation>
+			<xs:documentation>Tipo Origem da mercadoria CST ICMS  origem da mercadoria: 0-Nacional exceto as indicadas nos códigos 3, 4, 5 e 8;1-Estrangeira - Importação direta; 2-Estrangeira - Adquirida no mercado interno; 3-Nacional, conteudo superior 40% e inferior ou igual a 70%; 4-Nacional, processos produtivos básicos; 5-Nacional, conteudo inferior 40%; 6-Estrangeira - Importação direta, com similar nacional, lista CAMEX; 7-Estrangeira - mercado interno, sem simular,lista CAMEX;8-Nacional, Conteúdo de Importação superior a 70%.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="0"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+			<xs:enumeration value="3"/>
+			<xs:enumeration value="4"/>
+			<xs:enumeration value="5"/>
+			<xs:enumeration value="6"/>
+			<xs:enumeration value="7"/>
+			<xs:enumeration value="8"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TFinNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Finalidade da NF-e (1=Normal; 2=Complementar; 3=Ajuste; 4=Devolução/Retorno)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+			<xs:enumeration value="3"/>
+			<xs:enumeration value="4"/>
+			<xs:enumeration value="5"/>
+			<xs:enumeration value="6"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TTpNFDebito">
+		<xs:annotation>
+			<xs:documentation>Tipo de Nota de Débito: 01=Transferência de créditos para Cooperativas; 02=Anulação de Crédito por Saídas Imunes/Isentas; 03=Débitos de notas fiscais não processadas na apuração; 04=Multa e juros; 05=Transferência de crédito de sucessão); 06=Pagamento antecipado; 07=Perda em estoque</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="01"/>
+			<xs:enumeration value="02"/>
+			<xs:enumeration value="03"/>
+			<xs:enumeration value="04"/>
+			<xs:enumeration value="05"/>
+			<xs:enumeration value="06"/>
+			<xs:enumeration value="07"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TTpNFCredito">
+		<xs:annotation>
+			<xs:documentation>Tipo de Nota de Crédito: 01=Multa e juros; 02=Apropriação de crédito presumido de IBS sobre o saldo devedor na ZFM (art. 450, § 1º, LC 214/25)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="01"/>
+			<xs:enumeration value="02"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TProcEmi">
+		<xs:annotation>
+			<xs:documentation>Tipo processo de emissão da NF-e</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="0"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+			<xs:enumeration value="3"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCListServ">
+		<xs:annotation>
+			<xs:documentation>Tipo Código da Lista de Serviços LC 116/2003</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{2}.[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TIdLote">
+		<xs:annotation>
+			<xs:documentation> Tipo Identificação de Lote</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{1,15}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TVerNFe">
+		<xs:annotation>
+			<xs:documentation> Tipo Versão da NF-e - 4.00</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="4\.00"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TGuid">
+		<xs:annotation>
+			<xs:documentation>Identificador único (Globally Unique Identifier)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="TIpi">
+		<xs:annotation>
+			<xs:documentation>Tipo: Dados do IPI</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CNPJProd" type="TCnpj" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>CNPJ do produtor da mercadoria, quando diferente do emitente. Somente para os casos de exportação direta ou indireta.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cSelo" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Código do selo de controle do IPI</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:minLength value="1"/>
+						<xs:maxLength value="60"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="qSelo" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Quantidade de selo de controle do IPI</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{1,12}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cEnq">
+				<xs:annotation>
+					<xs:documentation>Código de Enquadramento Legal do IPI (tabela a ser criada pela RFB)</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:minLength value="1"/>
+						<xs:maxLength value="3"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:choice>
+				<xs:element name="IPITrib">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="CST">
+								<xs:annotation>
+									<xs:documentation>Código da Situação Tributária do IPI:
+00-Entrada com recuperação de crédito
+49 - Outras entradas
+50-Saída tributada
+99-Outras saídas</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:enumeration value="00"/>
+										<xs:enumeration value="49"/>
+										<xs:enumeration value="50"/>
+										<xs:enumeration value="99"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:choice>
+								<xs:sequence>
+									<xs:element name="vBC" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor da BC do IPI</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="pIPI" type="TDec_0302a04">
+										<xs:annotation>
+											<xs:documentation>Alíquota do IPI</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+								<xs:sequence>
+									<xs:element name="qUnid" type="TDec_1204v">
+										<xs:annotation>
+											<xs:documentation>Quantidade total na unidade padrão para tributação</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vUnid" type="TDec_1104">
+										<xs:annotation>
+											<xs:documentation>Valor por Unidade Tributável. Informar o valor do imposto Pauta por unidade de medida.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:choice>
+							<xs:element name="vIPI" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do IPI</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="IPINT">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="CST">
+								<xs:annotation>
+									<xs:documentation>Código da Situação Tributária do IPI:
+01-Entrada tributada com alíquota zero
+02-Entrada isenta
+03-Entrada não-tributada
+04-Entrada imune
+05-Entrada com suspensão
+51-Saída tributada com alíquota zero
+52-Saída isenta
+53-Saída não-tributada
+54-Saída imune
+55-Saída com suspensão</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:enumeration value="01"/>
+										<xs:enumeration value="02"/>
+										<xs:enumeration value="03"/>
+										<xs:enumeration value="04"/>
+										<xs:enumeration value="05"/>
+										<xs:enumeration value="51"/>
+										<xs:enumeration value="52"/>
+										<xs:enumeration value="53"/>
+										<xs:enumeration value="54"/>
+										<xs:enumeration value="55"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/nfe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/nfe_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas-softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteNFe_v4.00.xsd"/>
+	<xs:element name="NFe" type="TNFe">
+		<xs:annotation>
+			<xs:documentation>Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/procInutNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/procInutNFe_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteInutNFe_v4.00.xsd"/>
+	<xs:element name="ProcInutNFe" type="TProcInutNFe">
+		<xs:annotation>
+			<xs:documentation>Pedido de inutilização de númeração de  NF-e processado</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/procNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/procNFe_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteNFe_v4.00.xsd"/>
+	<xs:element name="nfeProc" type="TNfeProc">
+		<xs:annotation>
+			<xs:documentation>NF-e processada</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/retConsReciNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/retConsReciNFe_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteNFe_v4.00.xsd"/>
+	<xs:element name="retConsReciNFe" type="TRetConsReciNFe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do retorno do Pedido de  Consulta do Recido do Lote de Notas Fiscais Eletrônicas</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/retConsSitNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/retConsSitNFe_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteConsSitNFe_v4.00.xsd"/>
+	<xs:element name="retConsSitNFe" type="TRetConsSitNFe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do retorno da consulta da situação atual da NF-e</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/retConsStatServ_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/retConsStatServ_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteConsStatServ_v4.00.xsd"/>
+	<xs:element name="retConsStatServ" type="TRetConsStatServ">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do Resultado da Consulta do Status do Serviço</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/retEnviNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/retEnviNFe_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteNFe_v4.00.xsd"/>
+	<xs:element name="retEnviNFe" type="TRetEnviNFe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do retorno do Pedido de Concessão de Autorização da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/retInutNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/retInutNFe_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteInutNFe_v4.00.xsd"/>
+	<xs:element name="retInutNFe" type="TRetInutNFe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do retorno do Pedido de Inutilização de Numeração da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/tiposBasico_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/tiposBasico_v4.00.xsd
@@ -1,0 +1,598 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- PL_008  - 30/07/2013- NT 2013/005 -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:nfe="http://www.portalfiscal.inf.br/nfe" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:simpleType name="TCodUfIBGE">
+		<xs:annotation>
+			<xs:documentation>Tipo Código da UF da tabela do IBGE</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="11"/>
+			<xs:enumeration value="12"/>
+			<xs:enumeration value="13"/>
+			<xs:enumeration value="14"/>
+			<xs:enumeration value="15"/>
+			<xs:enumeration value="16"/>
+			<xs:enumeration value="17"/>
+			<xs:enumeration value="21"/>
+			<xs:enumeration value="22"/>
+			<xs:enumeration value="23"/>
+			<xs:enumeration value="24"/>
+			<xs:enumeration value="25"/>
+			<xs:enumeration value="26"/>
+			<xs:enumeration value="27"/>
+			<xs:enumeration value="28"/>
+			<xs:enumeration value="29"/>
+			<xs:enumeration value="31"/>
+			<xs:enumeration value="32"/>
+			<xs:enumeration value="33"/>
+			<xs:enumeration value="35"/>
+			<xs:enumeration value="41"/>
+			<xs:enumeration value="42"/>
+			<xs:enumeration value="43"/>
+			<xs:enumeration value="50"/>
+			<xs:enumeration value="51"/>
+			<xs:enumeration value="52"/>
+			<xs:enumeration value="53"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCodMunIBGE">
+		<xs:annotation>
+			<xs:documentation>Tipo Código do Município da tabela do IBGE</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{7}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TChNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Chave da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="44"/>
+			<xs:pattern value="[0-9]{44}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TProt">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do Protocolo de Status</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="17"/>
+			<xs:pattern value="[0-9]{15}|[0-9]{17}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TRec">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do Recibo do envio de lote de NF-e</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="15"/>
+			<xs:pattern value="[0-9]{15}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TStat">
+		<xs:annotation>
+			<xs:documentation>Tipo Código da Mensagem enviada</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="4"/>
+			<xs:pattern value="[0-9]{3,4}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCnpj">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do CNPJ</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="14"/>
+			<xs:pattern value="[0-9]{14}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCnpjVar">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do CNPJ tmanho varíavel (3-14)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="14"/>
+			<xs:pattern value="[0-9]{3,14}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCnpjOpc">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do CNPJ Opcional</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="14"/>
+			<xs:pattern value="[0-9]{0}|[0-9]{14}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCpf">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do CPF</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="11"/>
+			<xs:pattern value="[0-9]{11}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCpfVar">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do CPF de tamanho variável (3-11)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="11"/>
+			<xs:pattern value="[0-9]{3,11}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0104v">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com até 1 dígitos inteiros, podendo ter de 1 até 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{1,4}|[1-9]{1}(\.[0-9]{1,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0204v">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com até 2 dígitos inteiros, podendo ter de 1 até 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{1,4}|[1-9]{1}[0-9]{0,1}(\.[0-9]{1,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0302a04">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com até 3 dígitos inteiros, podendo ter de 2 até 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{2,4}|[1-9]{1}[0-9]{0,2}(\.[0-9]{2,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0302a04Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com até 3 dígitos inteiros e 2 até 4 decimais. Utilizados em TAGs opcionais, não aceita valor zero.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[0-9]{2,4}|[1-9]{1}[0-9]{0,2}(\.[0-9]{2,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0302Max100">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 3 inteiros (no máximo 100), com 2 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0(\.[0-9]{2})?|100(\.00)?|[1-9]{1}[0-9]{0,1}(\.[0-9]{2})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0304Max100">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 3 inteiros (no máximo 100), com 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0(\.[0-9]{4})?|100(\.00)?|[1-9]{1}[0-9]{0,1}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_03v00a04Max100Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 3 inteiros (no máximo 100), com 4 decimais, não aceita valor zero</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0(\.[1-9][0-9]{0,3})|0(\.[0][1-9][0-9]{0,2})|0(\.[0][0][1-9][0-9]{0,1})|0(\.[0][0][0][1-9])|100(\.[0]{1,4})?|[1-9]{1}[0-9]{0,1}(\.[0-9]{1,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0302a04Max100">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 3 inteiros (no máximo 100), com até 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0(\.[0-9]{2,4})?|[1-9]{1}[0-9]{0,1}(\.[0-9]{2,4})?|100(\.0{2,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0803v">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 8 inteiros, podendo ter de 1 até 3 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{3}|[1-9]{1}[0-9]{0,7}(\.[0-9]{1,3})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1104">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 11 inteiros, podendo ter 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{4}|[1-9]{1}[0-9]{0,10}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1104v">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 11 inteiros, podendo ter de 1 até 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{1,4}|[1-9]{1}[0-9]{0,10}|[1-9]{1}[0-9]{0,10}(\.[0-9]{1,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1104Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 11 inteiros, podendo ter 4 decimais (utilizado em tags opcionais)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[1-9]{1}[0-9]{3}|0\.[0-9]{3}[1-9]{1}|0\.[0-9]{2}[1-9]{1}[0-9]{1}|0\.[0-9]{1}[1-9]{1}[0-9]{2}|[1-9]{1}[0-9]{0,10}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1110v">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 11 inteiros, podendo ter de 1 até 10 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{1,10}|[1-9]{1}[0-9]{0,10}|[1-9]{1}[0-9]{0,10}(\.[0-9]{1,10})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1203">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 12 inteiros, podendo ter  3 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{3}|[1-9]{1}[0-9]{0,11}(\.[0-9]{3})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1204">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 12 inteiros e 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{1,4}|[1-9]{1}[0-9]{0,11}|[1-9]{1}[0-9]{0,11}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1204v">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 12 inteiros de 1 até 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{1,4}|[1-9]{1}[0-9]{0,11}|[1-9]{1}[0-9]{0,11}(\.[0-9]{1,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1204Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 12 inteiros com 1 até 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[0-9]{1,4}|[1-9]{1}[0-9]{0,11}|[1-9]{1}[0-9]{0,11}(\.[0-9]{1,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1204temperatura">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 12 inteiros, 1 a 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[1-9]{1}[0-9]{3}|0\.[0-9]{3}[1-9]{1}|0\.[0-9]{2}[1-9]{1}[0-9]{1}|0\.[0-9]{1}[1-9]{1}[0-9]{2}|[1-9]{1}[0-9]{0,11}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1302">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 13 de corpo e 2 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1302Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 13 de corpo e 2 decimais, utilizado em tags opcionais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[0-9]{1}[1-9]{1}|0\.[1-9]{1}[0-9]{1}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TIeDest">
+		<xs:annotation>
+			<xs:documentation>Tipo Inscrição Estadual do Destinatário // alterado para aceitar vazio ou ISENTO - maio/2010 v2.0</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="14"/>
+			<xs:pattern value="ISENTO|[0-9]{2,14}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TIeDestNaoIsento">
+		<xs:annotation>
+			<xs:documentation>Tipo Inscrição Estadual do Destinatário // alterado para aceitar vazio ou ISENTO - maio/2010 v2.0</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="14"/>
+			<xs:pattern value="[0-9]{2,14}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TIeST">
+		<xs:annotation>
+			<xs:documentation>Tipo Inscrição Estadual do ST // acrescentado EM 24/10/08</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="14"/>
+			<xs:pattern value="[0-9]{2,14}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TIe">
+		<xs:annotation>
+			<xs:documentation>Tipo Inscrição Estadual do Emitente // alterado EM 24/10/08 para aceitar ISENTO</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="14"/>
+			<xs:pattern value="[0-9]{2,14}|ISENTO"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TMod">
+		<xs:annotation>
+			<xs:documentation>Tipo Modelo Documento Fiscal</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="55"/>
+			<xs:enumeration value="65"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TNF">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do Documento Fiscal</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[1-9]{1}[0-9]{0,8}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TSerie">
+		<xs:annotation>
+			<xs:documentation>Tipo Série do Documento Fiscal </xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|[1-9]{1}[0-9]{0,2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TUf">
+		<xs:annotation>
+			<xs:documentation>Tipo Sigla da UF</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="AC"/>
+			<xs:enumeration value="AL"/>
+			<xs:enumeration value="AM"/>
+			<xs:enumeration value="AP"/>
+			<xs:enumeration value="BA"/>
+			<xs:enumeration value="CE"/>
+			<xs:enumeration value="DF"/>
+			<xs:enumeration value="ES"/>
+			<xs:enumeration value="GO"/>
+			<xs:enumeration value="MA"/>
+			<xs:enumeration value="MG"/>
+			<xs:enumeration value="MS"/>
+			<xs:enumeration value="MT"/>
+			<xs:enumeration value="PA"/>
+			<xs:enumeration value="PB"/>
+			<xs:enumeration value="PE"/>
+			<xs:enumeration value="PI"/>
+			<xs:enumeration value="PR"/>
+			<xs:enumeration value="RJ"/>
+			<xs:enumeration value="RN"/>
+			<xs:enumeration value="RO"/>
+			<xs:enumeration value="RR"/>
+			<xs:enumeration value="RS"/>
+			<xs:enumeration value="SC"/>
+			<xs:enumeration value="SE"/>
+			<xs:enumeration value="SP"/>
+			<xs:enumeration value="TO"/>
+			<xs:enumeration value="EX"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TUfEmi">
+		<xs:annotation>
+			<xs:documentation>Tipo Sigla da UF de emissor // acrescentado em 24/10/08 </xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="AC"/>
+			<xs:enumeration value="AL"/>
+			<xs:enumeration value="AM"/>
+			<xs:enumeration value="AP"/>
+			<xs:enumeration value="BA"/>
+			<xs:enumeration value="CE"/>
+			<xs:enumeration value="DF"/>
+			<xs:enumeration value="ES"/>
+			<xs:enumeration value="GO"/>
+			<xs:enumeration value="MA"/>
+			<xs:enumeration value="MG"/>
+			<xs:enumeration value="MS"/>
+			<xs:enumeration value="MT"/>
+			<xs:enumeration value="PA"/>
+			<xs:enumeration value="PB"/>
+			<xs:enumeration value="PE"/>
+			<xs:enumeration value="PI"/>
+			<xs:enumeration value="PR"/>
+			<xs:enumeration value="RJ"/>
+			<xs:enumeration value="RN"/>
+			<xs:enumeration value="RO"/>
+			<xs:enumeration value="RR"/>
+			<xs:enumeration value="RS"/>
+			<xs:enumeration value="SC"/>
+			<xs:enumeration value="SE"/>
+			<xs:enumeration value="SP"/>
+			<xs:enumeration value="TO"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TAmb">
+		<xs:annotation>
+			<xs:documentation>Tipo Ambiente</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TVerAplic">
+		<xs:annotation>
+			<xs:documentation>Tipo Versão do Aplicativo</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="nfe:TString">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="20"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TMotivo">
+		<xs:annotation>
+			<xs:documentation>Tipo Motivo</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="nfe:TString">
+			<xs:maxLength value="255"/>
+			<xs:minLength value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TJust">
+		<xs:annotation>
+			<xs:documentation>Tipo Justificativa</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="nfe:TString">
+			<xs:minLength value="15"/>
+			<xs:maxLength value="255"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TServ">
+		<xs:annotation>
+			<xs:documentation>Tipo Serviço solicitado</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="nfe:TString"/>
+	</xs:simpleType>
+	<xs:simpleType name="Tano">
+		<xs:annotation>
+			<xs:documentation> Tipo ano</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TMed">
+		<xs:annotation>
+			<xs:documentation> Tipo temp médio em segundos</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{1,4}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TString">
+		<xs:annotation>
+			<xs:documentation> Tipo string genérico</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TData">
+		<xs:annotation>
+			<xs:documentation> Tipo data AAAA-MM-DD</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="(((20(([02468][048])|([13579][26]))-02-29))|(20[0-9][0-9])-((((0[1-9])|(1[0-2]))-((0[1-9])|(1\d)|(2[0-8])))|((((0[13578])|(1[02]))-31)|(((0[1,3-9])|(1[0-2]))-(29|30)))))"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TTime">
+		<xs:annotation>
+			<xs:documentation> Tipo hora HH:MM:SS // tipo acrescentado na v2.0</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="(([0-1][0-9])|([2][0-3])):([0-5][0-9]):([0-5][0-9])"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDateTimeUTC">
+		<xs:annotation>
+			<xs:documentation>Data e Hora, formato UTC (AAAA-MM-DDThh:mm:ssTZD, onde TZD = +hh:mm ou -hh:mm)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="(((20(([02468][048])|([13579][26]))-02-29))|(20[0-9][0-9])-((((0[1-9])|(1[0-2]))-((0[1-9])|(1\d)|(2[0-8])))|((((0[13578])|(1[02]))-31)|(((0[1,3-9])|(1[0-2]))-(29|30)))))T(20|21|22|23|[0-1]\d):[0-5]\d:[0-5]\d([\-,\+](0[0-9]|10|11):00|([\+](12):00))"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TPlaca">
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[A-Z]{2,3}[0-9]{4}|[A-Z]{3,4}[0-9]{3}|[A-Z0-9]{7}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCOrgaoIBGE">
+		<xs:annotation>
+			<xs:documentation>Tipo Código de orgão (UF da tabela do IBGE + 90 RFB)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="11"/>
+			<xs:enumeration value="12"/>
+			<xs:enumeration value="13"/>
+			<xs:enumeration value="14"/>
+			<xs:enumeration value="15"/>
+			<xs:enumeration value="16"/>
+			<xs:enumeration value="17"/>
+			<xs:enumeration value="21"/>
+			<xs:enumeration value="22"/>
+			<xs:enumeration value="23"/>
+			<xs:enumeration value="24"/>
+			<xs:enumeration value="25"/>
+			<xs:enumeration value="26"/>
+			<xs:enumeration value="27"/>
+			<xs:enumeration value="28"/>
+			<xs:enumeration value="29"/>
+			<xs:enumeration value="31"/>
+			<xs:enumeration value="32"/>
+			<xs:enumeration value="33"/>
+			<xs:enumeration value="35"/>
+			<xs:enumeration value="41"/>
+			<xs:enumeration value="42"/>
+			<xs:enumeration value="43"/>
+			<xs:enumeration value="50"/>
+			<xs:enumeration value="51"/>
+			<xs:enumeration value="52"/>
+			<xs:enumeration value="53"/>
+			<xs:enumeration value="90"/>
+			<xs:enumeration value="91"/>
+			<xs:enumeration value="92"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/xmldsig-core-schema_v1.01.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.00/xmldsig-core-schema_v1.01.xsd
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- ***************************************************-->
+<!-- ***   Schema específico para assinaturas XML    ***-->
+<!-- *** a partir de certificados do padrão (X509)   ***-->
+<!-- *** ICP-Brasil - Projeto Nota Fiscal Eletrônica ***-->
+<!-- ***************************************************-->
+<!-- Schema for XML Signatures-->
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.w3.org/2000/09/xmldsig#" elementFormDefault="qualified" attributeFormDefault="unqualified" version="0.1">
+	<element name="Signature" type="ds:SignatureType"/>
+	<complexType name="SignatureType">
+		<sequence>
+			<element name="SignedInfo" type="ds:SignedInfoType"/>
+			<element name="SignatureValue" type="ds:SignatureValueType"/>
+			<element name="KeyInfo" type="ds:KeyInfoType"/>
+		</sequence>
+		<attribute name="Id" type="ID" use="optional"/>
+	</complexType>
+	<complexType name="SignatureValueType">
+		<simpleContent>
+			<extension base="base64Binary">
+				<attribute name="Id" type="ID" use="optional"/>
+			</extension>
+		</simpleContent>
+	</complexType>
+	<complexType name="SignedInfoType">
+		<sequence>
+			<element name="CanonicalizationMethod">
+				<complexType>
+					<attribute name="Algorithm" type="anyURI" use="required" fixed="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+				</complexType>
+			</element>
+			<element name="SignatureMethod">
+				<complexType>
+					<attribute name="Algorithm" type="anyURI" use="required" fixed="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+				</complexType>
+			</element>
+			<element name="Reference" type="ds:ReferenceType"/>
+		</sequence>
+		<attribute name="Id" type="ID" use="optional"/>
+	</complexType>
+	<complexType name="ReferenceType">
+		<sequence>
+			<element name="Transforms" type="ds:TransformsType">
+				<!-- Garante a unicidade do atributo -->
+				<unique name="unique_Transf_Alg">
+					<selector xpath="./*"/>
+					<field xpath="@Algorithm"/>
+				</unique>
+			</element>
+			<element name="DigestMethod">
+				<complexType>
+					<attribute name="Algorithm" type="anyURI" use="required" fixed="http://www.w3.org/2000/09/xmldsig#sha1"/>
+				</complexType>
+			</element>
+			<element name="DigestValue" type="ds:DigestValueType"/>
+		</sequence>
+		<attribute name="Id" type="ID" use="optional"/>
+		<attribute name="URI" use="required">
+			<simpleType>
+				<restriction base="anyURI">
+					<minLength value="2"/>
+				</restriction>
+			</simpleType>
+		</attribute>
+		<attribute name="Type" type="anyURI" use="optional"/>
+	</complexType>
+	<complexType name="TransformsType">
+		<sequence>
+			<element name="Transform" type="ds:TransformType" minOccurs="2" maxOccurs="2"/>
+		</sequence>
+	</complexType>
+	<complexType name="TransformType">
+		<sequence minOccurs="0" maxOccurs="unbounded">
+			<element name="XPath" type="string"/>
+		</sequence>
+		<attribute name="Algorithm" type="ds:TTransformURI" use="required"/>
+	</complexType>
+	<complexType name="KeyInfoType">
+		<sequence>
+			<element name="X509Data" type="ds:X509DataType"/>
+		</sequence>
+		<attribute name="Id" type="ID" use="optional"/>
+	</complexType>
+	<complexType name="X509DataType">
+		<sequence>
+			<element name="X509Certificate" type="base64Binary"/>
+		</sequence>
+	</complexType>
+	<simpleType name="DigestValueType">
+		<restriction base="base64Binary"/>
+	</simpleType>
+	<simpleType name="TTransformURI">
+		<restriction base="anyURI">
+			<enumeration value="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+			<enumeration value="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+		</restriction>
+	</simpleType>
+</schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/DFeTiposBasicos_v1.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/DFeTiposBasicos_v1.00.xsd
@@ -1,0 +1,1060 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas-softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+	<xs:simpleType name="TStringRTC">
+		<xs:annotation>
+			<xs:documentation> Tipo string genérico</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCST">
+		<xs:annotation>
+			<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="\d{3}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TcClassTrib">
+		<xs:annotation>
+			<xs:documentation>Código de Classificação Tributária do IBS e da CBS</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="\d{6}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec1104">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 11 de corpo e 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{4}|[1-9]{1}[0-9]{0,10}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1104Op">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 11 inteiros, podendo ter 4 decimais (utilizado em tags opcionais)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[1-9]{1}[0-9]{3}|0\.[0-9]{3}[1-9]{1}|0\.[0-9]{2}[1-9]{1}[0-9]{1}|0\.[0-9]{1}[1-9]{1}[0-9]{2}|[1-9]{1}[0-9]{0,10}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec1302">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 13 de corpo e 2 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0302_04">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com até 3 dígitos inteiros, podendo ter de 2 até 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{2,4}|[1-9]{1}[0-9]{0,2}(\.[0-9]{2,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TOperCompraGov">
+		<xs:annotation>
+			<xs:documentation>Tipo da Operação com Ente Governamental</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TEnteGov">
+		<xs:annotation>
+			<xs:documentation>Tipo de Ente Governamental</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+			<xs:enumeration value="3"/>
+			<xs:enumeration value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TTpCredPresIBSZFM">
+		<xs:annotation>
+			<xs:documentation>Tipo de classificação do Crédito Presumido IBS ZFM</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="0"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+			<xs:enumeration value="3"/>
+			<xs:enumeration value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="TTribNFCom">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NFCom</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribNF3e">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NF3e</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribCTe">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação do CTe</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribBPe">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação do BPe</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribNFCe">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NFCe</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:choice minOccurs="0">
+				<xs:element name="gIBSCBS" type="TCIBS"/>
+				<xs:element name="gIBSCBSMono" type="TMonofasia"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribNFe">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NFe</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:choice minOccurs="0">
+				<xs:element name="gIBSCBS" type="TCIBS"/>
+				<xs:element name="gIBSCBSMono" type="TMonofasia">
+					<xs:annotation>
+						<xs:documentation>Informar essa opção da Choice para Monofasia</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="gTransfCred" type="TTransfCred">
+					<xs:annotation>
+						<xs:documentation>Informar essa opção da Choice para o CST 800</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+			<xs:element name="gCredPresIBSZFM" type="TCredPresIBSZFM" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Classificação de acordo com o art. 450, § 1º, da LC 214/25 para o cálculo do crédito presumido na ZFM</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TIS">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações do Imposto Seletivo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CSTIS" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do Imposto Seletivo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTribIS" type="TcClassTrib"/>
+			<xs:sequence minOccurs="0">
+				<xs:element name="vBCIS" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor do BC</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="pIS" type="TDec_0302_04">
+					<xs:annotation>
+						<xs:documentation>Alíquota do Imposto Seletivo (percentual)</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="pISEspec" type="TDec_0302_04" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Alíquota do Imposto Seletivo (por valor)</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:sequence minOccurs="0">
+					<xs:element name="uTrib">
+						<xs:annotation>
+							<xs:documentation>Unidade de medida apropriada especificada em Lei Ordinaria para fins de apuração do Imposto Seletivo</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="TStringRTC">
+								<xs:minLength value="1"/>
+								<xs:maxLength value="6"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:element>
+					<xs:element name="qTrib" type="TDec_1104Op">
+						<xs:annotation>
+							<xs:documentation>Quantidade com abse no campo uTrib informado</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+				</xs:sequence>
+				<xs:element name="vIS" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor do Imposto Seletivo calculado</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TISTot">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações de totais do Imposto Seletivo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vIS" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor Total do Imposto Seletivo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TIBSCBSTot">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações de totais da CBS/IBS</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vBCIBSCBS" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Total Base de Calculo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gIBS">
+				<xs:annotation>
+					<xs:documentation>Totalização do IBS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="gIBSUF">
+							<xs:annotation>
+								<xs:documentation>Totalização do IBS de competência da UF</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vDif" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Total do Diferimento</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vDevTrib" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Total de devoluções de tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vIBSUF" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Valor total do IBS Estadual</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="gIBSMun">
+							<xs:annotation>
+								<xs:documentation>Totalização do IBS de competência Municipal</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vDif" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Total do Diferimento</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vDevTrib" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Total de devoluções de tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vIBSMun" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Valor total do IBS Municipal</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="vIBS" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor total do IBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPres" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPresCondSus" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido Condição Suspensiva</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gCBS">
+				<xs:annotation>
+					<xs:documentation>Totalização da CBS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="vDif" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total do Diferimento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vDevTrib" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total de devoluções de tributos</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBS" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor total da CBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPres" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPresCondSus" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido Condição Suspensiva</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TIBSCBSMonoTot">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações de totais da CBS/IBS com monofasia</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vBCIBSCBS" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Total Base de Calculo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gIBS" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Totalização do IBS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="gIBSUF">
+							<xs:annotation>
+								<xs:documentation>Totalização do IBS de competência da UF</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vDif" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Total do Diferimento</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vDevTrib" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Total de devoluções de tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vIBSUF" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Valor total do IBS Estadual</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="gIBSMun">
+							<xs:annotation>
+								<xs:documentation>Totalização do IBS de competência Municipal</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vDif" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Total do Diferimento</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vDevTrib" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Total de devoluções de tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vIBSMun" type="TDec1302">
+										<xs:annotation>
+											<xs:documentation>Valor total do IBS Municipal</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="vIBS" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor total do IBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPres" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gCBS" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Totalização da CBS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="vDif" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total do Diferimento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vDevTrib" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total de devoluções de tributos</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBS" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor total da CBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPres" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gMono" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Totais da Monofasia</xs:documentation>
+					<xs:documentation>Só deverá ser utilizado para DFe modelos 55 e 65</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="vIBSMono" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor total do IBS monofásico</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSMono" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor total da CBS monofásica</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vIBSMonoReten" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor total do IBS monofásico sujeito a retenção</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSMonoReten" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor total da CBS monofásica sujeita a retenção</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vIBSMonoRet" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor do IBS monofásico retido anteriormente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSMonoRet" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor da CBS monofásica retida anteriormente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TMonofasia">
+		<xs:annotation>
+			<xs:documentation>Tipo Monofasia</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:annotation>
+				<xs:documentation>Monofasia</xs:documentation>
+			</xs:annotation>
+			<xs:sequence minOccurs="0">
+				<xs:element name="qBCMono" type="TDec_1104Op">
+					<xs:annotation>
+						<xs:documentation>Quantidade tributada na monofasia</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="adRemIBS" type="TDec_0302_04">
+					<xs:annotation>
+						<xs:documentation>Alíquota ad rem do IBS</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="adRemCBS" type="TDec_0302_04">
+					<xs:annotation>
+						<xs:documentation>Alíquota ad rem da CBS</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vIBSMono" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor do IBS monofásico</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vCBSMono" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor da CBS monofásica</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+			<xs:sequence minOccurs="0">
+				<xs:element name="qBCMonoReten" type="TDec_1104Op">
+					<xs:annotation>
+						<xs:documentation>Quantidade tributada sujeita a retenção.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="adRemIBSReten" type="TDec_0302_04">
+					<xs:annotation>
+						<xs:documentation>Alíquota ad rem do IBS sujeito a retenção</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vIBSMonoReten" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor do IBS monofásico sujeito a retenção</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="adRemCBSReten" type="TDec_0302_04">
+					<xs:annotation>
+						<xs:documentation>Alíquota ad rem da CBS sujeita a retenção</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vCBSMonoReten" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor da CBS monofásica sujeita a retenção</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+			<xs:sequence minOccurs="0">
+				<xs:element name="qBCMonoRet" type="TDec_1104Op">
+					<xs:annotation>
+						<xs:documentation>Quantidade tributada retida anteriormente</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="adRemIBSRet" type="TDec_0302_04">
+					<xs:annotation>
+						<xs:documentation>Alíquota ad rem do IBS retido anteriormente</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vIBSMonoRet" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor do IBS retido anteriormente</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="adRemCBSRet" type="TDec_0302_04">
+					<xs:annotation>
+						<xs:documentation>Alíquota ad rem da CBS retida anteriormente</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vCBSMonoRet" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor da CBS retida anteriormente</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+			<xs:sequence minOccurs="0">
+				<xs:element name="pDifIBS" type="TDec_0302_04">
+					<xs:annotation>
+						<xs:documentation>Percentual do diferimento do imposto monofásico</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vIBSMonoDif" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor do IBS monofásico diferido</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="pDifCBS" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Percentual do diferimento do imposto monofásico</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vCBSMonoDif" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor da CBS monofásica diferida</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+			<xs:element name="vTotIBSMonoItem" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Total de IBS monofásico do item</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vTotCBSMonoItem" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Total da CBS monofásica do item</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCIBS">
+		<xs:annotation>
+			<xs:documentation>Tipo CBS IBS Completo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:annotation>
+				<xs:documentation>IBS / CBS</xs:documentation>
+			</xs:annotation>
+			<xs:element name="vBC" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor do BC</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gIBSUF">
+				<xs:annotation>
+					<xs:documentation>Grupo de informações do IBS na UF</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="pIBSUF" type="TDec_0302_04">
+							<xs:annotation>
+								<xs:documentation>Aliquota do IBS de competência das UF</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gDif" type="TDifIBS" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de campos do Diferimento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gDevTrib" type="TDevTrib" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de Informações da devolução de tributos</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gRed" type="TRed" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de campos da redução de aliquota</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vIBSUF" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor do IBS de competência das UF</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gIBSMun">
+				<xs:annotation>
+					<xs:documentation>Grupo de Informações do IBS no Município</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="pIBSMun" type="TDec_0302_04">
+							<xs:annotation>
+								<xs:documentation>Aliquota do IBS Municipal</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gDif" type="TDifIBS" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de campos do Diferimento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gDevTrib" type="TDevTrib" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de Informações da devolução de tributos</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gRed" type="TRed" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de campos da redução de aliquota</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vIBSMun" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor do IBS Municipal</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gCBS">
+				<xs:annotation>
+					<xs:documentation>Grupo de Tributação da CBS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="pCBS" type="TDec_0302_04">
+							<xs:annotation>
+								<xs:documentation>Aliquota da CBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gDif" type="TDifCBS" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de campos do Diferimento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gDevTrib" type="TDevTrib" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de Informações da devolução de tributos</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gRed" type="TRed" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de campos da redução de aliquota</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBS" type="TDec1302">
+							<xs:annotation>
+								<xs:documentation>Valor da CBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gTribRegular" type="TTribRegular" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de informações da Tributação Regular. Informar como seria a tributação caso não cumprida a condição resolutória/suspensiva. Exemplo 1: Art. 442, §4. Operações com ZFM e ALC. Exemplo 2: Operações com suspensão do tributo.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gIBSCredPres" type="TCredPres" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de Informações do Crédito Presumido referente ao IBS, quando aproveitado pelo emitente do documento. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gCBSCredPres" type="TCredPres" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de Informações do Crédito Presumido referente a CBS, quando aproveitado pelo emitente do documento. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gTribCompraGov" type="TTribCompraGov" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de informações da composição do valor do IBS e da CBS em compras governamental</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TRed">
+		<xs:annotation>
+			<xs:documentation>Tipo Redução Base de Cálculo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="pRedAliq" type="TDec_0302_04">
+				<xs:annotation>
+					<xs:documentation>Percentual de redução de aliquota do cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqEfet" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Aliquota Efetiva que será aplicada a Base de Calculo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCredPres">
+		<xs:annotation>
+			<xs:documentation>Tipo Crédito Presumido</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="cCredPres">
+				<xs:annotation>
+					<xs:documentation>Usar tabela Cred Presumido, para o emitente da nota.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pCredPres" type="TDec_0302_04">
+				<xs:annotation>
+					<xs:documentation>Percentual do Crédito Presumido</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice>
+				<xs:element name="vCredPres" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor do Crédito Presumido</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vCredPresCondSus" type="TDec1302">
+					<xs:annotation>
+						<xs:documentation>Valor do Crédito Presumido Condição Suspensiva, preencher apenas para cCredPres que possui indicação de Condição Suspensiva</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TDifIBS">
+		<xs:annotation>
+			<xs:documentation>Tipo Diferimento</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="pDif" type="TDec_0302_04">
+				<xs:annotation>
+					<xs:documentation>Percentual do diferimento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vDif" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor do diferimento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TDifCBS">
+		<xs:annotation>
+			<xs:documentation>Tipo Diferimento</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="pDif" type="TDec_0302_04">
+				<xs:annotation>
+					<xs:documentation>Percentual do diferimento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vDif" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor do diferimento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TDevTrib">
+		<xs:annotation>
+			<xs:documentation>Tipo Devolução Tributo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vDevTrib" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor do tributo devolvido. No fornecimento de energia elétrica, água, esgoto e
+gás natural e em outras hipóteses definidas no regulamento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribRegular">
+		<xs:annotation>
+			<xs:documentation>Tipo Tributação Regular</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CSTReg" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código da Situação Tributária do IBS e CBS</xs:documentation>
+					<xs:documentation>Informar qual seria o CST caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTribReg" type="TcClassTrib">
+				<xs:annotation>
+					<xs:documentation>Informar qual seria o cClassTrib caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqEfetRegIBSUF" type="TDec_0302_04">
+				<xs:annotation>
+					<xs:documentation>Alíquota do IBS da UF</xs:documentation>
+					<xs:documentation>Informar como seria a Alíquota caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vTribRegIBSUF" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor do IBS da UF</xs:documentation>
+					<xs:documentation>Informar como seria o valor do Tributo caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqEfetRegIBSMun" type="TDec_0302_04">
+				<xs:annotation>
+					<xs:documentation>Alíquota do IBS do Município</xs:documentation>
+					<xs:documentation>Informar como seria a Alíquota caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vTribRegIBSMun" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor do IBS do Município</xs:documentation>
+					<xs:documentation>Informar como seria o valor do Tributo caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqEfetRegCBS" type="TDec_0302_04">
+				<xs:annotation>
+					<xs:documentation>Alíquota da CBS</xs:documentation>
+					<xs:documentation>Informar como seria a Alíquota caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vTribRegCBS" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor da CBS</xs:documentation>
+					<xs:documentation>Informar como seria o valor do Tributo caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribCompraGov">
+		<xs:annotation>
+			<xs:documentation>Tipo Tributação Compra Governamental</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="pAliqIBSUF" type="TDec_0302_04" />
+			<xs:element name="vTribIBSUF" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor que seria devido a UF, sem aplicação do Art. 473. da LC 214/2025</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqIBSMun" type="TDec_0302_04" />
+			<xs:element name="vTribIBSMun" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor que seria devido ao município, sem aplicação do Art. 473. da LC 214/2025</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqCBS" type="TDec_0302_04" />
+			<xs:element name="vTribCBS" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor que seria devido a CBS, sem aplicação do Art. 473. da LC 214/2025</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCompraGovReduzido">
+		<xs:annotation>
+			<xs:documentation>Tipo Compras Governamentais</xs:documentation>
+			<xs:documentation>Cada DFe que utilizar deverá utilizar esses tipo no grupo ide</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpEnteGov" type="TEnteGov">
+				<xs:annotation>
+					<xs:documentation>Para administração pública direta e suas autarquias e fundações:
+1=União
+2=Estados
+3=Distrito Federal
+4=Municípios</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pRedutor" type="TDec_0302_04">
+				<xs:annotation>
+					<xs:documentation>Percentual de redução de aliquota em compra goverrnamental</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCompraGov">
+		<xs:annotation>
+			<xs:documentation>Tipo Compras Governamentais</xs:documentation>
+			<xs:documentation>Cada DFe que utilizar deverá utilizar esses tipo no grupo ide</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpEnteGov" type="TEnteGov">
+				<xs:annotation>
+					<xs:documentation>Para administração pública direta e suas autarquias e fundações:
+1=União
+2=Estados
+3=Distrito Federal
+4=Municípios</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pRedutor" type="TDec_0302_04">
+				<xs:annotation>
+					<xs:documentation>Percentual de redução de aliquota em compra goverrnamental</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="tpOperGov" type="TOperCompraGov">
+				<xs:annotation>
+					<xs:documentation>Tipo da operação com ente governamental:
+1 - Fornecimento
+2 - Recebimento do Pagamento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTransfCred">
+		<xs:annotation>
+			<xs:documentation>Tipo Transferência de Crédito</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vIBS" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor do IBS a ser transferido</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vCBS" type="TDec1302">
+				<xs:annotation>
+					<xs:documentation>Valor da CBS a ser transferida</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCredPresIBSZFM">
+		<xs:annotation>
+			<xs:documentation>Tipo Informações do crédito presumido de IBS para fornecimentos a partir da ZFM</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpCredPresIBSZFM" type="TTpCredPresIBSZFM">
+				<xs:annotation>
+					<xs:documentation>Classificação de acordo com o art. 450, § 1º, da LC 214/25 para o cálculo do crédito presumido na ZFM</xs:documentation>
+					<xs:documentation>0 - Sem crédito presumido;
+1 - Bens de consumo final (55%);
+2 - Bens de capital (75%);
+3 - Bens intermediários (90,25%);
+4 - Bens de informática e outros definidos em legislação (100%).
+OBS: Percentuais definidos no art. 450, § 1º, da LC 214/25 para o cálculo do crédito presumido
+</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vCredPresIBSZFM" type="TDec1302" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Valor do crédito presumido calculado sobre o saldo devedor apurado</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/GTVe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/GTVe_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="GTVe" type="TGTVe">
+		<xs:annotation>
+			<xs:documentation>Guia de Trasnsporte Eletrônica</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/consSitCTeTiposBasico_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/consSitCTeTiposBasico_v4.00.xsd
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposGeralCTe_v4.00.xsd"/>
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v1.01.xsd"/>
+	<xs:complexType name="TConsSitCTe">
+		<xs:annotation>
+			<xs:documentation>Tipo Pedido de Consulta da Situação Atual do Conhecimento de Transporte eletrônico</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xServ" type="TServ" fixed="CONSULTAR">
+				<xs:annotation>
+					<xs:documentation>Serviço Solicitado</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="chCTe" type="TChDFe">
+				<xs:annotation>
+					<xs:documentation>Chaves de acesso da CT-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" use="required">
+			<xs:simpleType>
+				<xs:restriction base="TVerConsSitCTe"/>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="TRetConsSitCTe">
+		<xs:annotation>
+			<xs:documentation>Tipo Retorno de Pedido de Consulta da Situação Atual do Conhecimento de Transporte eletrônico</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="verAplic" type="TVerAplic">
+				<xs:annotation>
+					<xs:documentation>Versão do Aplicativo que processou o CT-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cStat" type="TStat">
+				<xs:annotation>
+					<xs:documentation>Código do status da mensagem enviada.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMotivo" type="TMotivo">
+				<xs:annotation>
+					<xs:documentation>Descrição literal do status do serviço solicitado.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>código da UF de atendimento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="protCTe" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:any processContents="skip">
+							<xs:annotation>
+								<xs:documentation>Retornar protCTe da versão correspondente do CT-e autorizado</xs:documentation>
+							</xs:annotation>
+						</xs:any>
+					</xs:sequence>
+					<xs:attribute name="versao" use="required">
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:whiteSpace value="preserve"/>
+								<xs:enumeration value="1.03"/>
+								<xs:enumeration value="1.04"/>
+								<xs:enumeration value="2.00"/>
+								<xs:enumeration value="3.00"/>
+								<xs:enumeration value="4.00"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="procEventoCTe" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:any>
+							<xs:annotation>
+								<xs:documentation>Retornar procEventoCTe da versão correspondente do evento CT-e autorizado</xs:documentation>
+							</xs:annotation>
+						</xs:any>
+					</xs:sequence>
+					<xs:attribute name="versao" use="required">
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:whiteSpace value="preserve"/>
+								<xs:enumeration value="1.04"/>
+								<xs:enumeration value="2.00"/>
+								<xs:enumeration value="3.00"/>
+								<xs:enumeration value="4.00"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerConsSitCTe" use="required"/>
+	</xs:complexType>
+	<xs:simpleType name="TVerConsSitCTe">
+		<xs:annotation>
+			<xs:documentation> Tipo Versão do Consulta situação de CT-e - 4.00</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="4\.00"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/consSitCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/consSitCTe_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="consSitCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="consSitCTe" type="TConsSitCTe">
+		<xs:annotation>
+			<xs:documentation>Schema de validação XML dp Pedido de Consulta da Situação Atual do CT-e.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/consStatServCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/consStatServCTe_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="consStatServTiposBasico_v4.00.xsd"/>
+	<xs:element name="consStatServCTe" type="TConsStatServ">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do Pedido de Consulta do Status do Serviço CT-e</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/consStatServTiposBasico_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/consStatServTiposBasico_v4.00.xsd
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposGeralCTe_v4.00.xsd"/>
+	<xs:complexType name="TConsStatServ">
+		<xs:annotation>
+			<xs:documentation>Tipo Pedido de Consulta do Status do Serviço CTe</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>Código da UF a ser verificado o status</xs:documentation>
+					<xs:documentation>Utilizar a Tabela do IBGE.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xServ" type="TServ" fixed="STATUS">
+				<xs:annotation>
+					<xs:documentation>Serviço Solicitado</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" use="required">
+			<xs:simpleType>
+				<xs:restriction base="TVerConsStat"/>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="TRetConsStatServ">
+		<xs:annotation>
+			<xs:documentation>Tipo Resultado da Consulta do Status do Serviço CTe</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="verAplic">
+				<xs:annotation>
+					<xs:documentation>Versão do Aplicativo que processou o CT-e</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TVerAplic">
+						<xs:whiteSpace value="collapse"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cStat" type="TStat">
+				<xs:annotation>
+					<xs:documentation>Código do status da mensagem enviada.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMotivo" type="TMotivo">
+				<xs:annotation>
+					<xs:documentation>Descrição literal do status do serviço solicitado.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>Código da UF responsável pelo serviço</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="dhRecbto" type="TDateTimeUTC">
+				<xs:annotation>
+					<xs:documentation>AAAA-MM-DDTHH:MM:SS TZD</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="tMed" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Tempo médio de resposta do serviço (em segundos) dos últimos 5 minutos</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:integer">
+						<xs:pattern value="[0-9]{1,4}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="dhRetorno" type="TDateTimeUTC" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>AAAA-MM-DDTHH:MM:SSDeve ser preenchida com data e hora previstas para o retorno dos serviços prestados.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xObs" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Campo observação utilizado para incluir informações ao contribuinte</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:minLength value="1"/>
+						<xs:maxLength value="255"/>
+						<xs:whiteSpace value="collapse"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerConsStat" use="required"/>
+	</xs:complexType>
+	<xs:simpleType name="TVerConsStat">
+		<xs:annotation>
+			<xs:documentation> Tipo Versão do Consulta do Status do Serviço CTe</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="4\.00"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cteModalAereo_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cteModalAereo_v4.00.xsd
@@ -1,0 +1,240 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposGeralCTe_v4.00.xsd"/>
+	<xs:element name="aereo">
+		<xs:annotation>
+			<xs:documentation>Informações do modal Aéreo</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="nMinu" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Número da Minuta</xs:documentation>
+						<xs:documentation>Documento que precede o CT-e, assinado pelo expedidor, espécie de pedido de serviço</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:pattern value="[0-9]{9}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nOCA" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Número Operacional do Conhecimento Aéreo</xs:documentation>
+						<xs:documentation>Representa o número de controle comumente utilizado pelo conhecimento aéreo composto por uma sequência numérica de onze dígitos. Os três primeiros dígitos representam um código que os operadores de transporte aéreo associados à IATA possuem. Em seguida um número de série de sete dígitos determinados pelo operador de transporte aéreo. Para finalizar, um dígito verificador, que é um sistema de módulo sete imponderado o qual divide o número de série do conhecimento aéreo por sete e usa o resto como dígito de verificação. </xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:pattern value="[0-9]{11}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="dPrevAereo" type="TData">
+					<xs:annotation>
+						<xs:documentation>Data prevista da entrega</xs:documentation>
+						<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="natCarga">
+					<xs:annotation>
+						<xs:documentation>Natureza da carga</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="xDime" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Dimensão</xs:documentation>
+									<xs:documentation>Formato:1234X1234X1234 (cm). Esse campo deve sempre que possível ser preenchido. Entretanto, quando for impossível o preenchimento das dimensões, fica obrigatório o preenchimento da cubagem em metro cúbico do leiaute do CT-e da estrutura genérica (infQ).
+</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="5"/>
+										<xs:maxLength value="14"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="cInfManu" minOccurs="0" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>Informações de manuseio</xs:documentation>
+									<xs:documentation>01 - certificado do expedidor para embarque de animal vivo;
+
+02 - artigo perigoso conforme Declaração do Expedidor anexa;
+
+03 - somente em aeronave cargueira; 
+
+04 - artigo perigoso - declaração do expedidor não requerida; 
+
+05 - artigo perigoso em quantidade isenta;
+
+06 - gelo seco para refrigeração (especificar no campo observações a quantidade); 
+
+07 - não restrito (especificar a Disposição Especial no campo observações);
+
+08 - artigo perigoso em carga consolidada (especificar a quantidade no campo observações)
+;
+09 - autorização da autoridade governamental anexa (especificar no campo observações); 
+
+10 – baterias de íons de lítio em conformidade com a Seção II da PI965 – CAO
+; 
+11 - baterias de íons de lítio em conformidade com a Seção II da PI966
+; 
+12 - baterias de íons de lítio em conformidade com a Seção II da PI967
+; 
+13 – baterias de metal lítio em conformidade com a Seção II da PI968 — CAO; 
+
+14 - baterias de metal lítio em conformidade com a Seção II da PI969; 
+
+15 - baterias de metal lítio em conformidade com a Seção II da PI970
+; 
+99 - outro (especificar no campo observações)
+.</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:enumeration value="01"/>
+										<xs:enumeration value="02"/>
+										<xs:enumeration value="03"/>
+										<xs:enumeration value="04"/>
+										<xs:enumeration value="05"/>
+										<xs:enumeration value="06"/>
+										<xs:enumeration value="07"/>
+										<xs:enumeration value="08"/>
+										<xs:enumeration value="09"/>
+										<xs:enumeration value="10"/>
+										<xs:enumeration value="11"/>
+										<xs:enumeration value="12"/>
+										<xs:enumeration value="13"/>
+										<xs:enumeration value="14"/>
+										<xs:enumeration value="15"/>
+										<xs:enumeration value="99"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="tarifa">
+					<xs:annotation>
+						<xs:documentation>Informações de tarifa</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="CL">
+								<xs:annotation>
+									<xs:documentation>Classe</xs:documentation>
+									<xs:documentation>Preencher com:
+									M - Tarifa Mínima;
+									G - Tarifa Geral;
+									E - Tarifa Específica</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:length value="1"/>
+										<xs:whiteSpace value="preserve"/>
+										<xs:pattern value="M"/>
+										<xs:pattern value="G"/>
+										<xs:pattern value="E"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="cTar" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Código da Tarifa</xs:documentation>
+									<xs:documentation>Deverão ser incluídos os códigos de três dígitos, correspondentes à tarifa.</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="4"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="vTar" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor da Tarifa</xs:documentation>
+									<xs:documentation>Valor da tarifa por kg quando for o caso.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="peri" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Preenchido quando for  transporte de produtos classificados pela ONU como perigosos.</xs:documentation>
+						<xs:documentation>O preenchimento desses campos não desobriga a empresa aérea de emitir os demais documentos que constam na legislação vigente.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="nONU">
+								<xs:annotation>
+									<xs:documentation>Número ONU/UN</xs:documentation>
+									<xs:documentation>Ver a legislação de transporte de produtos perigosos aplicadas ao modal  </xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:pattern value="[0-9]{4}|ND"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="qTotEmb">
+								<xs:annotation>
+									<xs:documentation>Quantidade total de volumes contendo artigos perigosos</xs:documentation>
+									<xs:documentation>Preencher com o número de volumes (unidades) de artigos perigosos, ou seja, cada embalagem devidamente marcada e etiquetada (por ex.: número de caixas, de tambores, de bombonas, dentre outros). Não deve ser preenchido com o número de ULD, pallets ou containers.</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="20"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="infTotAP">
+								<xs:annotation>
+									<xs:documentation>Grupo de informações das quantidades totais de artigos perigosos</xs:documentation>
+									<xs:documentation>Preencher conforme a legislação de transporte de produtos perigosos aplicada ao modal</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="qTotProd" type="TDec_1104">
+											<xs:annotation>
+												<xs:documentation>Quantidade total de artigos perigosos</xs:documentation>
+												<xs:documentation>15 posições, sendo 11 inteiras e 4 decimais. 
+Deve indicar a quantidade total do artigo perigoso, tendo como base a unidade referenciada na Tabela 3-1 do Doc 9284, por exemplo: litros; quilogramas; quilograma bruto etc. O preenchimento não deve, entretanto, incluir a unidade de medida. No caso de transporte de material radioativo, deve-se indicar o somatório dos Índices de Transporte (TI). Não indicar a quantidade do artigo perigoso por embalagem.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="uniAP">
+											<xs:annotation>
+												<xs:documentation>Unidade de medida</xs:documentation>
+												<xs:documentation>1 – KG; 
+2 – KG G (quilograma bruto);
+3 – LITROS;
+4 – TI (índice de transporte para radioativos); 5- Unidades (apenas para artigos perigosos medidos em unidades que não se enquadram nos itens acima. Exemplo: baterias, celulares, equipamentos, veículos, dentre outros)</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="1"/>
+													<xs:maxLength value="1"/>
+													<xs:enumeration value="1"/>
+													<xs:enumeration value="2"/>
+													<xs:enumeration value="3"/>
+													<xs:enumeration value="4"/>
+													<xs:enumeration value="5"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cteModalAquaviario_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cteModalAquaviario_v4.00.xsd
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="aquav">
+		<xs:annotation>
+			<xs:documentation>Informações do modal Aquaviário</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="vPrest" type="TDec_1302">
+					<xs:annotation>
+						<xs:documentation>Valor da Prestação Base de Cálculo do AFRMM</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vAFRMM" type="TDec_1302">
+					<xs:annotation>
+						<xs:documentation>AFRMM (Adicional de Frete para Renovação da Marinha Mercante)</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="xNavio">
+					<xs:annotation>
+						<xs:documentation>Identificação do Navio </xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TString">
+							<xs:maxLength value="60"/>
+							<xs:minLength value="1"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="balsa" minOccurs="0" maxOccurs="3">
+					<xs:annotation>
+						<xs:documentation>Grupo de informações das balsas</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="xBalsa">
+								<xs:annotation>
+									<xs:documentation>Identificador da Balsa</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="60"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="nViag" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Número da Viagem</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:pattern value="[1-9]{1}[0-9]{0,9}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="direc">
+					<xs:annotation>
+						<xs:documentation>Direção</xs:documentation>
+						<xs:documentation>Preencher com: N-Norte, L-Leste, S-Sul, O-Oeste  </xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="N"/>
+							<xs:enumeration value="S"/>
+							<xs:enumeration value="L"/>
+							<xs:enumeration value="O"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="irin">
+					<xs:annotation>
+						<xs:documentation>Irin do navio sempre deverá ser informado</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:maxLength value="10"/>
+							<xs:minLength value="1"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="detCont" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Grupo de informações de detalhamento dos conteiners 
+(Somente para Redespacho Intermediário e Serviço Vinculado a Multimodal)</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="nCont" type="TContainer">
+								<xs:annotation>
+									<xs:documentation>Identificação do Container</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="lacre" minOccurs="0" maxOccurs="3">
+								<xs:annotation>
+									<xs:documentation>Grupo de informações dos lacres dos cointainers da qtde da carga </xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="nLacre">
+											<xs:annotation>
+												<xs:documentation>Lacre</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="1"/>
+													<xs:maxLength value="20"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="infDoc" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Informações dos documentos dos conteiners</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:choice>
+										<xs:element name="infNF" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>Informações das NF</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="serie">
+														<xs:annotation>
+															<xs:documentation>Série</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="3"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="nDoc">
+														<xs:annotation>
+															<xs:documentation>Número </xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="20"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="unidRat" type="TDec_0302_0303" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Unidade de medida rateada (Peso,Volume)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infNFe" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>Informações das NFe</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="chave" type="TChDFe">
+														<xs:annotation>
+															<xs:documentation>Chave de acesso da NF-e</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="unidRat" type="TDec_0302_0303" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Unidade de medida rateada (Peso,Volume)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+									</xs:choice>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="tpNav" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Tipo de Navegação</xs:documentation>
+						<xs:documentation>Preencher com: 
+						0 - Interior;
+						1 - Cabotagem</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="0"/>
+							<xs:enumeration value="1"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cteModalDutoviario_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cteModalDutoviario_v4.00.xsd
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposGeralCTe_v4.00.xsd"/>
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="duto">
+		<xs:annotation>
+			<xs:documentation>Informações do modal Dutoviário</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="vTar" type="TDec_0906Opc" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Valor da tarifa</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="dIni" type="TData">
+					<xs:annotation>
+						<xs:documentation>Data de Início da prestação do serviço</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="dFim" type="TData">
+					<xs:annotation>
+						<xs:documentation>Data de Fim da prestação do serviço</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="classDuto" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Classificação do Dutoviário</xs:documentation>
+						<xs:documentation>Informar: 1 - Gasoduto 2 - Mineroduto 3 - Oleoduto</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="1"/>
+							<xs:enumeration value="2"/>
+							<xs:enumeration value="3"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="tpContratacao" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Tipo de contratação do serviço de transporte (apenas para gasoduto)</xs:documentation>
+						<xs:documentation>Informar:
+0 - Ponta a ponto
+1 - Capacidade de Entrada 
+2 - Capacidade de Saida</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="0"/>
+							<xs:enumeration value="1"/>
+							<xs:enumeration value="2"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="codPontoEntrada" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Código do Ponto de Entrada</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TString">
+							<xs:minLength value="2"/>
+							<xs:maxLength value="20"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="codPontoSaida" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Código do Ponto de Saída</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TString">
+							<xs:minLength value="2"/>
+							<xs:maxLength value="20"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nContrato" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Número do Contrato de Capacidade</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TString">
+							<xs:minLength value="2"/>
+							<xs:maxLength value="20"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cteModalFerroviario_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cteModalFerroviario_v4.00.xsd
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposGeralCTe_v4.00.xsd"/>
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:complexType name="TEnderFer">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Endereço</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="xLgr">
+				<xs:annotation>
+					<xs:documentation>Logradouro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="255"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="nro" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Número</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xCpl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Complemento</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xBairro" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Bairro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cMun" type="TCodMunIBGE">
+				<xs:annotation>
+					<xs:documentation>Código do município</xs:documentation>
+					<xs:documentation> Utilizar a tabela do IBGE
+					Informar 9999999 para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMun">
+				<xs:annotation>
+					<xs:documentation>Nome do município</xs:documentation>
+					<xs:documentation>Informar EXTERIOR para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="CEP">
+				<xs:annotation>
+					<xs:documentation>CEP</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{8}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUf">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF</xs:documentation>
+					<xs:documentation>Informar EX para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="ferrov">
+		<xs:annotation>
+			<xs:documentation>Informações do modal Ferroviário</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="tpTraf">
+					<xs:annotation>
+						<xs:documentation>Tipo de Tráfego</xs:documentation>
+						<xs:documentation>Preencher com:
+						0-Próprio;
+						1-Mútuo;
+						2-Rodoferroviário;
+						3-Rodoviário.</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="0"/>
+							<xs:enumeration value="1"/>
+							<xs:enumeration value="2"/>
+							<xs:enumeration value="3"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="trafMut" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Detalhamento de informações para o tráfego mútuo</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="respFat">
+								<xs:annotation>
+									<xs:documentation>Responsável pelo Faturamento</xs:documentation>
+									<xs:documentation>Preencher com: 
+									1-Ferrovia de origem; 
+									2-Ferrovia de destino</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:enumeration value="1"/>
+										<xs:enumeration value="2"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="ferrEmi">
+								<xs:annotation>
+									<xs:documentation>Ferrovia Emitente do CTe</xs:documentation>
+									<xs:documentation>Preencher com: 
+									1-Ferrovia de origem; 
+									2-Ferrovia de destino</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:enumeration value="1"/>
+										<xs:enumeration value="2"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="vFrete" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do Frete do Tráfego Mútuo</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="chCTeFerroOrigem" type="TChDFe" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Chave de acesso do CT-e emitido pelo ferrovia de origem</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="ferroEnv" minOccurs="0" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>Informações das Ferrovias Envolvidas</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="CNPJ" type="TCnpj">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+												<xs:documentation>Informar o CNPJ da Ferrovia Envolvida. Caso a Ferrovia envolvida não seja inscrita no CNPJ o campo deverá preenchido com zeros.
+Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="cInt" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Código interno da Ferrovia envolvida</xs:documentation>
+												<xs:documentation>Uso da transportadora</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="1"/>
+													<xs:maxLength value="10"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="IE" type="TIe" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Inscrição Estadual</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="xNome">
+											<xs:annotation>
+												<xs:documentation>Razão Social ou Nome</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:maxLength value="60"/>
+													<xs:minLength value="2"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="enderFerro" type="TEnderFer">
+											<xs:annotation>
+												<xs:documentation>Dados do endereço da ferrovia envolvida</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="fluxo">
+					<xs:annotation>
+						<xs:documentation>Fluxo Ferroviário</xs:documentation>
+						<xs:documentation>Trata-se de um número identificador do contrato firmado com o cliente </xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TString">
+							<xs:minLength value="1"/>
+							<xs:maxLength value="10"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cteModalRodoviarioOS_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cteModalRodoviarioOS_v4.00.xsd
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposGeralCTe_v4.00.xsd"/>
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:simpleType name="TTermoAutFreta">
+		<xs:annotation>
+			<xs:documentation>Tipo Termo  de Autorização de Fretamento – TAF</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="12"/>
+			<xs:pattern value="[0-9]{12}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TNroRegEstadual">
+		<xs:annotation>
+			<xs:documentation>Tipo Número de Registro Estadual</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="25"/>
+			<xs:pattern value="[0-9]{25}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:element name="rodoOS">
+		<xs:annotation>
+			<xs:documentation>Informações do modal Rodoviário</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:choice>
+					<xs:element name="TAF" type="TTermoAutFreta">
+						<xs:annotation>
+							<xs:documentation>Termo de Autorização de Fretamento – TAF</xs:documentation>
+							<xs:documentation>Registro obrigatório do emitente do CT-e OS junto à ANTT, de acordo com a Resolução ANTT nº 4.777/2015</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="NroRegEstadual" type="TNroRegEstadual">
+						<xs:annotation>
+							<xs:documentation>Número do Registro Estadual </xs:documentation>
+							<xs:documentation>Registro obrigatório do emitente do CT-e OS junto à Agência Reguladora  Estadual.					</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+				</xs:choice>
+				<xs:element name="veic" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Dados do Veículo</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="placa">
+								<xs:annotation>
+									<xs:documentation>Placa do veículo </xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TPlaca"/>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="RENAVAM" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>RENAVAM do veículo </xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="9"/>
+										<xs:maxLength value="11"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="prop" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Proprietário ou possuidor do Veículo.
+Só preenchido quando o veículo não pertencer à empresa emitente do CT-e OS</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:choice>
+											<xs:element name="CPF" type="TCpf">
+												<xs:annotation>
+													<xs:documentation>Número do CPF</xs:documentation>
+													<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+											<xs:element name="CNPJ" type="TCnpjOpc">
+												<xs:annotation>
+													<xs:documentation>Número do CNPJ</xs:documentation>
+													<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+										</xs:choice>
+										<xs:choice>
+											<xs:element name="TAF" type="TTermoAutFreta">
+												<xs:annotation>
+													<xs:documentation>Termo de Autorização de Fretamento – TAF</xs:documentation>
+													<xs:documentation>De acordo com a Resolução ANTT nº 4.777/2015						</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+											<xs:element name="NroRegEstadual" type="TNroRegEstadual">
+												<xs:annotation>
+													<xs:documentation>Número do Registro Estadual </xs:documentation>
+													<xs:documentation>Registro obrigatório do emitente do CT-e OS junto à Agência Reguladora  Estadual						</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+										</xs:choice>
+										<xs:element name="xNome">
+											<xs:annotation>
+												<xs:documentation>Razão Social ou Nome do proprietário</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:maxLength value="60"/>
+													<xs:minLength value="2"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:sequence minOccurs="0">
+											<xs:element name="IE">
+												<xs:annotation>
+													<xs:documentation>Inscrição Estadual</xs:documentation>
+												</xs:annotation>
+												<xs:simpleType>
+													<xs:restriction base="TIeDest"/>
+												</xs:simpleType>
+											</xs:element>
+											<xs:element name="UF" type="TUf">
+												<xs:annotation>
+													<xs:documentation>UF</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+										</xs:sequence>
+										<xs:element name="tpProp">
+											<xs:annotation>
+												<xs:documentation>Tipo Proprietário ou possuidor</xs:documentation>
+												<xs:documentation>Preencher com:
+												0-TAC – Agregado;
+												1-TAC Independente; ou 
+												2 – Outros.</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:whiteSpace value="preserve"/>
+													<xs:enumeration value="0"/>
+													<xs:enumeration value="1"/>
+													<xs:enumeration value="2"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="UF" type="TUf" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>UF em que veículo está licenciado</xs:documentation>
+									<xs:documentation>Sigla da UF de licenciamento do veículo.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="infFretamento" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Dados do fretamento (apenas para Transporte de Pessoas)</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="tpFretamento">
+								<xs:annotation>
+									<xs:documentation>Tipo Fretamento</xs:documentation>
+									<xs:documentation>Preencher com:
+ 1 - Eventual 2 - Continuo								</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:enumeration value="1"/>
+										<xs:enumeration value="2"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="dhViagem" type="TDateTimeUTC" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Data e hora da viagem (Apenas para fretamento eventual)</xs:documentation>
+									<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cteModalRodoviario_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cteModalRodoviario_v4.00.xsd
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposGeralCTe_v4.00.xsd"/>
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="rodo">
+		<xs:annotation>
+			<xs:documentation>Informações do modal Rodoviário</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="RNTRC">
+					<xs:annotation>
+						<xs:documentation>Registro Nacional de Transportadores Rodoviários de Carga</xs:documentation>
+						<xs:documentation>Registro obrigatório do emitente do CT-e junto à ANTT para exercer a atividade de transportador rodoviário de cargas por conta de terceiros e mediante remuneração.
+						</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TRNTRC"/>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="occ" minOccurs="0" maxOccurs="10">
+					<xs:annotation>
+						<xs:documentation>Ordens de Coleta associados</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="serie" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Série da OCC</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="3"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="nOcc">
+								<xs:annotation>
+									<xs:documentation>Número da Ordem de coleta</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:pattern value="[1-9]{1}[0-9]{0,5}"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="dEmi" type="TData">
+								<xs:annotation>
+									<xs:documentation>Data de emissão da ordem de coleta</xs:documentation>
+									<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="emiOcc">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="CNPJ" type="TCnpj">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+												<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="cInt" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Código interno de uso da transportadora</xs:documentation>
+												<xs:documentation>Uso intermo das transportadoras.</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="1"/>
+													<xs:maxLength value="10"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="IE" type="TIe">
+											<xs:annotation>
+												<xs:documentation>Inscrição Estadual</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="UF" type="TUf">
+											<xs:annotation>
+												<xs:documentation>Sigla da UF</xs:documentation>
+												<xs:documentation>Informar EX para operações com o exterior.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="fone" type="TFone" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Telefone</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cteMultiModal_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cteMultiModal_v4.00.xsd
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposGeralCTe_v4.00.xsd"/>
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="multimodal">
+		<xs:annotation>
+			<xs:documentation>Informações do Multimodal</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="COTM">
+					<xs:annotation>
+						<xs:documentation>Número do Certificado do Operador de Transporte Multimodal</xs:documentation>
+						<xs:documentation/>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:minLength value="1"/>
+							<xs:maxLength value="20"/>
+							<xs:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="indNegociavel">
+					<xs:annotation>
+						<xs:documentation>Indicador Negociável
+Preencher com: 0 - Não Negociável; 1 - Negociável</xs:documentation>
+						<xs:documentation/>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="0"/>
+							<xs:enumeration value="1"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="seg" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Informações de Seguro do Multimodal</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="infSeg">
+								<xs:annotation>
+									<xs:documentation>Informações da seguradora</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="xSeg">
+											<xs:annotation>
+												<xs:documentation>Nome da Seguradora</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="1"/>
+													<xs:maxLength value="30"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="CNPJ" type="TCnpjOpc">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ da seguradora</xs:documentation>
+												<xs:documentation>Obrigatório apenas se responsável pelo seguro for (2) responsável pela contratação do transporte - pessoa jurídica</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="nApol">
+								<xs:annotation>
+									<xs:documentation>Número da Apólice</xs:documentation>
+									<xs:documentation>Obrigatório pela lei 11.442/07 (RCTRC)</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="20"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="nAver">
+								<xs:annotation>
+									<xs:documentation>Número da Averbação</xs:documentation>
+									<xs:documentation>Não é obrigatório, pois muitas averbações ocorrem aapós a emissão do CT, mensalmente, por exemplo.</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="20"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cteOS_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cteOS_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="CTeOS" type="TCTeOS">
+		<xs:annotation>
+			<xs:documentation>Conhecimento de Transporte Eletrônico Outros Serviços</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cteSimp_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cteSimp_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="CTeSimp" type="TCTeSimp">
+		<xs:annotation>
+			<xs:documentation>Conhecimento de Transporte Eletrônico Simplificado</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cteTiposBasico_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cteTiposBasico_v4.00.xsd
@@ -1,0 +1,8038 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2014 rel. 2 (http://www.altova.com) by private (private) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v1.01.xsd"/>
+	<xs:include schemaLocation="tiposGeralCTe_v4.00.xsd"/>
+	<xs:include schemaLocation="DFeTiposBasicos_v1.00.xsd"/>
+	<xs:simpleType name="TModTranspGTVe">
+		<xs:annotation>
+			<xs:documentation> Tipo Modal transporte GTVe</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="01"/>
+			<xs:enumeration value="06"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TFinGTVe">
+		<xs:annotation>
+			<xs:documentation>Tipo Finalidade da GTV-e</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="TGTVe">
+		<xs:annotation>
+			<xs:documentation>Tipo Guia de Transporte de Valores Eletrônica (Modelo 64)</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infCte">
+				<xs:annotation>
+					<xs:documentation>Informações do CT-e do tipo GTV-e</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ide">
+							<xs:annotation>
+								<xs:documentation>Identificação da GTV-e </xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="cUF" type="TCodUfIBGE">
+										<xs:annotation>
+											<xs:documentation>Código da UF do emitente da GTV-e.</xs:documentation>
+											<xs:documentation>Utilizar a Tabela do IBGE.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="cCT">
+										<xs:annotation>
+											<xs:documentation>Código numérico que compõe a Chave de Acesso. </xs:documentation>
+											<xs:documentation>Número aleatório gerado pelo emitente para cada CT-e, com o objetivo de evitar acessos indevidos ao documento.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{8}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="CFOP" type="TCfop">
+										<xs:annotation>
+											<xs:documentation>Código Fiscal de Operações e Prestações</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="natOp">
+										<xs:annotation>
+											<xs:documentation>Natureza da Operação</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="mod" type="TModGTVe">
+										<xs:annotation>
+											<xs:documentation>Modelo do documento fiscal</xs:documentation>
+											<xs:documentation>Utilizar o código 64 para identificação do CT-e Guia de Transporte de Valores</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="serie">
+										<xs:annotation>
+											<xs:documentation>Série da GTV-e</xs:documentation>
+											<xs:documentation>Preencher com "0" no caso de série única</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TSerie"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="nCT" type="TNF">
+										<xs:annotation>
+											<xs:documentation>Número da GTV-e</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="dhEmi">
+										<xs:annotation>
+											<xs:documentation>Data e hora de emissão da GTV-e</xs:documentation>
+											<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TDateTimeUTC"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpImp">
+										<xs:annotation>
+											<xs:documentation>Formato de impressão do DACTE</xs:documentation>
+											<xs:documentation>Preencher com: 1 - Retrato; 2 - Paisagem.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpEmis">
+										<xs:annotation>
+											<xs:documentation>Forma de emissão da GTV-e</xs:documentation>
+											<xs:documentation>Preencher com:
+1 - Normal;
+2- Contingencia offline </xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cDV">
+										<xs:annotation>
+											<xs:documentation>Digito Verificador da chave de acesso da GTV-e</xs:documentation>
+											<xs:documentation>Informar o dígito  de controle da chave de acesso do CT-e, que deve ser calculado com a aplicação do algoritmo módulo 11 (base 2,9) da chave de acesso. </xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{1}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpAmb" type="TAmb">
+										<xs:annotation>
+											<xs:documentation>Tipo do Ambiente</xs:documentation>
+											<xs:documentation>Preencher com:1 - Produção; 2 - Homologação</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpCTe">
+										<xs:annotation>
+											<xs:documentation>Tipo da GTV-e</xs:documentation>
+											<xs:documentation>Preencher com:
+ 4 - GTV-e</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TFinGTVe"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="verProc">
+										<xs:annotation>
+											<xs:documentation>Versão do processo de emissão</xs:documentation>
+											<xs:documentation>Iinformar a versão do aplicativo emissor de CT-e.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="20"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cMunEnv" type="TCodMunIBGE">
+										<xs:annotation>
+											<xs:documentation>Código do Município de envio da GTV-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Utilizar a tabela do IBGE. Informar 9999999 para as operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="xMunEnv">
+										<xs:annotation>
+											<xs:documentation>Nome do Município de envio da GTV-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Informar PAIS/Municipio para as operações com o exterior.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="UFEnv" type="TUf">
+										<xs:annotation>
+											<xs:documentation>Sigla da UF de envio da GTV-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="modal">
+										<xs:annotation>
+											<xs:documentation>Modal da GTV-e</xs:documentation>
+											<xs:documentation>Preencher com:
+01-Rodoviário 
+06-Multimodal</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TModTranspGTVe">
+												<xs:enumeration value="01"/>
+												<xs:enumeration value="06"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpServ">
+										<xs:annotation>
+											<xs:documentation>Tipo do Serviço</xs:documentation>
+											<xs:documentation>Preencher com: 
+
+9 - GTV</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="9"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="indIEToma">
+										<xs:annotation>
+											<xs:documentation>Indicador da IE do tomador:
+1 – Contribuinte ICMS;
+2 – Contribuinte isento de inscrição;
+9 – Não Contribuinte</xs:documentation>
+											<xs:documentation>Aplica-se ao tomador que for indicado no toma3 ou toma4</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="9"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="dhSaidaOrig">
+										<xs:annotation>
+											<xs:documentation>Data e hora de saida da origem</xs:documentation>
+											<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TDateTimeUTC"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="dhChegadaDest">
+										<xs:annotation>
+											<xs:documentation>Data e hora de chegada no destino</xs:documentation>
+											<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TDateTimeUTC"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:choice>
+										<xs:element name="toma">
+											<xs:annotation>
+												<xs:documentation>Indicador do "papel" do tomador do serviço no GT-e</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="toma">
+														<xs:annotation>
+															<xs:documentation>Tomador do Serviço</xs:documentation>
+															<xs:documentation>Preencher com:
+															0-Remetente;
+															1-Destinatário
+															</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:whiteSpace value="preserve"/>
+																<xs:enumeration value="0"/>
+																<xs:enumeration value="1"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="tomaTerceiro">
+											<xs:annotation>
+												<xs:documentation>Indicador do "papel" do tomador do serviço no CTV-e</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="toma">
+														<xs:annotation>
+															<xs:documentation>Tomador do Serviço</xs:documentation>
+															<xs:documentation>Preencher com: 
+															4 - Outros
+															Obs: Informar os dados cadastrais do tomador do serviço</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:whiteSpace value="preserve"/>
+																<xs:enumeration value="4"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:choice>
+														<xs:element name="CNPJ" type="TCnpjOpc">
+															<xs:annotation>
+																<xs:documentation>Número do CNPJ</xs:documentation>
+																<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.															
+Informar os zeros não significativos.</xs:documentation>
+															</xs:annotation>
+														</xs:element>
+														<xs:element name="CPF" type="TCpf">
+															<xs:annotation>
+																<xs:documentation>Número do CPF</xs:documentation>
+																<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+															</xs:annotation>
+														</xs:element>
+													</xs:choice>
+													<xs:element name="IE" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Inscrição Estadual</xs:documentation>
+															<xs:documentation>Informar a IE do tomador ou ISENTO se tomador é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o tomador não seja contribuinte do ICMS não informar o conteúdo.</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TIeDest"/>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="xNome">
+														<xs:annotation>
+															<xs:documentation>Razão Social ou Nome</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:maxLength value="60"/>
+																<xs:minLength value="2"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="xFant" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Nome Fantasia</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:maxLength value="60"/>
+																<xs:minLength value="2"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="fone" type="TFone" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Telefone</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="enderToma" type="TEndereco">
+														<xs:annotation>
+															<xs:documentation>Dados do endereço</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="email" type="TEmail" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Endereço de email</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+									</xs:choice>
+									<xs:sequence minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informar apenas
+para tpEmis diferente de 1</xs:documentation>
+										</xs:annotation>
+										<xs:element name="dhCont" type="TDateTimeUTC">
+											<xs:annotation>
+												<xs:documentation>Data e Hora da entrada em contingência</xs:documentation>
+												<xs:documentation>Informar a data e hora no formato AAAA-MM-DDTHH:MM:SS</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="xJust">
+											<xs:annotation>
+												<xs:documentation>Justificativa da entrada em contingência</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="15"/>
+													<xs:maxLength value="256"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="compl" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Dados complementares da GTV-e para fins operacionais ou comerciais</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="xCaracAd" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Característica adicional do transporte</xs:documentation>
+											<xs:documentation>Texto livre:
+REENTREGA; DEVOLUÇÃO; REFATURAMENTO; etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="15"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xCaracSer" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Característica adicional do serviço</xs:documentation>
+											<xs:documentation>Texto livre:
+											ENTREGA EXPRESSA; LOGÍSTICA REVERSA; CONVENCIONAL; EMERGENCIAL; etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="30"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xEmi" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Funcionário emissor da GTV-e</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="20"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xObs" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Observações Gerais</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="2000"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="ObsCont" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Campo de uso livre do contribuinte</xs:documentation>
+											<xs:documentation>Informar o nome do campo no atributo xCampo e o conteúdo do campo no XTexto</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xTexto">
+													<xs:annotation>
+														<xs:documentation>Conteúdo do campo</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="160"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="xCampo" use="required">
+												<xs:annotation>
+													<xs:documentation>Identificação do campo</xs:documentation>
+												</xs:annotation>
+												<xs:simpleType>
+													<xs:restriction base="TString">
+														<xs:minLength value="1"/>
+														<xs:maxLength value="20"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="ObsFisco" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Campo de uso livre do contribuinte</xs:documentation>
+											<xs:documentation>Informar o nome do campo no atributo xCampo e o conteúdo do campo no XTexto</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xTexto">
+													<xs:annotation>
+														<xs:documentation>Conteúdo do campo</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="xCampo" use="required">
+												<xs:annotation>
+													<xs:documentation>Identificação do campo</xs:documentation>
+												</xs:annotation>
+												<xs:simpleType>
+													<xs:restriction base="TString">
+														<xs:minLength value="1"/>
+														<xs:maxLength value="20"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="emit">
+							<xs:annotation>
+								<xs:documentation>Identificação do Emitente da GTV-e </xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="CNPJ" type="TCnpj">
+										<xs:annotation>
+											<xs:documentation>CNPJ do emitente</xs:documentation>
+											<xs:documentation>Informar zeros não significativos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="IE">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual do Emitente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIe"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="IEST" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual do Substituto Tributário</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIe"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão social ou Nome do emitente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xFant" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Nome fantasia</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="enderEmit" type="TEndeEmi">
+										<xs:annotation>
+											<xs:documentation>Endereço do emitente</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="rem">
+							<xs:annotation>
+								<xs:documentation>Informações do Remetente </xs:documentation>
+								<xs:documentation>Poderá não ser informado para os CT-e de redespacho intermediário e serviço vinculado a multimodal. Nos demais casos deverá sempre ser informado.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpjOpc">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+												<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.
+												Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>Número do CPF</xs:documentation>
+												<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="IE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual</xs:documentation>
+											<xs:documentation>Informar a IE do remetente ou ISENTO se remetente é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o remetente não seja contribuinte do ICMS não informar a tag.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIeDest"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão social ou nome do remetente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xFant" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Nome fantasia</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fone" type="TFone" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Telefone</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="enderReme" type="TEndereco">
+										<xs:annotation>
+											<xs:documentation>Dados do endereço</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="email" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Endereço de email</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TEmail"/>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="dest">
+							<xs:annotation>
+								<xs:documentation>Informações do Destinatário </xs:documentation>
+								<xs:documentation>Poderá não ser informado para os CT-e de redespacho intermediário e serviço vinculado a multimodal. Nos demais casos deverá sempre ser informado.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpjOpc">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+												<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.
+												Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>Número do CPF</xs:documentation>
+												<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="IE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual</xs:documentation>
+											<xs:documentation>Informar a IE do destinatário ou ISENTO se destinatário é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o destinatário não seja contribuinte do ICMS não informar o conteúdo.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIeDest"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão Social ou Nome do destinatário</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fone" type="TFone" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Telefone</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="ISUF" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição na SUFRAMA</xs:documentation>
+											<xs:documentation>(Obrigatório nas operações com as áreas com benefícios de incentivos fiscais sob controle da SUFRAMA)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{8,9}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="enderDest" type="TEndereco">
+										<xs:annotation>
+											<xs:documentation>Dados do endereço</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="email" type="TEmail" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Endereço de email</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="origem" type="TEndeEmi" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do endereço da origem do serviço</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="destino" type="TEndeEmi" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do endereço do destino do serviço</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="detGTV">
+							<xs:annotation>
+								<xs:documentation>Grupo de informações detalhadas da GTV-e </xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="infEspecie" maxOccurs="unbounded">
+										<xs:annotation>
+											<xs:documentation>Informações das Espécies transportadas</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="tpEspecie">
+													<xs:annotation>
+														<xs:documentation>Tipo da Espécie</xs:documentation>
+														<xs:documentation>1 - Cédula
+2 - Cheque
+3 - Moeda
+4 - Outros</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:enumeration value="1"/>
+															<xs:enumeration value="2"/>
+															<xs:enumeration value="3"/>
+															<xs:enumeration value="4"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="vEspecie" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Transportada em Espécie indicada</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="tpNumerario">
+													<xs:annotation>
+														<xs:documentation>Nacionalidade do Numerário</xs:documentation>
+														<xs:documentation>1 - Nacional
+2 - Estrangeiro</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:enumeration value="1"/>
+															<xs:enumeration value="2"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="xMoedaEstr" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Nome da Moeda</xs:documentation>
+														<xs:documentation>Informar somente se tipo de numerário for 2 - Estrangeiro</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="60"/>
+															<xs:minLength value="2"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="qCarga" type="TDec_1104">
+										<xs:annotation>
+											<xs:documentation>Quantidade de volumes/malotes</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="infVeiculo" maxOccurs="unbounded">
+										<xs:annotation>
+											<xs:documentation>Grupo de informações dos veículos utilizados no transporte de valores</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="placa" type="TPlaca">
+													<xs:annotation>
+														<xs:documentation>Placa do veículo </xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="UF" type="TUf" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>UF em que veículo está licenciado</xs:documentation>
+														<xs:documentation>Sigla da UF de licenciamento do veículo.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="RNTRC" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>RNTRC do transportador</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="[0-9]{8}|ISENTO"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="autXML" minOccurs="0" maxOccurs="10">
+							<xs:annotation>
+								<xs:documentation>Autorizados para download do XML do DF-e</xs:documentation>
+								<xs:documentation>Informar CNPJ ou CPF. Preencher os zeros não significativos.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpj">
+											<xs:annotation>
+												<xs:documentation>CNPJ do autorizado</xs:documentation>
+												<xs:documentation>Informar zeros não significativos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>CPF do autorizado</xs:documentation>
+												<xs:documentation>Informar zeros não significativos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infRespTec" type="TRespTec" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do Responsável Técnico pela emissão do DF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="versao" use="required">
+						<xs:annotation>
+							<xs:documentation>Versão do leiaute</xs:documentation>
+							<xs:documentation>Ex: "4.00"</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="TVerCTe"/>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="Id" use="required">
+						<xs:annotation>
+							<xs:documentation>Identificador da tag a ser assinada</xs:documentation>
+							<xs:documentation>Informar a chave de acesso do CT-e OS e precedida do literal "CTe"</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:ID">
+								<xs:pattern value="CTe[0-9]{6}[A-Z0-9]{12}[0-9]{26}"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="infCTeSupl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informações suplementares da GTV-e</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="qrCodCTe">
+							<xs:annotation>
+								<xs:documentation>Texto com o QR-Code impresso no DACTE</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:minLength value="50"/>
+									<xs:maxLength value="1000"/>
+									<xs:pattern value="((HTTPS?|https?)://.*\?chCTe=[0-9]{44}&amp;tpAmb=[1-2](&amp;sign=[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1})?)"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature"/>
+		</xs:sequence>
+		<xs:attribute name="versao" use="required">
+			<xs:annotation>
+				<xs:documentation>Versão do leiaute</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="TVerCTe"/>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="TProtCTe">
+		<xs:annotation>
+			<xs:documentation>Tipo Protocolo de status resultado do processamento da CT-e</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infProt">
+				<xs:annotation>
+					<xs:documentation>Dados do protocolo de status</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="verAplic" type="TVerAplic">
+							<xs:annotation>
+								<xs:documentation>Versão do Aplicativo que processou o CT-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="chCTe" type="TChDFe">
+							<xs:annotation>
+								<xs:documentation>Chaves de acesso da CT-e, </xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="dhRecbto" type="TDateTimeUTC">
+							<xs:annotation>
+								<xs:documentation>Data e hora de processamento, no formato AAAA-MM-DDTHH:MM:SS TZD. </xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nProt" type="TProt" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número do Protocolo de Status do CT-e. </xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="digVal" type="ds:DigestValueType" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Digest Value da CT-e processado. Utilizado para conferir a integridade do CT-e original.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cStat">
+							<xs:annotation>
+								<xs:documentation>Código do status do CT-e.</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TStat"/>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="xMotivo" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Descrição literal do status do CT-e.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" type="xs:ID" use="optional"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="infFisco" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Mensagem do Fisco</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="cMsg">
+							<xs:annotation>
+								<xs:documentation>Código do status da mensagem do fisco</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TStat"/>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="xMsg" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Mensagem do Fisco</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="versao" use="required">
+			<xs:simpleType>
+				<xs:restriction base="TVerCTe"/>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="TProtCTeOS">
+		<xs:annotation>
+			<xs:documentation>Tipo Protocolo de status resultado do processamento do CT-e OS (Modelo 67)</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infProt">
+				<xs:annotation>
+					<xs:documentation>Dados do protocolo de status</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="verAplic" type="TVerAplic">
+							<xs:annotation>
+								<xs:documentation>Versão do Aplicativo que processou o CT-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="chCTe" type="TChDFe">
+							<xs:annotation>
+								<xs:documentation>Chaves de acesso da CT-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="dhRecbto" type="TDateTimeUTC">
+							<xs:annotation>
+								<xs:documentation>Data e hora de processamento, no formato AAAA-MM-DDTHH:MM:SS TZD. </xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nProt" type="TProt" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número do Protocolo de Status do CT-e.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="digVal" type="ds:DigestValueType" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Digest Value da CT-e processado. Utilizado para conferir a integridade do CT-e original.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cStat">
+							<xs:annotation>
+								<xs:documentation>Código do status do CT-e.</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TStat"/>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="xMotivo" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Descrição literal do status do CT-e.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" type="xs:ID" use="optional"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="infFisco" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Mensagem do Fisco</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="cMsg">
+							<xs:annotation>
+								<xs:documentation>Código do status da mensagem do fisco</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TStat"/>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="xMsg" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Mensagem do Fisco</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="versao" use="required">
+			<xs:simpleType>
+				<xs:restriction base="TVerCTe"/>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="TProtGTVe">
+		<xs:annotation>
+			<xs:documentation>Tipo Protocolo de status resultado do processamento da GTV-e (Modelo 64)</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infProt">
+				<xs:annotation>
+					<xs:documentation>Dados do protocolo de status</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="verAplic" type="TVerAplic">
+							<xs:annotation>
+								<xs:documentation>Versão do Aplicativo que processou a GTV-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="chCTe" type="TChDFe">
+							<xs:annotation>
+								<xs:documentation>Chaves de acesso da CT-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="dhRecbto" type="TDateTimeUTC">
+							<xs:annotation>
+								<xs:documentation>Data e hora de processamento, no formato AAAA-MM-DDTHH:MM:SS TZD. </xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nProt" type="TProt" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número do Protocolo de Status da GTV-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="digVal" type="ds:DigestValueType" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Digest Value da GTV-e processado. Utilizado para conferir a integridade da GTV-e original.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cStat">
+							<xs:annotation>
+								<xs:documentation>Código do status da GTV-e.</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TStat"/>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="xMotivo" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Descrição literal do status da GTV-e.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" type="xs:ID" use="optional"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="infFisco" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Mensagem do Fisco</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="cMsg">
+							<xs:annotation>
+								<xs:documentation>Código do status da mensagem do fisco</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TStat"/>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="xMsg" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Mensagem do Fisco</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="versao" use="required">
+			<xs:simpleType>
+				<xs:restriction base="TVerCTe"/>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="TRetCTeSimp">
+		<xs:annotation>
+			<xs:documentation>Tipo Retorno do Pedido de Autorização de CT-e Simplificado (Modelo 57)</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>Identificação da UF</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="verAplic" type="TVerAplic">
+				<xs:annotation>
+					<xs:documentation>Versão do Aplicativo que processou a CT-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cStat" type="TStat">
+				<xs:annotation>
+					<xs:documentation>código do status do retorno da consulta.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMotivo" type="TMotivo">
+				<xs:annotation>
+					<xs:documentation>Descrição literal do status do do retorno da consulta.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="protCTe" type="TProtCTe" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Reposta ao processamento do CT-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerCTe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetCTe">
+		<xs:annotation>
+			<xs:documentation>Tipo Retorno do Pedido de Autorização de CT-e (Modelo 57)</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>Identificação da UF</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="verAplic" type="TVerAplic">
+				<xs:annotation>
+					<xs:documentation>Versão do Aplicativo que processou a CT-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cStat">
+				<xs:annotation>
+					<xs:documentation>código do status do retorno da consulta.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TStat">
+						<xs:pattern value="[0-9]{3}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xMotivo" type="TMotivo">
+				<xs:annotation>
+					<xs:documentation>Descrição literal do status do do retorno da consulta.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="protCTe" type="TProtCTe" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Reposta ao processamento do CT-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerCTe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetGTVe">
+		<xs:annotation>
+			<xs:documentation>Tipo Retorno do Pedido de Autorização de GTV-e (Modelo 64)</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>Identificação da UF</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="verAplic" type="TVerAplic">
+				<xs:annotation>
+					<xs:documentation>Versão do Aplicativo que processou a GTV-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cStat" type="TStat">
+				<xs:annotation>
+					<xs:documentation>código do status do retorno da consulta.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMotivo" type="TMotivo">
+				<xs:annotation>
+					<xs:documentation>Descrição literal do status do do retorno da consulta.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="protCTe" type="TProtGTVe" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Reposta ao processamento do CT-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerCTe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetCTeOS">
+		<xs:annotation>
+			<xs:documentation>Tipo Retorno do Pedido de Autorização de CT-e OS (Modelo 67)</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>Identificação da UF</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="verAplic" type="TVerAplic">
+				<xs:annotation>
+					<xs:documentation>Versão do Aplicativo que processou a CT-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cStat" type="TStat">
+				<xs:annotation>
+					<xs:documentation>código do status do retorno da consulta.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMotivo" type="TMotivo">
+				<xs:annotation>
+					<xs:documentation>Descrição literal do status do do retorno da consulta.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="protCTe" type="TProtCTeOS" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Reposta ao processamento do CT-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerCTe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TCTeSimp">
+		<xs:annotation>
+			<xs:documentation>Tipo Conhecimento de Transporte Eletrônico (Modelo 57) - Modelo Simplificado</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infCte">
+				<xs:annotation>
+					<xs:documentation>Informações do CT-e</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ide">
+							<xs:annotation>
+								<xs:documentation>Identificação do CT-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="cUF" type="TCodUfIBGE">
+										<xs:annotation>
+											<xs:documentation>Código da UF do emitente do CT-e.</xs:documentation>
+											<xs:documentation>Utilizar a Tabela do IBGE.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="cCT">
+										<xs:annotation>
+											<xs:documentation>Código numérico que compõe a Chave de Acesso. </xs:documentation>
+											<xs:documentation>Número aleatório gerado pelo emitente para cada CT-e, com o objetivo de evitar acessos indevidos ao documento.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{8}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="CFOP" type="TCfop">
+										<xs:annotation>
+											<xs:documentation>Código Fiscal de Operações e Prestações</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="natOp">
+										<xs:annotation>
+											<xs:documentation>Natureza da Operação</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="mod" type="TModCT">
+										<xs:annotation>
+											<xs:documentation>Modelo do documento fiscal</xs:documentation>
+											<xs:documentation>Utilizar o código 57 para identificação do CT-e, emitido em substituição aos modelos de conhecimentos em papel.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="serie">
+										<xs:annotation>
+											<xs:documentation>Série do CT-e</xs:documentation>
+											<xs:documentation>Preencher com "0" no caso de série única</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TSerie"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="nCT" type="TNF">
+										<xs:annotation>
+											<xs:documentation>Número do CT-e</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="dhEmi">
+										<xs:annotation>
+											<xs:documentation>Data e hora de emissão do CT-e</xs:documentation>
+											<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TDateTimeUTC"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpImp">
+										<xs:annotation>
+											<xs:documentation>Formato de impressão do DACTE</xs:documentation>
+											<xs:documentation>Preencher com: 1 - Retrato; 2 - Paisagem.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpEmis">
+										<xs:annotation>
+											<xs:documentation>Forma de emissão do CT-e </xs:documentation>
+											<xs:documentation>Preencher com:
+1 - Normal;
+3 - Regime Especial NFF;  
+4 - EPEC pela SVC; 
+7 - Autorização pela SVC-RS;
+8 - Autorização pela SVC-SP</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="3"/>
+												<xs:enumeration value="4"/>
+												<xs:enumeration value="7"/>
+												<xs:enumeration value="8"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cDV">
+										<xs:annotation>
+											<xs:documentation>Digito Verificador da chave de acesso do CT-e</xs:documentation>
+											<xs:documentation>Informar o dígito  de controle da chave de acesso do CT-e, que deve ser calculado com a aplicação do algoritmo módulo 11 (base 2,9) da chave de acesso. </xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{1}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpAmb" type="TAmb">
+										<xs:annotation>
+											<xs:documentation>Tipo do Ambiente</xs:documentation>
+											<xs:documentation>Preencher com:1 - Produção; 2 - Homologação.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpCTe" type="TFinCTeSimp">
+										<xs:annotation>
+											<xs:documentation>Tipo do CT-e Simplificado</xs:documentation>
+											<xs:documentation>Preencher com:
+5 - CTe Simplificado
+6 - Substituição CTe Simplificado</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="procEmi" type="TProcEmi">
+										<xs:annotation>
+											<xs:documentation>Identificador do processo de emissão do CT-e</xs:documentation>
+											<xs:documentation>Preencher com: 
+											0 - emissão de CT-e com aplicativo do contribuinte;
+											3- emissão CT-e pelo contribuinte com aplicativo fornecido pelo SEBRAE.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="verProc">
+										<xs:annotation>
+											<xs:documentation>Versão do processo de emissão</xs:documentation>
+											<xs:documentation>Informar a versão do aplicativo emissor de CT-e.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="20"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cMunEnv" type="TCodMunIBGE">
+										<xs:annotation>
+											<xs:documentation>Código do Município de envio do CT-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Utilizar a tabela do IBGE. Informar 9999999 para as operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="xMunEnv">
+										<xs:annotation>
+											<xs:documentation>Nome do Município de envio do CT-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Informar PAIS/Municipio para as operações com o exterior.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="UFEnv" type="TUf">
+										<xs:annotation>
+											<xs:documentation>Sigla da UF de envio do CT-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="modal" type="TModTranspSimp">
+										<xs:annotation>
+											<xs:documentation>Modal</xs:documentation>
+											<xs:documentation>Preencher com:
+01-Rodoviário
+02-Aéreo
+03-Aquaviário</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpServ">
+										<xs:annotation>
+											<xs:documentation>Tipo do Serviço</xs:documentation>
+											<xs:documentation>Preencher com: 
+0 - Normal;
+1 - Subcontratação;
+2 - Redespacho;</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="UFIni" type="TUf">
+										<xs:annotation>
+											<xs:documentation>UF do início da prestação</xs:documentation>
+											<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="UFFim" type="TUf">
+										<xs:annotation>
+											<xs:documentation>UF do término da prestação</xs:documentation>
+											<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="retira">
+										<xs:annotation>
+											<xs:documentation>Indicador se o Recebedor retira no Aeroporto, Filial, Porto ou Estação de Destino?</xs:documentation>
+											<xs:documentation>Preencher com: 0 - sim; 1 - não</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xDetRetira" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Detalhes do retira</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="160"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:sequence minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informar apenas
+para tpEmis diferente de 1</xs:documentation>
+										</xs:annotation>
+										<xs:element name="dhCont" type="TDateTimeUTC">
+											<xs:annotation>
+												<xs:documentation>Data e Hora da entrada em contingência</xs:documentation>
+												<xs:documentation>Informar a data e hora no formato AAAA-MM-DDTHH:MM:SS</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="xJust">
+											<xs:annotation>
+												<xs:documentation>Justificativa da entrada em contingência</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="15"/>
+													<xs:maxLength value="256"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+									<xs:element name="gCompraGov" type="TCompraGovReduzido" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Grupo de Compras Governamentais</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="compl" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Dados complementares do CT-e para fins operacionais ou comerciais</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="xCaracAd" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Característica adicional do transporte</xs:documentation>
+											<xs:documentation>Texto livre:
+REENTREGA; DEVOLUÇÃO; REFATURAMENTO; etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="15"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xCaracSer" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Característica adicional do serviço</xs:documentation>
+											<xs:documentation>Texto livre:
+											ENTREGA EXPRESSA; LOGÍSTICA REVERSA; CONVENCIONAL; EMERGENCIAL; etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="30"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fluxo" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Previsão do fluxo da carga</xs:documentation>
+											<xs:documentation>Preenchimento obrigatório para o modal aéreo.</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xOrig" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Sigla ou código interno da Filial/Porto/Estação/ Aeroporto de Origem</xs:documentation>
+														<xs:documentation>Observações para o modal aéreo:
+														- Preenchimento obrigatório para o modal aéreo.
+														- O código de três letras IATA do aeroporto de partida deverá ser incluído como primeira anotação. Quando não for possível, utilizar a sigla OACI.</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="pass" minOccurs="0" maxOccurs="unbounded">
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="xPass" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Sigla ou código interno da Filial/Porto/Estação/Aeroporto de Passagem</xs:documentation>
+																	<xs:documentation>Observação para o modal aéreo:
+																	- O código de três letras IATA, referente ao aeroporto de transferência, deverá ser incluído, quando for o caso. Quando não for possível,  utilizar a sigla OACI. Qualquer solicitação de itinerário deverá ser incluída.</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="15"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="xDest" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Sigla ou código interno da Filial/Porto/Estação/Aeroporto de Destino</xs:documentation>
+														<xs:documentation>Observações para o modal aéreo:
+														- Preenchimento obrigatório para o modal aéreo.
+														- Deverá ser incluído o código de três letras IATA do aeroporto de destino. Quando não for possível, utilizar a sigla OACI.</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="xRota" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Código da Rota de Entrega</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="10"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="xObs" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Observações Gerais</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="2000"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="ObsCont" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Campo de uso livre do contribuinte</xs:documentation>
+											<xs:documentation>Informar o nome do campo no atributo xCampo e o conteúdo do campo no XTexto</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xTexto">
+													<xs:annotation>
+														<xs:documentation>Conteúdo do campo</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="160"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="xCampo" use="required">
+												<xs:annotation>
+													<xs:documentation>Identificação do campo</xs:documentation>
+												</xs:annotation>
+												<xs:simpleType>
+													<xs:restriction base="TString">
+														<xs:minLength value="1"/>
+														<xs:maxLength value="20"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="ObsFisco" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Campo de uso livre do contribuinte</xs:documentation>
+											<xs:documentation>Informar o nome do campo no atributo xCampo e o conteúdo do campo no XTexto</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xTexto">
+													<xs:annotation>
+														<xs:documentation>Conteúdo do campo</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="xCampo" use="required">
+												<xs:annotation>
+													<xs:documentation>Identificação do campo</xs:documentation>
+												</xs:annotation>
+												<xs:simpleType>
+													<xs:restriction base="TString">
+														<xs:minLength value="1"/>
+														<xs:maxLength value="20"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="emit">
+							<xs:annotation>
+								<xs:documentation>Identificação do Emitente do CT-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpj">
+											<xs:annotation>
+												<xs:documentation>CNPJ do emitente</xs:documentation>
+												<xs:documentation>Informar zeros não significativos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>CPF do emitente</xs:documentation>
+												<xs:documentation>Informar zeros não significativos.
+
+Usar com série específica 920-969 para emitente pessoa física com inscrição estadual</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="IE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual do Emitente</xs:documentation>
+											<xs:documentation>A IE do emitente somente ficará sem informação para o caso do Regime Especial da NFF (tpEmis=3)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIe"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="IEST" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual do Substituto Tributário</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIe"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão social ou Nome do emitente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xFant" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Nome fantasia</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="enderEmit" type="TEndeEmi">
+										<xs:annotation>
+											<xs:documentation>Endereço do emitente</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="CRT" type="TCRT">
+										<xs:annotation>
+											<xs:documentation>Código do Regime Tributário</xs:documentation>
+											<xs:documentation>Informar: 1=Simples Nacional; 
+2=Simples Nacional, excesso sublimite de receita bruta;
+3=Regime Normal. 
+4=Simples Nacional - Microempreendedor Individual – MEI.
+</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="toma">
+							<xs:annotation>
+								<xs:documentation>Identificação do tomador do serviço no CT-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="toma">
+										<xs:annotation>
+											<xs:documentation>Tomador do Serviço</xs:documentation>
+											<xs:documentation>Preencher com:
+
+0-Remetente;
+1-Expedidor;
+2-Recebedor;
+3-Destinatário
+4-Terceiro</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="3"/>
+												<xs:enumeration value="4"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="indIEToma">
+										<xs:annotation>
+											<xs:documentation>Indicador do papel do tomador na prestação do serviço:
+1 – Contribuinte ICMS;
+2 – Contribuinte isento de inscrição;
+9 – Não Contribuinte</xs:documentation>
+											<xs:documentation>Aplica-se ao tomador que for indicado no toma</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="9"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpjOpc">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+												<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.															
+Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>Número do CPF</xs:documentation>
+												<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="IE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual</xs:documentation>
+											<xs:documentation>Informar a IE do tomador ou ISENTO se tomador é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o tomador não seja contribuinte do ICMS não informar o conteúdo.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIeDest"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão Social ou Nome</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="ISUF" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição na SUFRAMA</xs:documentation>
+											<xs:documentation>(Obrigatório nas operações com as áreas com benefícios de incentivos fiscais sob controle da SUFRAMA)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{8,9}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fone" type="TFone" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Telefone</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="enderToma" type="TEndereco">
+										<xs:annotation>
+											<xs:documentation>Dados do endereço</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="email" type="TEmail" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Endereço de email</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infCarga">
+							<xs:annotation>
+								<xs:documentation>Informações da Carga do CT-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vCarga" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor total da carga</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="proPred">
+										<xs:annotation>
+											<xs:documentation>Produto predominante</xs:documentation>
+											<xs:documentation>Informar a descrição do produto predominante</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xOutCat" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Outras características da carga</xs:documentation>
+											<xs:documentation>"FRIA", "GRANEL", "REFRIGERADA", "Medidas: 12X12X12"</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="30"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="infQ" maxOccurs="unbounded">
+										<xs:annotation>
+											<xs:documentation>Informações de quantidades da Carga do CT-e</xs:documentation>
+											<xs:documentation>Para o Aéreo é obrigatório o preenchimento desse campo da seguinte forma.
+1 - Peso Bruto, sempre em quilogramas (obrigatório);
+2 - Peso Cubado; sempre em quilogramas;
+3 - Quantidade de volumes, sempre em unidades (obrigatório);
+4 - Cubagem, sempre em metros cúbicos (obrigatório apenas quando for impossível preencher as dimensões da(s) embalagem(ens) na tag xDime do leiaute do Aéreo).</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="cUnid">
+													<xs:annotation>
+														<xs:documentation>Código da Unidade de Medida </xs:documentation>
+														<xs:documentation>Preencher com:
+00-M3;
+01-KG;
+02-TON;
+03-UNIDADE;
+04-LITROS;
+05-MMBTU</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:enumeration value="00"/>
+															<xs:enumeration value="01"/>
+															<xs:enumeration value="02"/>
+															<xs:enumeration value="03"/>
+															<xs:enumeration value="04"/>
+															<xs:enumeration value="05"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="tpMed">
+													<xs:annotation>
+														<xs:documentation>Tipo da Medida</xs:documentation>
+														<xs:documentation>Informar com:
+00-Cubagem da NF-e
+01-Cubagem Aferida pelo Transportador
+02-Peso Bruto da NF-e
+03-Peso Bruto Aferido pelo Transportador
+04-Peso Cubado
+05-Peso Base do Cálculo do Frete
+06-Peso para uso Operacional
+07-Caixas
+08-Paletes
+09-Sacas
+10-Containers
+11-Rolos
+12-Bombonas
+13-Latas
+14-Litragem
+15-Milhão de BTU (British Thermal Units)
+99-Outros</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="2"/>
+															<xs:enumeration value="00"/>
+															<xs:enumeration value="01"/>
+															<xs:enumeration value="02"/>
+															<xs:enumeration value="03"/>
+															<xs:enumeration value="04"/>
+															<xs:enumeration value="05"/>
+															<xs:enumeration value="06"/>
+															<xs:enumeration value="07"/>
+															<xs:enumeration value="08"/>
+															<xs:enumeration value="09"/>
+															<xs:enumeration value="10"/>
+															<xs:enumeration value="11"/>
+															<xs:enumeration value="12"/>
+															<xs:enumeration value="13"/>
+															<xs:enumeration value="14"/>
+															<xs:enumeration value="15"/>
+															<xs:enumeration value="99"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="qCarga" type="TDec_1104">
+													<xs:annotation>
+														<xs:documentation>Quantidade</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="vCargaAverb" type="TDec_1302Opc" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor da Carga para efeito de averbação</xs:documentation>
+											<xs:documentation>Normalmente igual ao valor declarado da mercadoria, diferente por exemplo, quando a mercadoria transportada é isenta de tributos nacionais para exportação, onde é preciso averbar um valor maior, pois no caso de indenização, o valor a ser pago será maior</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="det" maxOccurs="999">
+							<xs:annotation>
+								<xs:documentation>Detalhamento das entregas / prestações do CTe Simplificado</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:sequence>
+										<xs:element name="cMunIni" type="TCodMunIBGE">
+											<xs:annotation>
+												<xs:documentation>Código do Município de início da prestação</xs:documentation>
+												<xs:documentation>Utilizar a tabela do IBGE. Informar 9999999 para operações com o exterior.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="xMunIni">
+											<xs:annotation>
+												<xs:documentation>Nome do Município do início da prestação</xs:documentation>
+												<xs:documentation>Informar 'EXTERIOR' para operações com o exterior.</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="2"/>
+													<xs:maxLength value="60"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+									<xs:sequence>
+										<xs:element name="cMunFim" type="TCodMunIBGE">
+											<xs:annotation>
+												<xs:documentation>Código do Município de término da prestação</xs:documentation>
+												<xs:documentation>Utilizar a tabela do IBGE. Informar 9999999 para operações com o exterior.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="xMunFim">
+											<xs:annotation>
+												<xs:documentation>Nome do Município do término da prestação</xs:documentation>
+												<xs:documentation>Informar 'EXTERIOR' para operações com o exterior.</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="2"/>
+													<xs:maxLength value="60"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+									<xs:element name="vPrest" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valorl da Prestação do Serviço</xs:documentation>
+											<xs:documentation>Pode conter zeros quando o CT-e for de complemento de ICMS</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vRec" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor a Receber</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="Comp" minOccurs="0" maxOccurs="unbounded">
+										<xs:annotation>
+											<xs:documentation>Componentes do Valor da Prestação</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xNome">
+													<xs:annotation>
+														<xs:documentation>Nome do componente</xs:documentation>
+														<xs:documentation>Exxemplos: FRETE PESO, FRETE VALOR, SEC/CAT, ADEME, AGENDAMENTO, etc</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="15"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="vComp" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do componente</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:choice>
+										<xs:element name="infNFe" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>Informações das NF-e</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="chNFe">
+														<xs:annotation>
+															<xs:documentation>Chave de acesso da NF-e</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TChDFe">
+																<xs:pattern value="[0-9]{6}[A-Z0-9]{12}[0-9]{26}"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="PIN" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>PIN SUFRAMA</xs:documentation>
+															<xs:documentation>PIN atribuído pela SUFRAMA para a operação.</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:whiteSpace value="preserve"/>
+																<xs:minLength value="2"/>
+																<xs:maxLength value="9"/>
+																<xs:pattern value="[1-9]{1}[0-9]{1,8}"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="dPrev" type="TData" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Data prevista de entrega</xs:documentation>
+															<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:choice>
+														<xs:element name="infUnidCarga" type="TUnidCarga" minOccurs="0" maxOccurs="unbounded">
+															<xs:annotation>
+																<xs:documentation>Informações das Unidades de Carga (Containeres/ULD/Outros)</xs:documentation>
+																<xs:documentation>Dispositivo de carga utilizada (Unit Load Device - ULD) significa todo tipo de contêiner de carga, vagão, contêiner de avião, palete de aeronave com rede ou palete de aeronave com rede sobre um iglu. </xs:documentation>
+															</xs:annotation>
+														</xs:element>
+														<xs:element name="infUnidTransp" type="TUnidadeTransp" minOccurs="0" maxOccurs="unbounded">
+															<xs:annotation>
+																<xs:documentation>Informações das Unidades de Transporte (Carreta/Reboque/Vagão)</xs:documentation>
+																<xs:documentation>Deve ser preenchido com as informações das unidades de transporte utilizadas.</xs:documentation>
+															</xs:annotation>
+														</xs:element>
+													</xs:choice>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infDocAnt" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>Documentos anteriores</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="chCTe" type="TChDFe">
+														<xs:annotation>
+															<xs:documentation>Chave de acesso do CT-e</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="tpPrest">
+														<xs:annotation>
+															<xs:documentation>indica se a prestação é total ou parcial em relação as notas do documento anterior</xs:documentation>
+															<xs:documentation>Preencher com:
+
+1 - Total
+2 - Parcial</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:whiteSpace value="preserve"/>
+																<xs:enumeration value="1"/>
+																<xs:enumeration value="2"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="infNFeTranspParcial" minOccurs="0" maxOccurs="unbounded">
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="chNFe" type="TChDFe">
+																	<xs:annotation>
+																		<xs:documentation>Chave de acesso da NF-e</xs:documentation>
+																		<xs:documentation>Informando o tpPrest com “2 – Parcial” deve-se informar as chaves de acesso das NF-e que acobertam a carga transportada.</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+									</xs:choice>
+								</xs:sequence>
+								<xs:attribute name="nItem" use="required">
+									<xs:annotation>
+										<xs:documentation>Número identificador do item agrupador da prestação</xs:documentation>
+									</xs:annotation>
+									<xs:simpleType>
+										<xs:restriction base="xs:string">
+											<xs:whiteSpace value="preserve"/>
+											<xs:pattern value="[1-9]{1}[0-9]{0,1}|[1-8]{1}[0-9]{2}|[9]{1}[0-8]{1}[0-9]{1}|[9]{1}[9]{1}[0]{1}"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infModal">
+							<xs:annotation>
+								<xs:documentation>Informações do modal</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:any processContents="skip">
+										<xs:annotation>
+											<xs:documentation>XML do modal
+Insira neste local o XML específico do modal (rodoviário, aéreo, ferroviário, aquaviário ou dutoviário).  </xs:documentation>
+											<xs:documentation>O elemento do tipo -any- permite estender o documento XML com elementos não especificados pelo schema.
+															Insira neste local - any- o XML específico do modal (rodoviário, aéreo, ferroviário, aquaviário ou dutoviário). A especificação do schema XML para cada modal pode ser encontrada nos arquivos que acompanham este pacote de liberação:
+													Rodoviário - ver arquivo CTeModalRodoviario_v9.99
+			Aéreo - ver arquivo CTeModalAereo_v9.99
+				Aquaviário - arquivo CTeModalAquaviario_v9.99
+				Ferroviário - arquivo CTeModalFerroviario_v9.99
+				Dutoviário - arquivo CTeModalDutoviario_v9.99
+
+Onde v9.99 é a a designação genérica para a versão do arquivo. Por exemplo, o arquivo para o schema do modal Rodoviário na versão 1.04 será denominado "CTeModalRodoviario_v1.04".</xs:documentation>
+										</xs:annotation>
+									</xs:any>
+								</xs:sequence>
+								<xs:attribute name="versaoModal" use="required">
+									<xs:annotation>
+										<xs:documentation>Versão do leiaute específico para o Modal</xs:documentation>
+									</xs:annotation>
+									<xs:simpleType>
+										<xs:restriction base="xs:string">
+											<xs:whiteSpace value="preserve"/>
+											<xs:pattern value="4\.(0[0-9]|[1-9][0-9])"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="cobr" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Dados da cobrança do CT-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="fat" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Dados da fatura</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="nFat" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Número da fatura</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="vOrig" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor original da fatura</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vDesc" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor do desconto da fatura</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vLiq" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor líquido da fatura</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="dup" minOccurs="0" maxOccurs="unbounded">
+										<xs:annotation>
+											<xs:documentation>Dados das duplicatas</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="nDup" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Número da duplicata</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="60"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="dVenc" type="TData" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Data de vencimento da duplicata (AAAA-MM-DD)</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vDup" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor da duplicata</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infCteSub" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do CT-e de substituição </xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="chCte">
+										<xs:annotation>
+											<xs:documentation>Chave de acesso do CT-e a ser substituído (original)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:pattern value="[0-9]{44}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="indAlteraToma" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Indicador de CT-e Alteração de Tomador</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:enumeration value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="imp">
+							<xs:annotation>
+								<xs:documentation>Informações relativas aos Impostos</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="ICMS" type="TImp">
+										<xs:annotation>
+											<xs:documentation>Informações relativas ao ICMS</xs:documentation>
+											<xs:documentation/>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vTotTrib" type="TDec_1302" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor Total dos Tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="infAdFisco" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações adicionais de interesse do Fisco</xs:documentation>
+											<xs:documentation>Norma referenciada, informações complementares, etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="2000"/>
+												<xs:minLength value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="ICMSUFFim" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações do ICMS de partilha com a UF de término do serviço de transporte na operação interestadual</xs:documentation>
+											<xs:documentation>Grupo a ser informado nas prestações interestaduais para consumidor final, não contribuinte do ICMS</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="vBCUFFim" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor da BC do ICMS na UF de término da prestação do serviço de transporte</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pFCPUFFim" type="TDec_0302">
+													<xs:annotation>
+														<xs:documentation>Percentual do ICMS relativo ao Fundo de Combate à pobreza (FCP) na UF de término da prestação do serviço de transporte</xs:documentation>
+														<xs:documentation>Alíquota adotada nas operações internas na UF do destinatário</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pICMSUFFim" type="TDec_0302">
+													<xs:annotation>
+														<xs:documentation>Alíquota interna da UF de término da prestação do serviço de transporte</xs:documentation>
+														<xs:documentation>Alíquota adotada nas operações internas na UF do destinatário</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pICMSInter" type="TDec_0302">
+													<xs:annotation>
+														<xs:documentation>Alíquota interestadual das UF envolvidas</xs:documentation>
+														<xs:documentation>Alíquota interestadual das UF envolvidas
+</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vFCPUFFim" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS relativo ao Fundo de Combate á Pobreza (FCP) da UF de término da prestação</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSUFFim" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS de partilha para a UF de término da prestação do serviço de transporte</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSUFIni" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS de partilha para a UF de início da prestação do serviço de transporte</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="IBSCBS" type="TTribCTe" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Grupo de informações do IBS e CBS</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="total">
+							<xs:annotation>
+								<xs:documentation>Valores Totais do CTe</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vTPrest" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor Total da Prestação do Serviço</xs:documentation>
+											<xs:documentation>Pode conter zeros quando o CT-e for de complemento de ICMS</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vTRec" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor total a Receber</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vTotDFe" type="TDec_1302" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor total do documento fiscal 
+(vTPrest + total do IBS + total da CBS) 
+</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="autXML" minOccurs="0" maxOccurs="10">
+							<xs:annotation>
+								<xs:documentation>Autorizados para download do XML do DF-e</xs:documentation>
+								<xs:documentation>Informar CNPJ ou CPF. Preencher os zeros não significativos.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpj">
+											<xs:annotation>
+												<xs:documentation>CNPJ do autorizado</xs:documentation>
+												<xs:documentation>Informar zeros não significativos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>CPF do autorizado</xs:documentation>
+												<xs:documentation>Informar zeros não significativos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infRespTec" type="TRespTec" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do Responsável Técnico pela emissão do DF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="infSolicNFF" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de informações do pedido de emissão da Nota Fiscal Fácil</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="xSolic">
+										<xs:annotation>
+											<xs:documentation>Solicitação do pedido de emissão da NFF.</xs:documentation>
+											<xs:documentation>Será preenchido com a totalidade de campos informados no aplicativo emissor serializado.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="8000"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infPAA" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de Informação do Provedor de Assinatura e Autorização</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="CNPJPAA" type="TCnpj">
+										<xs:annotation>
+											<xs:documentation>CNPJ do Provedor de Assinatura e Autorização</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="PAASignature">
+										<xs:annotation>
+											<xs:documentation>Assinatura RSA do Emitente para DFe gerados por PAA</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="SignatureValue" type="xs:base64Binary">
+													<xs:annotation>
+														<xs:documentation>Assinatura digital padrão RSA</xs:documentation>
+														<xs:documentation>Converter o atributo Id do DFe para array de bytes e assinar com a chave privada do RSA com algoritmo SHA1 gerando um valor no formato base64.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="RSAKeyValue" type="TRSAKeyValueType">
+													<xs:annotation>
+														<xs:documentation>Chave Publica no padrão XML RSA Key</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="versao" use="required">
+						<xs:annotation>
+							<xs:documentation>Versão do leiaute</xs:documentation>
+							<xs:documentation>Ex: "4.00"</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="TVerCTe"/>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="Id" use="required">
+						<xs:annotation>
+							<xs:documentation>Identificador da tag a ser assinada</xs:documentation>
+							<xs:documentation>Informar a chave de acesso do CT-e e precedida do literal "CTe"</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:ID">
+								<xs:pattern value="CTe[0-9]{6}[A-Z0-9]{12}[0-9]{26}"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+				<xs:unique name="pk_nItem">
+					<xs:selector xpath="./*"/>
+					<xs:field xpath="@nItem"/>
+				</xs:unique>
+			</xs:element>
+			<xs:element name="infCTeSupl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informações suplementares do CT-e</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="qrCodCTe">
+							<xs:annotation>
+								<xs:documentation>Texto com o QR-Code impresso no DACTE</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:minLength value="50"/>
+									<xs:maxLength value="1000"/>
+									<xs:pattern value="((HTTPS?|https?)://.*\?chCTe=[0-9]{44}&amp;tpAmb=[1-2](&amp;sign=[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1})?)"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCTe">
+		<xs:annotation>
+			<xs:documentation>Tipo Conhecimento de Transporte Eletrônico (Modelo 57)</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infCte">
+				<xs:annotation>
+					<xs:documentation>Informações do CT-e</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ide">
+							<xs:annotation>
+								<xs:documentation>Identificação do CT-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="cUF" type="TCodUfIBGE">
+										<xs:annotation>
+											<xs:documentation>Código da UF do emitente do CT-e.</xs:documentation>
+											<xs:documentation>Utilizar a Tabela do IBGE.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="cCT">
+										<xs:annotation>
+											<xs:documentation>Código numérico que compõe a Chave de Acesso. </xs:documentation>
+											<xs:documentation>Número aleatório gerado pelo emitente para cada CT-e, com o objetivo de evitar acessos indevidos ao documento.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{8}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="CFOP" type="TCfop">
+										<xs:annotation>
+											<xs:documentation>Código Fiscal de Operações e Prestações</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="natOp">
+										<xs:annotation>
+											<xs:documentation>Natureza da Operação</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="mod" type="TModCT">
+										<xs:annotation>
+											<xs:documentation>Modelo do documento fiscal</xs:documentation>
+											<xs:documentation>Utilizar o código 57 para identificação do CT-e, emitido em substituição aos modelos de conhecimentos em papel.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="serie">
+										<xs:annotation>
+											<xs:documentation>Série do CT-e</xs:documentation>
+											<xs:documentation>Preencher com "0" no caso de série única</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TSerie"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="nCT" type="TNF">
+										<xs:annotation>
+											<xs:documentation>Número do CT-e</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="dhEmi">
+										<xs:annotation>
+											<xs:documentation>Data e hora de emissão do CT-e</xs:documentation>
+											<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TDateTimeUTC"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpImp">
+										<xs:annotation>
+											<xs:documentation>Formato de impressão do DACTE</xs:documentation>
+											<xs:documentation>Preencher com: 1 - Retrato; 2 - Paisagem.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpEmis">
+										<xs:annotation>
+											<xs:documentation>Forma de emissão do CT-e </xs:documentation>
+											<xs:documentation>Preencher com:
+1 - Normal;
+ 3-Regime Especial NFF;  4-EPEC pela SVC; 5 - Contingência FSDA;
+	7 - Autorização pela SVC-RS;
+  8 - Autorização pela SVC-SP</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="3"/>
+												<xs:enumeration value="4"/>
+												<xs:enumeration value="5"/>
+												<xs:enumeration value="7"/>
+												<xs:enumeration value="8"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cDV">
+										<xs:annotation>
+											<xs:documentation>Digito Verificador da chave de acesso do CT-e</xs:documentation>
+											<xs:documentation>Informar o dígito  de controle da chave de acesso do CT-e, que deve ser calculado com a aplicação do algoritmo módulo 11 (base 2,9) da chave de acesso. </xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{1}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpAmb" type="TAmb">
+										<xs:annotation>
+											<xs:documentation>Tipo do Ambiente</xs:documentation>
+											<xs:documentation>Preencher com:1 - Produção; 2 - Homologação.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpCTe" type="TFinCTe">
+										<xs:annotation>
+											<xs:documentation>Tipo do CT-e</xs:documentation>
+											<xs:documentation>Preencher com:
+	0 - CT-e Normal;
+ 1 - CT-e de Complemento de Valores;
+ 3 - CT-e de Substituição</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="procEmi" type="TProcEmi">
+										<xs:annotation>
+											<xs:documentation>Identificador do processo de emissão do CT-e</xs:documentation>
+											<xs:documentation>Preencher com: 
+											0 - emissão de CT-e com aplicativo do contribuinte;
+											3- emissão CT-e pelo contribuinte com aplicativo fornecido pelo SEBRAE.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="verProc">
+										<xs:annotation>
+											<xs:documentation>Versão do processo de emissão</xs:documentation>
+											<xs:documentation>Iinformar a versão do aplicativo emissor de CT-e.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="20"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="indGlobalizado" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Indicador de CT-e Globalizado</xs:documentation>
+											<xs:documentation>Informar valor 1 quando for Globalizado e não informar a tag quando não tratar de CT-e Globalizado</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:enumeration value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cMunEnv" type="TCodMunIBGE">
+										<xs:annotation>
+											<xs:documentation>Código do Município de envio do CT-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Utilizar a tabela do IBGE. Informar 9999999 para as operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="xMunEnv">
+										<xs:annotation>
+											<xs:documentation>Nome do Município de envio do CT-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Informar PAIS/Municipio para as operações com o exterior.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="UFEnv" type="TUf">
+										<xs:annotation>
+											<xs:documentation>Sigla da UF de envio do CT-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="modal" type="TModTransp">
+										<xs:annotation>
+											<xs:documentation>Modal</xs:documentation>
+											<xs:documentation>Preencher com:01-Rodoviário;
+02-Aéreo;03-Aquaviário;04-Ferroviário;05-Dutoviário;06-Multimodal;</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpServ">
+										<xs:annotation>
+											<xs:documentation>Tipo do Serviço</xs:documentation>
+											<xs:documentation>Preencher com: 
+0 - Normal;
+1 - Subcontratação;
+2 - Redespacho;
+3 - Redespacho Intermediário; 
+4 - Serviço Vinculado a Multimodal</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="3"/>
+												<xs:enumeration value="4"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cMunIni" type="TCodMunIBGE">
+										<xs:annotation>
+											<xs:documentation>Código do Município de início da prestação</xs:documentation>
+											<xs:documentation>Utilizar a tabela do IBGE. Informar 9999999 para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="xMunIni">
+										<xs:annotation>
+											<xs:documentation>Nome do Município do início da prestação</xs:documentation>
+											<xs:documentation>Informar 'EXTERIOR' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="UFIni" type="TUf">
+										<xs:annotation>
+											<xs:documentation>UF do início da prestação</xs:documentation>
+											<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="cMunFim" type="TCodMunIBGE">
+										<xs:annotation>
+											<xs:documentation>Código do Município de término da prestação</xs:documentation>
+											<xs:documentation>Utilizar a tabela do IBGE. Informar 9999999 para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="xMunFim">
+										<xs:annotation>
+											<xs:documentation>Nome do Município do término da prestação</xs:documentation>
+											<xs:documentation>Informar 'EXTERIOR' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="UFFim" type="TUf">
+										<xs:annotation>
+											<xs:documentation>UF do término da prestação</xs:documentation>
+											<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="retira">
+										<xs:annotation>
+											<xs:documentation>Indicador se o Recebedor retira no Aeroporto, Filial, Porto ou Estação de Destino?</xs:documentation>
+											<xs:documentation>Preencher com: 0 - sim; 1 - não</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xDetRetira" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Detalhes do retira</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="160"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="indIEToma">
+										<xs:annotation>
+											<xs:documentation>Indicador do papel do tomador na prestação do serviço:
+1 – Contribuinte ICMS;
+2 – Contribuinte isento de inscrição;
+9 – Não Contribuinte</xs:documentation>
+											<xs:documentation>Aplica-se ao tomador que for indicado no toma3 ou toma4</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="9"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:choice>
+										<xs:element name="toma3">
+											<xs:annotation>
+												<xs:documentation>Indicador do "papel" do tomador do serviço no CT-e</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="toma">
+														<xs:annotation>
+															<xs:documentation>Tomador do Serviço</xs:documentation>
+															<xs:documentation>Preencher com:
+															0-Remetente;
+															1-Expedidor;
+															2-Recebedor;
+															3-Destinatário
+															Serão utilizadas as informações contidas no respectivo grupo, conforme indicado pelo conteúdo deste campo</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:whiteSpace value="preserve"/>
+																<xs:enumeration value="0"/>
+																<xs:enumeration value="1"/>
+																<xs:enumeration value="2"/>
+																<xs:enumeration value="3"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="toma4">
+											<xs:annotation>
+												<xs:documentation>Indicador do "papel" do tomador do serviço no CT-e</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="toma">
+														<xs:annotation>
+															<xs:documentation>Tomador do Serviço</xs:documentation>
+															<xs:documentation>Preencher com: 
+															4 - Outros
+															Obs: Informar os dados cadastrais do tomador do serviço</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:whiteSpace value="preserve"/>
+																<xs:enumeration value="4"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:choice>
+														<xs:element name="CNPJ" type="TCnpjOpc">
+															<xs:annotation>
+																<xs:documentation>Número do CNPJ</xs:documentation>
+																<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.															
+Informar os zeros não significativos.</xs:documentation>
+															</xs:annotation>
+														</xs:element>
+														<xs:element name="CPF" type="TCpf">
+															<xs:annotation>
+																<xs:documentation>Número do CPF</xs:documentation>
+																<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+															</xs:annotation>
+														</xs:element>
+													</xs:choice>
+													<xs:element name="IE" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Inscrição Estadual</xs:documentation>
+															<xs:documentation>Informar a IE do tomador ou ISENTO se tomador é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o tomador não seja contribuinte do ICMS não informar o conteúdo.</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TIeDest"/>
+														</xs:simpleType>
+													</xs:element>
+													<xs:sequence>
+														<xs:element name="xNome">
+															<xs:annotation>
+																<xs:documentation>Razão Social ou Nome</xs:documentation>
+															</xs:annotation>
+															<xs:simpleType>
+																<xs:restriction base="TString">
+																	<xs:maxLength value="60"/>
+																	<xs:minLength value="2"/>
+																</xs:restriction>
+															</xs:simpleType>
+														</xs:element>
+														<xs:element name="xFant" minOccurs="0">
+															<xs:annotation>
+																<xs:documentation>Nome Fantasia</xs:documentation>
+															</xs:annotation>
+															<xs:simpleType>
+																<xs:restriction base="TString">
+																	<xs:maxLength value="60"/>
+																	<xs:minLength value="2"/>
+																</xs:restriction>
+															</xs:simpleType>
+														</xs:element>
+														<xs:element name="fone" type="TFone" minOccurs="0">
+															<xs:annotation>
+																<xs:documentation>Telefone</xs:documentation>
+															</xs:annotation>
+														</xs:element>
+														<xs:element name="enderToma" type="TEndereco">
+															<xs:annotation>
+																<xs:documentation>Dados do endereço</xs:documentation>
+															</xs:annotation>
+														</xs:element>
+														<xs:element name="email" type="TEmail" minOccurs="0">
+															<xs:annotation>
+																<xs:documentation>Endereço de email</xs:documentation>
+															</xs:annotation>
+														</xs:element>
+													</xs:sequence>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+									</xs:choice>
+									<xs:sequence minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informar apenas
+para tpEmis diferente de 1</xs:documentation>
+										</xs:annotation>
+										<xs:element name="dhCont" type="TDateTimeUTC">
+											<xs:annotation>
+												<xs:documentation>Data e Hora da entrada em contingência</xs:documentation>
+												<xs:documentation>Informar a data e hora no formato AAAA-MM-DDTHH:MM:SS</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="xJust">
+											<xs:annotation>
+												<xs:documentation>Justificativa da entrada em contingência</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="15"/>
+													<xs:maxLength value="256"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+									<xs:element name="gCompraGov" type="TCompraGovReduzido" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Grupo de Compras Governamentais</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="compl" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Dados complementares do CT-e para fins operacionais ou comerciais</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="xCaracAd" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Característica adicional do transporte</xs:documentation>
+											<xs:documentation>Texto livre:
+REENTREGA; DEVOLUÇÃO; REFATURAMENTO; etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="15"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xCaracSer" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Característica adicional do serviço</xs:documentation>
+											<xs:documentation>Texto livre:
+											ENTREGA EXPRESSA; LOGÍSTICA REVERSA; CONVENCIONAL; EMERGENCIAL; etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="30"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xEmi" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Funcionário emissor do CTe</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="20"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fluxo" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Previsão do fluxo da carga</xs:documentation>
+											<xs:documentation>Preenchimento obrigatório para o modal aéreo.</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xOrig" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Sigla ou código interno da Filial/Porto/Estação/ Aeroporto de Origem</xs:documentation>
+														<xs:documentation>Observações para o modal aéreo:
+														- Preenchimento obrigatório para o modal aéreo.
+														- O código de três letras IATA do aeroporto de partida deverá ser incluído como primeira anotação. Quando não for possível, utilizar a sigla OACI.</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="pass" minOccurs="0" maxOccurs="unbounded">
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="xPass" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Sigla ou código interno da Filial/Porto/Estação/Aeroporto de Passagem</xs:documentation>
+																	<xs:documentation>Observação para o modal aéreo:
+																	- O código de três letras IATA, referente ao aeroporto de transferência, deverá ser incluído, quando for o caso. Quando não for possível,  utilizar a sigla OACI. Qualquer solicitação de itinerário deverá ser incluída.</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="15"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="xDest" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Sigla ou código interno da Filial/Porto/Estação/Aeroporto de Destino</xs:documentation>
+														<xs:documentation>Observações para o modal aéreo:
+														- Preenchimento obrigatório para o modal aéreo.
+														- Deverá ser incluído o código de três letras IATA do aeroporto de destino. Quando não for possível, utilizar a sigla OACI.</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="xRota" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Código da Rota de Entrega</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="10"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="Entrega" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações ref. a previsão de entrega</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:choice>
+													<xs:element name="semData">
+														<xs:annotation>
+															<xs:documentation>Entrega sem data definida</xs:documentation>
+															<xs:documentation>Esta opção é proibida para o modal aéreo.</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="tpPer">
+																	<xs:annotation>
+																		<xs:documentation>Tipo de data/período programado para entrega</xs:documentation>
+																		<xs:documentation>0- Sem data definida</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="0"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="comData">
+														<xs:annotation>
+															<xs:documentation>Entrega com data definida</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="tpPer">
+																	<xs:annotation>
+																		<xs:documentation>Tipo de data/período programado para entrega</xs:documentation>
+																		<xs:documentation>Preencher com:
+																		1-Na data;
+																		2-Até a data;
+																		3-A partir da data</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="1"/>
+																			<xs:enumeration value="2"/>
+																			<xs:enumeration value="3"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="dProg" type="TData">
+																	<xs:annotation>
+																		<xs:documentation>Data programada </xs:documentation>
+																		<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="noPeriodo">
+														<xs:annotation>
+															<xs:documentation>Entrega no período definido</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="tpPer">
+																	<xs:annotation>
+																		<xs:documentation>Tipo período</xs:documentation>
+																		<xs:documentation>4-no período</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="4"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="dIni" type="TData">
+																	<xs:annotation>
+																		<xs:documentation>Data inicial </xs:documentation>
+																		<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="dFim" type="TData">
+																	<xs:annotation>
+																		<xs:documentation>Data final </xs:documentation>
+																		<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+												</xs:choice>
+												<xs:choice>
+													<xs:element name="semHora">
+														<xs:annotation>
+															<xs:documentation>Entrega sem hora definida</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="tpHor">
+																	<xs:annotation>
+																		<xs:documentation>Tipo de hora</xs:documentation>
+																		<xs:documentation>0- Sem hora definida</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="0"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="comHora">
+														<xs:annotation>
+															<xs:documentation>Entrega com hora definida</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="tpHor">
+																	<xs:annotation>
+																		<xs:documentation>Tipo de hora</xs:documentation>
+																		<xs:documentation>Preencher com:
+																		1 - No horário;
+																		2 - Até o horário;
+																		3 - A partir do horário.</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="1"/>
+																			<xs:enumeration value="2"/>
+																			<xs:enumeration value="3"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="hProg" type="TTime">
+																	<xs:annotation>
+																		<xs:documentation>Hora programada </xs:documentation>
+																		<xs:documentation>Formato HH:MM:SS</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="noInter">
+														<xs:annotation>
+															<xs:documentation>Entrega no intervalo de horário definido</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="tpHor">
+																	<xs:annotation>
+																		<xs:documentation> Tipo de hora</xs:documentation>
+																		<xs:documentation>4 - No intervalo de tempo</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="4"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="hIni" type="TTime">
+																	<xs:annotation>
+																		<xs:documentation>Hora inicial </xs:documentation>
+																		<xs:documentation>Formato HH:MM:SS</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="hFim" type="TTime">
+																	<xs:annotation>
+																		<xs:documentation>Hora final </xs:documentation>
+																		<xs:documentation>Formato HH:MM:SS</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+												</xs:choice>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="origCalc" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Município de origem para efeito de cálculo do frete</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="40"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="destCalc" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Município de destino para efeito de cálculo do frete</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="40"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xObs" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Observações Gerais</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="2000"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="ObsCont" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Campo de uso livre do contribuinte</xs:documentation>
+											<xs:documentation>Informar o nome do campo no atributo xCampo e o conteúdo do campo no XTexto</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xTexto">
+													<xs:annotation>
+														<xs:documentation>Conteúdo do campo</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="160"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="xCampo" use="required">
+												<xs:annotation>
+													<xs:documentation>Identificação do campo</xs:documentation>
+												</xs:annotation>
+												<xs:simpleType>
+													<xs:restriction base="TString">
+														<xs:minLength value="1"/>
+														<xs:maxLength value="20"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="ObsFisco" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Campo de uso livre do contribuinte</xs:documentation>
+											<xs:documentation>Informar o nome do campo no atributo xCampo e o conteúdo do campo no XTexto</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xTexto">
+													<xs:annotation>
+														<xs:documentation>Conteúdo do campo</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="xCampo" use="required">
+												<xs:annotation>
+													<xs:documentation>Identificação do campo</xs:documentation>
+												</xs:annotation>
+												<xs:simpleType>
+													<xs:restriction base="TString">
+														<xs:minLength value="1"/>
+														<xs:maxLength value="20"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="emit">
+							<xs:annotation>
+								<xs:documentation>Identificação do Emitente do CT-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpj">
+											<xs:annotation>
+												<xs:documentation>CNPJ do emitente</xs:documentation>
+												<xs:documentation>Informar zeros não significativos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>CPF do emitente</xs:documentation>
+												<xs:documentation>Informar zeros não significativos.
+
+Usar com série específica 920-969 para emitente pessoa física com inscrição estadual</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="IE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual do Emitente</xs:documentation>
+											<xs:documentation>A IE do emitente somente ficará sem informação para o caso do Regime Especial da NFF (tpEmis=3)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIe"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="IEST" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual do Substituto Tributário</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIe"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão social ou Nome do emitente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xFant" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Nome fantasia</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="enderEmit" type="TEndeEmi">
+										<xs:annotation>
+											<xs:documentation>Endereço do emitente</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="CRT" type="TCRT">
+										<xs:annotation>
+											<xs:documentation>Código do Regime Tributário</xs:documentation>
+											<xs:documentation>Informar: 1=Simples Nacional; 
+2=Simples Nacional, excesso sublimite de receita bruta;
+3=Regime Normal. 
+4=Simples Nacional - Microempreendedor Individual – MEI.
+</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="rem" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do Remetente das mercadorias transportadas pelo CT-e</xs:documentation>
+								<xs:documentation>Poderá não ser informado para os CT-e de redespacho intermediário e serviço vinculado a multimodal. Nos demais casos deverá sempre ser informado.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpjOpc">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+												<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.
+												Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>Número do CPF</xs:documentation>
+												<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="IE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual</xs:documentation>
+											<xs:documentation>Informar a IE do remetente ou ISENTO se remetente é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o remetente não seja contribuinte do ICMS não informar a tag.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIeDest"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão social ou nome do remetente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xFant" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Nome fantasia</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fone" type="TFone" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Telefone</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="enderReme" type="TEndereco">
+										<xs:annotation>
+											<xs:documentation>Dados do endereço</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="email" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Endereço de email</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TEmail"/>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="exped" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do Expedidor da Carga</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpjOpc">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+												<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.
+												Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>Número do CPF</xs:documentation>
+												<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="IE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual</xs:documentation>
+											<xs:documentation>Informar a IE do expedidor ou ISENTO se expedidor é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o expedidor não seja contribuinte do ICMS não informar a tag.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIeDest"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão Social ou Nome</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fone" type="TFone" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Telefone</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="enderExped" type="TEndereco">
+										<xs:annotation>
+											<xs:documentation>Dados do endereço</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="email" type="TEmail" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Endereço de email</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="receb" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do Recebedor da Carga</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpjOpc">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+												<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.
+												Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>Número do CPF</xs:documentation>
+												<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="IE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual</xs:documentation>
+											<xs:documentation>Informar a IE do recebedor ou ISENTO se recebedor é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o recebedor não seja contribuinte do ICMS não informar o conteúdo.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIeDest"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão Social ou Nome </xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fone" type="TFone" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Telefone</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="enderReceb" type="TEndereco">
+										<xs:annotation>
+											<xs:documentation>Dados do endereço</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="email" type="TEmail" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Endereço de email</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="dest" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do Destinatário do CT-e</xs:documentation>
+								<xs:documentation>Poderá não ser informado para os CT-e de redespacho intermediário e serviço vinculado a multimodal. Nos demais casos deverá sempre ser informado.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpjOpc">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+												<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.
+												Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>Número do CPF</xs:documentation>
+												<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="IE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual</xs:documentation>
+											<xs:documentation>Informar a IE do destinatário ou ISENTO se destinatário é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o destinatário não seja contribuinte do ICMS não informar o conteúdo.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIeDest"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão Social ou Nome do destinatário</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fone" type="TFone" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Telefone</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="ISUF" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição na SUFRAMA</xs:documentation>
+											<xs:documentation>(Obrigatório nas operações com as áreas com benefícios de incentivos fiscais sob controle da SUFRAMA)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{8,9}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="enderDest" type="TEndereco">
+										<xs:annotation>
+											<xs:documentation>Dados do endereço</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="email" type="TEmail" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Endereço de email</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="vPrest">
+							<xs:annotation>
+								<xs:documentation>Valores da Prestação de Serviço</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vTPrest" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor Total da Prestação do Serviço</xs:documentation>
+											<xs:documentation>Pode conter zeros quando o CT-e for de complemento de ICMS</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vRec" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor a Receber</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="Comp" minOccurs="0" maxOccurs="unbounded">
+										<xs:annotation>
+											<xs:documentation>Componentes do Valor da Prestação</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xNome">
+													<xs:annotation>
+														<xs:documentation>Nome do componente</xs:documentation>
+														<xs:documentation>Exxemplos: FRETE PESO, FRETE VALOR, SEC/CAT, ADEME, AGENDAMENTO, etc</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="15"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="vComp" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do componente</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="imp">
+							<xs:annotation>
+								<xs:documentation>Informações relativas aos Impostos</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="ICMS" type="TImp">
+										<xs:annotation>
+											<xs:documentation>Informações relativas ao ICMS</xs:documentation>
+											<xs:documentation/>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vTotTrib" type="TDec_1302" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor Total dos Tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="infAdFisco" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações adicionais de interesse do Fisco</xs:documentation>
+											<xs:documentation>Norma referenciada, informações complementares, etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="2000"/>
+												<xs:minLength value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="ICMSUFFim" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações do ICMS de partilha com a UF de término do serviço de transporte na operação interestadual</xs:documentation>
+											<xs:documentation>Grupo a ser informado nas prestações interestaduais para consumidor final, não contribuinte do ICMS</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="vBCUFFim" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor da BC do ICMS na UF de término da prestação do serviço de transporte</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pFCPUFFim" type="TDec_0302">
+													<xs:annotation>
+														<xs:documentation>Percentual do ICMS relativo ao Fundo de Combate à pobreza (FCP) na UF de término da prestação do serviço de transporte</xs:documentation>
+														<xs:documentation>Alíquota adotada nas operações internas na UF do destinatário</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pICMSUFFim" type="TDec_0302">
+													<xs:annotation>
+														<xs:documentation>Alíquota interna da UF de término da prestação do serviço de transporte</xs:documentation>
+														<xs:documentation>Alíquota adotada nas operações internas na UF do destinatário</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pICMSInter" type="TDec_0302">
+													<xs:annotation>
+														<xs:documentation>Alíquota interestadual das UF envolvidas</xs:documentation>
+														<xs:documentation>Alíquota interestadual das UF envolvidas
+</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vFCPUFFim" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS relativo ao Fundo de Combate á Pobreza (FCP) da UF de término da prestação</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSUFFim" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS de partilha para a UF de término da prestação do serviço de transporte</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSUFIni" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS de partilha para a UF de início da prestação do serviço de transporte</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="IBSCBS" type="TTribCTe" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Grupo de informações do IBS e CBS</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vTotDFe" type="TDec_1302" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor total do documento fiscal 
+(vTPrest + total do IBS + total da CBS) 
+</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:choice>
+							<xs:element name="infCTeNorm">
+								<xs:annotation>
+									<xs:documentation>Grupo de informações do CT-e Normal e Substituto</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="infCarga">
+											<xs:annotation>
+												<xs:documentation>Informações da Carga do CT-e</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="vCarga" type="TDec_1302" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Valor total da carga</xs:documentation>
+															<xs:documentation>Dever ser informado para todos os modais, com exceção para o Dutoviário.</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="proPred">
+														<xs:annotation>
+															<xs:documentation>Produto predominante</xs:documentation>
+															<xs:documentation>Informar a descrição do produto predominante</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="60"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="xOutCat" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Outras características da carga</xs:documentation>
+															<xs:documentation>"FRIA", "GRANEL", "REFRIGERADA", "Medidas: 12X12X12"</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="30"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="infQ" maxOccurs="unbounded">
+														<xs:annotation>
+															<xs:documentation>Informações de quantidades da Carga do CT-e</xs:documentation>
+															<xs:documentation>Para o Aéreo é obrigatório o preenchimento desse campo da seguinte forma.
+1 - Peso Bruto, sempre em quilogramas (obrigatório);
+2 - Peso Cubado; sempre em quilogramas;
+3 - Quantidade de volumes, sempre em unidades (obrigatório);
+4 - Cubagem, sempre em metros cúbicos (obrigatório apenas quando for impossível preencher as dimensões da(s) embalagem(ens) na tag xDime do leiaute do Aéreo).</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="cUnid">
+																	<xs:annotation>
+																		<xs:documentation>Código da Unidade de Medida </xs:documentation>
+																		<xs:documentation>Preencher com:
+																		00-M3;
+																		01-KG;
+																		02-TON;
+																		03-UNIDADE;
+																		04-LITROS;
+																		05-MMBTU</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="00"/>
+																			<xs:enumeration value="01"/>
+																			<xs:enumeration value="02"/>
+																			<xs:enumeration value="03"/>
+																			<xs:enumeration value="04"/>
+																			<xs:enumeration value="05"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="tpMed">
+																	<xs:annotation>
+																		<xs:documentation>Tipo da Medida</xs:documentation>
+																		<xs:documentation>Exemplos:
+PESO BRUTO, PESO DECLARADO, PESO CUBADO, PESO AFORADO, PESO AFERIDO, PESO BASE DE CÁLCULO, LITRAGEM, CAIXAS e etc</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="20"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="qCarga" type="TDec_1104">
+																	<xs:annotation>
+																		<xs:documentation>Quantidade</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="vCargaAverb" type="TDec_1302Opc" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Valor da Carga para efeito de averbação</xs:documentation>
+															<xs:documentation>Normalmente igual ao valor declarado da mercadoria, diferente por exemplo, quando a mercadoria transportada é isenta de tributos nacionais para exportação, onde é preciso averbar um valor maior, pois no caso de indenização, o valor a ser pago será maior</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infDoc" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Informações dos documentos transportados pelo CT-e
+Opcional para Redespacho Intermediario e Serviço vinculado a multimodal.</xs:documentation>
+												<xs:documentation>Poderá não ser informado para os CT-e de redespacho intermediário e serviço vinculado a multimodal. Nos demais casos deverá sempre ser informado.</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:choice>
+														<xs:element name="infNF" maxOccurs="unbounded">
+															<xs:annotation>
+																<xs:documentation>Informações das NF</xs:documentation>
+																<xs:documentation>Este grupo deve ser informado quando o documento originário for NF </xs:documentation>
+															</xs:annotation>
+															<xs:complexType>
+																<xs:sequence>
+																	<xs:element name="nRoma" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Número do Romaneio da NF</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="TString">
+																				<xs:minLength value="1"/>
+																				<xs:maxLength value="20"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="nPed" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Número do Pedido da NF</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="TString">
+																				<xs:minLength value="1"/>
+																				<xs:maxLength value="20"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="mod" type="TModNF">
+																		<xs:annotation>
+																			<xs:documentation>Modelo da Nota Fiscal</xs:documentation>
+																			<xs:documentation>Preencher com: 
+01 - NF Modelo 01/1A e Avulsa; 
+04 - NF de Produtor</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="serie">
+																		<xs:annotation>
+																			<xs:documentation>Série</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="TString">
+																				<xs:minLength value="1"/>
+																				<xs:maxLength value="3"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="nDoc">
+																		<xs:annotation>
+																			<xs:documentation>Número </xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="TString">
+																				<xs:minLength value="1"/>
+																				<xs:maxLength value="20"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="dEmi" type="TData">
+																		<xs:annotation>
+																			<xs:documentation>Data de Emissão</xs:documentation>
+																			<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vBC" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor da Base de Cálculo do ICMS</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vICMS" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor Total do ICMS</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vBCST" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor da Base de Cálculo do ICMS ST</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vST" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor Total do ICMS ST</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vProd" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor Total dos Produtos</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vNF" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor Total da NF</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="nCFOP" type="TCfop">
+																		<xs:annotation>
+																			<xs:documentation>CFOP Predominante</xs:documentation>
+																			<xs:documentation>CFOP da NF ou, na existência de mais de um, predominância pelo critério de valor econômico.</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="nPeso" type="TDec_1203Opc" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Peso total em Kg</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="PIN" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>PIN SUFRAMA</xs:documentation>
+																			<xs:documentation>PIN atribuído pela SUFRAMA para a operação.</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="xs:string">
+																				<xs:whiteSpace value="preserve"/>
+																				<xs:minLength value="2"/>
+																				<xs:maxLength value="9"/>
+																				<xs:pattern value="[1-9]{1}[0-9]{1,8}"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="dPrev" type="TData" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Data prevista de entrega</xs:documentation>
+																			<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:choice>
+																		<xs:element name="infUnidCarga" type="TUnidCarga" minOccurs="0" maxOccurs="unbounded">
+																			<xs:annotation>
+																				<xs:documentation>Informações das Unidades de Carga (Containeres/ULD/Outros)</xs:documentation>
+																				<xs:documentation>Dispositivo de carga utilizada (Unit Load Device - ULD) significa todo tipo de contêiner de carga, vagão, contêiner de avião, palete de aeronave com rede ou palete de aeronave com rede sobre um iglu. </xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="infUnidTransp" type="TUnidadeTransp" minOccurs="0" maxOccurs="unbounded">
+																			<xs:annotation>
+																				<xs:documentation>Informações das Unidades de Transporte (Carreta/Reboque/Vagão)</xs:documentation>
+																				<xs:documentation>Deve ser preenchido com as informações das unidades de transporte utilizadas.</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																	</xs:choice>
+																</xs:sequence>
+															</xs:complexType>
+														</xs:element>
+														<xs:element name="infNFe" maxOccurs="unbounded">
+															<xs:annotation>
+																<xs:documentation>Informações das NF-e</xs:documentation>
+															</xs:annotation>
+															<xs:complexType>
+																<xs:sequence>
+																	<xs:element name="chave" type="TChDFe">
+																		<xs:annotation>
+																			<xs:documentation>Chave de acesso da NF-e</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="PIN" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>PIN SUFRAMA</xs:documentation>
+																			<xs:documentation>PIN atribuído pela SUFRAMA para a operação.</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="xs:string">
+																				<xs:whiteSpace value="preserve"/>
+																				<xs:minLength value="2"/>
+																				<xs:maxLength value="9"/>
+																				<xs:pattern value="[1-9]{1}[0-9]{1,8}"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="dPrev" type="TData" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Data prevista de entrega</xs:documentation>
+																			<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:choice>
+																		<xs:element name="infUnidCarga" type="TUnidCarga" minOccurs="0" maxOccurs="unbounded">
+																			<xs:annotation>
+																				<xs:documentation>Informações das Unidades de Carga (Containeres/ULD/Outros)</xs:documentation>
+																				<xs:documentation>Dispositivo de carga utilizada (Unit Load Device - ULD) significa todo tipo de contêiner de carga, vagão, contêiner de avião, palete de aeronave com rede ou palete de aeronave com rede sobre um iglu. </xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="infUnidTransp" type="TUnidadeTransp" minOccurs="0" maxOccurs="unbounded">
+																			<xs:annotation>
+																				<xs:documentation>Informações das Unidades de Transporte (Carreta/Reboque/Vagão)</xs:documentation>
+																				<xs:documentation>Deve ser preenchido com as informações das unidades de transporte utilizadas.</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																	</xs:choice>
+																</xs:sequence>
+															</xs:complexType>
+														</xs:element>
+														<xs:element name="infOutros" maxOccurs="unbounded">
+															<xs:annotation>
+																<xs:documentation>Informações dos demais documentos</xs:documentation>
+															</xs:annotation>
+															<xs:complexType>
+																<xs:sequence>
+																	<xs:element name="tpDoc">
+																		<xs:annotation>
+																			<xs:documentation>Tipo de documento originário</xs:documentation>
+																			<xs:documentation>Preencher com:
+															00 - Declaração;
+															10 - Dutoviário;
+							
+
+59 - CF-e SAT;
+
+65 - NFC-e;
+								99 - Outros</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="xs:string">
+																				<xs:whiteSpace value="preserve"/>
+																				<xs:enumeration value="00"/>
+																				<xs:enumeration value="10"/>
+																				<xs:enumeration value="59"/>
+																				<xs:enumeration value="65"/>
+																				<xs:enumeration value="99"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="descOutros" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Descrição do documento</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="TString">
+																				<xs:minLength value="1"/>
+																				<xs:maxLength value="100"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="nDoc" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Número </xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="TString">
+																				<xs:minLength value="1"/>
+																				<xs:maxLength value="20"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="dEmi" type="TData" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Data de Emissão</xs:documentation>
+																			<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vDocFisc" type="TDec_1302Opc" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Valor do documento</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="dPrev" type="TData" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Data prevista de entrega</xs:documentation>
+																			<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:choice>
+																		<xs:element name="infUnidCarga" type="TUnidCarga" minOccurs="0" maxOccurs="unbounded">
+																			<xs:annotation>
+																				<xs:documentation>Informações das Unidades de Carga (Containeres/ULD/Outros)</xs:documentation>
+																				<xs:documentation>Dispositivo de carga utilizada (Unit Load Device - ULD) significa todo tipo de contêiner de carga, vagão, contêiner de avião, palete de aeronave com rede ou palete de aeronave com rede sobre um iglu. </xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="infUnidTransp" type="TUnidadeTransp" minOccurs="0" maxOccurs="unbounded">
+																			<xs:annotation>
+																				<xs:documentation>Informações das Unidades de Transporte (Carreta/Reboque/Vagão)</xs:documentation>
+																				<xs:documentation>Deve ser preenchido com as informações das unidades de transporte utilizadas.</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																	</xs:choice>
+																</xs:sequence>
+															</xs:complexType>
+														</xs:element>
+														<xs:element name="infDCe" maxOccurs="unbounded">
+															<xs:annotation>
+																<xs:documentation>Informações das DCe</xs:documentation>
+															</xs:annotation>
+															<xs:complexType>
+																<xs:sequence>
+																	<xs:element name="chave" type="TChDFe">
+																		<xs:annotation>
+																			<xs:documentation>Chave de acesso da DCe</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																</xs:sequence>
+															</xs:complexType>
+														</xs:element>
+													</xs:choice>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="docAnt" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Documentos de Transporte Anterior</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="emiDocAnt" maxOccurs="unbounded">
+														<xs:annotation>
+															<xs:documentation>Emissor do documento anterior</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:choice>
+																	<xs:element name="CNPJ" type="TCnpjOpc">
+																		<xs:annotation>
+																			<xs:documentation>Número do CNPJ</xs:documentation>
+																			<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.
+																			Informar os zeros não significativos.</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="CPF" type="TCpf">
+																		<xs:annotation>
+																			<xs:documentation>Número do CPF</xs:documentation>
+																			<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																</xs:choice>
+																<xs:sequence minOccurs="0">
+																	<xs:element name="IE" type="TIe">
+																		<xs:annotation>
+																			<xs:documentation>Inscrição Estadual</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="UF" type="TUf">
+																		<xs:annotation>
+																			<xs:documentation>Sigla da UF</xs:documentation>
+																			<xs:documentation>Informar EX para operações com o exterior.</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																</xs:sequence>
+																<xs:element name="xNome">
+																	<xs:annotation>
+																		<xs:documentation>Razão Social ou Nome do expedidor</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:maxLength value="60"/>
+																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="idDocAnt" maxOccurs="2">
+																	<xs:annotation>
+																		<xs:documentation>Informações de identificação dos documentos de Transporte Anterior</xs:documentation>
+																	</xs:annotation>
+																	<xs:complexType>
+																		<xs:choice>
+																			<xs:element name="idDocAntPap" maxOccurs="unbounded">
+																				<xs:annotation>
+																					<xs:documentation>Documentos de transporte anterior em papel</xs:documentation>
+																				</xs:annotation>
+																				<xs:complexType>
+																					<xs:sequence>
+																						<xs:element name="tpDoc">
+																							<xs:annotation>
+																								<xs:documentation>Tipo do Documento de Transporte Anterior</xs:documentation>
+																								<xs:documentation>Preencher com:
+07-ATRE;							
+08-DTA (Despacho de Transito Aduaneiro);
+09-Conhecimento Aéreo Internacional;
+10 – Conhecimento - Carta de Porte Internacional;
+11 – Conhecimento Avulso;
+12-TIF (Transporte Internacional Ferroviário); 13-BL (Bill of Lading)</xs:documentation>
+																							</xs:annotation>
+																							<xs:simpleType>
+																								<xs:restriction base="TDocAssoc"/>
+																							</xs:simpleType>
+																						</xs:element>
+																						<xs:element name="serie">
+																							<xs:annotation>
+																								<xs:documentation>Série do Documento Fiscal</xs:documentation>
+																							</xs:annotation>
+																							<xs:simpleType>
+																								<xs:restriction base="TString">
+																									<xs:minLength value="1"/>
+																									<xs:maxLength value="3"/>
+																								</xs:restriction>
+																							</xs:simpleType>
+																						</xs:element>
+																						<xs:element name="subser" minOccurs="0">
+																							<xs:annotation>
+																								<xs:documentation>Série do Documento Fiscal</xs:documentation>
+																							</xs:annotation>
+																							<xs:simpleType>
+																								<xs:restriction base="TString">
+																									<xs:minLength value="1"/>
+																									<xs:maxLength value="2"/>
+																								</xs:restriction>
+																							</xs:simpleType>
+																						</xs:element>
+																						<xs:element name="nDoc">
+																							<xs:annotation>
+																								<xs:documentation>Número do Documento Fiscal</xs:documentation>
+																							</xs:annotation>
+																							<xs:simpleType>
+																								<xs:restriction base="TString">
+																									<xs:minLength value="1"/>
+																									<xs:maxLength value="30"/>
+																								</xs:restriction>
+																							</xs:simpleType>
+																						</xs:element>
+																						<xs:element name="dEmi" type="TData">
+																							<xs:annotation>
+																								<xs:documentation>Data de emissão (AAAA-MM-DD)</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																					</xs:sequence>
+																				</xs:complexType>
+																			</xs:element>
+																			<xs:element name="idDocAntEle" maxOccurs="unbounded">
+																				<xs:annotation>
+																					<xs:documentation>Documentos de transporte anterior eletrônicos</xs:documentation>
+																				</xs:annotation>
+																				<xs:complexType>
+																					<xs:sequence>
+																						<xs:element name="chCTe" type="TChDFe">
+																							<xs:annotation>
+																								<xs:documentation>Chave de acesso do CT-e</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																					</xs:sequence>
+																				</xs:complexType>
+																			</xs:element>
+																		</xs:choice>
+																	</xs:complexType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infModal">
+											<xs:annotation>
+												<xs:documentation>Informações do modal</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:any processContents="skip">
+														<xs:annotation>
+															<xs:documentation>XML do modal
+Insira neste local o XML específico do modal (rodoviário, aéreo, ferroviário, aquaviário ou dutoviário).  </xs:documentation>
+															<xs:documentation>O elemento do tipo -any- permite estender o documento XML com elementos não especificados pelo schema.
+															Insira neste local - any- o XML específico do modal (rodoviário, aéreo, ferroviário, aquaviário ou dutoviário). A especificação do schema XML para cada modal pode ser encontrada nos arquivos que acompanham este pacote de liberação:
+													Rodoviário - ver arquivo CTeModalRodoviario_v9.99
+			Aéreo - ver arquivo CTeModalAereo_v9.99
+				Aquaviário - arquivo CTeModalAquaviario_v9.99
+				Ferroviário - arquivo CTeModalFerroviario_v9.99
+				Dutoviário - arquivo CTeModalDutoviario_v9.99
+
+Onde v9.99 é a a designação genérica para a versão do arquivo. Por exemplo, o arquivo para o schema do modal Rodoviário na versão 1.04 será denominado "CTeModalRodoviario_v1.04".</xs:documentation>
+														</xs:annotation>
+													</xs:any>
+												</xs:sequence>
+												<xs:attribute name="versaoModal" use="required">
+													<xs:annotation>
+														<xs:documentation>Versão do leiaute específico para o Modal</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="4\.(0[0-9]|[1-9][0-9])"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:attribute>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="veicNovos" minOccurs="0" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>informações dos veículos transportados</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="chassi">
+														<xs:annotation>
+															<xs:documentation>Chassi do veículo</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:whiteSpace value="preserve"/>
+																<xs:length value="17"/>
+																<xs:pattern value="[A-Z0-9]+"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="cCor">
+														<xs:annotation>
+															<xs:documentation>Cor do veículo</xs:documentation>
+															<xs:documentation>Código de cada montadora</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="4"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="xCor">
+														<xs:annotation>
+															<xs:documentation>Descrição da cor</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="40"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="cMod">
+														<xs:annotation>
+															<xs:documentation>Código Marca Modelo</xs:documentation>
+															<xs:documentation>Utilizar tabela RENAVAM</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="6"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="vUnit" type="TDec_1302">
+														<xs:annotation>
+															<xs:documentation>Valor Unitário do Veículo</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="vFrete" type="TDec_1302">
+														<xs:annotation>
+															<xs:documentation>Frete Unitário</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="cobr" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Dados da cobrança do CT-e</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="fat" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Dados da fatura</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="nFat" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Número da fatura</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="60"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="vOrig" type="TDec_1302Opc" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor original da fatura</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="vDesc" type="TDec_1302Opc" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor do desconto da fatura</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="vLiq" type="TDec_1302Opc" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor líquido da fatura</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="dup" minOccurs="0" maxOccurs="unbounded">
+														<xs:annotation>
+															<xs:documentation>Dados das duplicatas</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="nDup" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Número da duplicata</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:maxLength value="60"/>
+																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="dVenc" type="TData" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Data de vencimento da duplicata (AAAA-MM-DD)</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="vDup" type="TDec_1302Opc" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor da duplicata</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infCteSub" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Informações do CT-e de substituição </xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="chCte">
+														<xs:annotation>
+															<xs:documentation>Chave de acesso do CT-e a ser substituído (original)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:pattern value="[0-9]{44}"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="indAlteraToma" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Indicador de CT-e Alteração de Tomador</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:enumeration value="1"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infGlobalizado" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Informações do CT-e Globalizado</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="xObs">
+														<xs:annotation>
+															<xs:documentation>Preencher com informações adicionais, legislação do regime especial, etc</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="15"/>
+																<xs:maxLength value="256"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infServVinc" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Informações do Serviço Vinculado a Multimodal</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="infCTeMultimodal" maxOccurs="unbounded">
+														<xs:annotation>
+															<xs:documentation>informações do CT-e multimodal vinculado</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="chCTeMultimodal" type="TChDFe">
+																	<xs:annotation>
+																		<xs:documentation>Chave de acesso do CT-e Multimodal</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="infCteComp" maxOccurs="10">
+								<xs:annotation>
+									<xs:documentation>Detalhamento do CT-e complementado</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="chCTe" type="TChDFe">
+											<xs:annotation>
+												<xs:documentation>Chave do CT-e complementado</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:choice>
+						<xs:element name="autXML" minOccurs="0" maxOccurs="10">
+							<xs:annotation>
+								<xs:documentation>Autorizados para download do XML do DF-e</xs:documentation>
+								<xs:documentation>Informar CNPJ ou CPF. Preencher os zeros não significativos.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpj">
+											<xs:annotation>
+												<xs:documentation>CNPJ do autorizado</xs:documentation>
+												<xs:documentation>Informar zeros não significativos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>CPF do autorizado</xs:documentation>
+												<xs:documentation>Informar zeros não significativos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infRespTec" type="TRespTec" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do Responsável Técnico pela emissão do DF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="infSolicNFF" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de informações do pedido de emissão da Nota Fiscal Fácil</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="xSolic">
+										<xs:annotation>
+											<xs:documentation>Solicitação do pedido de emissão da NFF.</xs:documentation>
+											<xs:documentation>Será preenchido com a totalidade de campos informados no aplicativo emissor serializado.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="8000"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infPAA" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de Informação do Provedor de Assinatura e Autorização</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="CNPJPAA" type="TCnpj">
+										<xs:annotation>
+											<xs:documentation>CNPJ do Provedor de Assinatura e Autorização</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="PAASignature">
+										<xs:annotation>
+											<xs:documentation>Assinatura RSA do Emitente para DFe gerados por PAA</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="SignatureValue" type="xs:base64Binary">
+													<xs:annotation>
+														<xs:documentation>Assinatura digital padrão RSA</xs:documentation>
+														<xs:documentation>Converter o atributo Id do DFe para array de bytes e assinar com a chave privada do RSA com algoritmo SHA1 gerando um valor no formato base64.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="RSAKeyValue" type="TRSAKeyValueType">
+													<xs:annotation>
+														<xs:documentation>Chave Publica no padrão XML RSA Key</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="versao" use="required">
+						<xs:annotation>
+							<xs:documentation>Versão do leiaute</xs:documentation>
+							<xs:documentation>Ex: "4.00"</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="TVerCTe"/>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="Id" use="required">
+						<xs:annotation>
+							<xs:documentation>Identificador da tag a ser assinada</xs:documentation>
+							<xs:documentation>Informar a chave de acesso do CT-e e precedida do literal "CTe"</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:ID">
+								<xs:pattern value="CTe[0-9]{6}[A-Z0-9]{12}[0-9]{26}"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="infCTeSupl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informações suplementares do CT-e</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="qrCodCTe">
+							<xs:annotation>
+								<xs:documentation>Texto com o QR-Code impresso no DACTE</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:minLength value="50"/>
+									<xs:maxLength value="1000"/>
+									<xs:pattern value="((HTTPS?|https?)://.*\?chCTe=[0-9]{44}&amp;tpAmb=[1-2](&amp;sign=[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1})?)"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCTeOS">
+		<xs:annotation>
+			<xs:documentation>Tipo Conhecimento de Transporte Eletrônico Outros Serviços (Modelo 67)</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infCte">
+				<xs:annotation>
+					<xs:documentation>Informações do CT-e Outros Serviços</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ide">
+							<xs:annotation>
+								<xs:documentation>Identificação do CT-e Outros Serviços</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="cUF" type="TCodUfIBGE">
+										<xs:annotation>
+											<xs:documentation>Código da UF do emitente do CT-e.</xs:documentation>
+											<xs:documentation>Utilizar a Tabela do IBGE.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="cCT">
+										<xs:annotation>
+											<xs:documentation>Código numérico que compõe a Chave de Acesso. </xs:documentation>
+											<xs:documentation>Número aleatório gerado pelo emitente para cada CT-e, com o objetivo de evitar acessos indevidos ao documento.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{8}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="CFOP" type="TCfop">
+										<xs:annotation>
+											<xs:documentation>Código Fiscal de Operações e Prestações</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="natOp">
+										<xs:annotation>
+											<xs:documentation>Natureza da Operação</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="mod" type="TModCTOS">
+										<xs:annotation>
+											<xs:documentation>Modelo do documento fiscal</xs:documentation>
+											<xs:documentation>Utilizar o código 67 para identificação do CT-e Outros Serviços, emitido em substituição a Nota Fiscal Modelo 7 para transporte de pessoas, valores e excesso de bagagem.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="serie">
+										<xs:annotation>
+											<xs:documentation>Série do CT-e OS</xs:documentation>
+											<xs:documentation>Preencher com "0" no caso de série única</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TSerie"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="nCT" type="TNF">
+										<xs:annotation>
+											<xs:documentation>Número do CT-e OS</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="dhEmi">
+										<xs:annotation>
+											<xs:documentation>Data e hora de emissão do CT-e OS</xs:documentation>
+											<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TDateTimeUTC"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpImp">
+										<xs:annotation>
+											<xs:documentation>Formato de impressão do DACTE OS</xs:documentation>
+											<xs:documentation>Preencher com: 1 - Retrato; 2 - Paisagem.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpEmis">
+										<xs:annotation>
+											<xs:documentation>Forma de emissão do CT-e</xs:documentation>
+											<xs:documentation>Preencher com:
+1 - Normal;
+ 5 - Contingência FSDA;
+7 - Autorização pela SVC-RS;
+ 8 - Autorização pela SVC-SP</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="5"/>
+												<xs:enumeration value="7"/>
+												<xs:enumeration value="8"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cDV">
+										<xs:annotation>
+											<xs:documentation>Digito Verificador da chave de acesso do CT-e</xs:documentation>
+											<xs:documentation>Informar o dígito  de controle da chave de acesso do CT-e, que deve ser calculado com a aplicação do algoritmo módulo 11 (base 2,9) da chave de acesso. </xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{1}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpAmb" type="TAmb">
+										<xs:annotation>
+											<xs:documentation>Tipo do Ambiente</xs:documentation>
+											<xs:documentation>Preencher com:1 - Produção; 2 - Homologação</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpCTe" type="TFinCTe">
+										<xs:annotation>
+											<xs:documentation>Tipo do CT-e OS</xs:documentation>
+											<xs:documentation>Preencher com:
+0 - CT-e Normal; 
+1 - CT-e Complementar; 
+3 - CT-e de Substituição.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="procEmi" type="TProcEmi">
+										<xs:annotation>
+											<xs:documentation>Identificador do processo de emissão do CT-e OS</xs:documentation>
+											<xs:documentation>Preencher com: 
+											0 - emissão de CT-e com aplicativo do contribuinte;
+											3- emissão CT-e pelo contribuinte com aplicativo fornecido pelo Fisco.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="verProc">
+										<xs:annotation>
+											<xs:documentation>Versão do processo de emissão</xs:documentation>
+											<xs:documentation>Iinformar a versão do aplicativo emissor de CT-e.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="20"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cMunEnv" type="TCodMunIBGE">
+										<xs:annotation>
+											<xs:documentation>Código do Município de envio do CT-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Utilizar a tabela do IBGE. Informar 9999999 para as operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="xMunEnv">
+										<xs:annotation>
+											<xs:documentation>Nome do Município de envio do CT-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Informar PAIS/Municipio para as operações com o exterior.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="UFEnv" type="TUf">
+										<xs:annotation>
+											<xs:documentation>Sigla da UF de envio do CT-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="modal" type="TModTranspOS">
+										<xs:annotation>
+											<xs:documentation>Modal do CT-e OS</xs:documentation>
+											<xs:documentation>Preencher com:
+01-Rodoviário;
+02- Aéreo;
+03 - Aquaviário;
+04 - Ferroviário.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpServ">
+										<xs:annotation>
+											<xs:documentation>Tipo do Serviço</xs:documentation>
+											<xs:documentation>Preencher com: 
+
+6 - Transporte de Pessoas;
+7 - Transporte de Valores;
+8 - Excesso de Bagagem.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="6"/>
+												<xs:enumeration value="7"/>
+												<xs:enumeration value="8"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="indIEToma">
+										<xs:annotation>
+											<xs:documentation>Indicador da IE do tomador:
+1 – Contribuinte ICMS;
+2 – Contribuinte isento de inscrição;
+9 – Não Contribuinte</xs:documentation>
+											<xs:documentation>Aplica-se ao tomador que for indicado no toma3 ou toma4</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="9"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cMunIni" type="TCodMunIBGE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Código do Município de início da prestação</xs:documentation>
+											<xs:documentation>Utilizar a tabela do IBGE. Informar 9999999 para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="xMunIni" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Nome do Município do início da prestação</xs:documentation>
+											<xs:documentation>Informar 'EXTERIOR' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="UFIni" type="TUf" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>UF do início da prestação</xs:documentation>
+											<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="cMunFim" type="TCodMunIBGE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Código do Município de término da prestação</xs:documentation>
+											<xs:documentation>Utilizar a tabela do IBGE. Informar 9999999 para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="xMunFim" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Nome do Município do término da prestação</xs:documentation>
+											<xs:documentation>Informar 'EXTERIOR' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="UFFim" type="TUf" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>UF do término da prestação</xs:documentation>
+											<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="infPercurso" minOccurs="0" maxOccurs="25">
+										<xs:annotation>
+											<xs:documentation source=" Municípios onde ocorreram os carregamentos">Informações do Percurso do CT-e Outros Serviços</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="UFPer" type="TUf">
+													<xs:annotation>
+														<xs:documentation>Sigla das Unidades da Federação do percurso do veículo.</xs:documentation>
+														<xs:documentation>Não é necessário repetir as UF de Início e Fim</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:sequence minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informar apenas
+para tpEmis diferente de 1</xs:documentation>
+										</xs:annotation>
+										<xs:element name="dhCont" type="TDateTimeUTC">
+											<xs:annotation>
+												<xs:documentation>Data e Hora da entrada em contingência</xs:documentation>
+												<xs:documentation>Informar a data e hora no formato AAAA-MM-DDTHH:MM:SS</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="xJust">
+											<xs:annotation>
+												<xs:documentation>Justificativa da entrada em contingência</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="15"/>
+													<xs:maxLength value="256"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+									<xs:element name="gCompraGov" type="TCompraGovReduzido" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Grupo de Compras Governamentais</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="compl" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Dados complementares do CT-e para fins operacionais ou comerciais</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="xCaracAd" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Característica adicional do transporte</xs:documentation>
+											<xs:documentation>Texto livre:
+REENTREGA; DEVOLUÇÃO; REFATURAMENTO; etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="15"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xCaracSer" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Característica adicional do serviço</xs:documentation>
+											<xs:documentation>Texto livre:
+											ENTREGA EXPRESSA; LOGÍSTICA REVERSA; CONVENCIONAL; EMERGENCIAL; etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="30"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xEmi" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Funcionário emissor do CTe</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="20"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xObs" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Observações Gerais</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="2000"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="ObsCont" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Campo de uso livre do contribuinte</xs:documentation>
+											<xs:documentation>Informar o nome do campo no atributo xCampo e o conteúdo do campo no XTexto</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xTexto">
+													<xs:annotation>
+														<xs:documentation>Conteúdo do campo</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="160"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="xCampo" use="required">
+												<xs:annotation>
+													<xs:documentation>Identificação do campo</xs:documentation>
+												</xs:annotation>
+												<xs:simpleType>
+													<xs:restriction base="TString">
+														<xs:minLength value="1"/>
+														<xs:maxLength value="20"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="ObsFisco" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Campo de uso livre do contribuinte</xs:documentation>
+											<xs:documentation>Informar o nome do campo no atributo xCampo e o conteúdo do campo no XTexto</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xTexto">
+													<xs:annotation>
+														<xs:documentation>Conteúdo do campo</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="xCampo" use="required">
+												<xs:annotation>
+													<xs:documentation>Identificação do campo</xs:documentation>
+												</xs:annotation>
+												<xs:simpleType>
+													<xs:restriction base="TString">
+														<xs:minLength value="1"/>
+														<xs:maxLength value="20"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="emit">
+							<xs:annotation>
+								<xs:documentation>Identificação do Emitente do CT-e OS</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="CNPJ" type="TCnpj">
+										<xs:annotation>
+											<xs:documentation>CNPJ do emitente</xs:documentation>
+											<xs:documentation>Informar zeros não significativos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="IE">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual do Emitente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIe"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="IEST" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual do Substituto Tributário</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIe"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão social ou Nome do emitente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xFant" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Nome fantasia</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="enderEmit" type="TEndeEmi">
+										<xs:annotation>
+											<xs:documentation>Endereço do emitente</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="CRT" type="TCRT">
+										<xs:annotation>
+											<xs:documentation>Código do Regime Tributário</xs:documentation>
+											<xs:documentation>Informar: 1=Simples Nacional; 
+2=Simples Nacional, excesso sublimite de receita bruta;
+3=Regime Normal;
+4=Simples Nacional - Microempreendedor Individual – MEI.
+</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="toma" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do Tomador/Usuário do Serviço</xs:documentation>
+								<xs:documentation>Opcional para Excesso de Bagagem</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpjOpc">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+												<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.
+												Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>Número do CPF</xs:documentation>
+												<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="IE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual</xs:documentation>
+											<xs:documentation>Informar a IE do tomador ou ISENTO se tomador é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o tomador não seja contribuinte do ICMS não informar o conteúdo.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIeDest"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão social ou nome do tomador</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xFant" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Nome fantasia</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fone" type="TFone" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Telefone</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="enderToma" type="TEndereco">
+										<xs:annotation>
+											<xs:documentation>Dados do endereço</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="email" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Endereço de email</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TEmail"/>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="vPrest">
+							<xs:annotation>
+								<xs:documentation>Valores da Prestação de Serviço</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vTPrest" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor Total da Prestação do Serviço</xs:documentation>
+											<xs:documentation>Pode conter zeros quando o CT-e for de complemento de ICMS</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vRec" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor a Receber</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="Comp" minOccurs="0" maxOccurs="unbounded">
+										<xs:annotation>
+											<xs:documentation>Componentes do Valor da Prestação</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xNome">
+													<xs:annotation>
+														<xs:documentation>Nome do componente</xs:documentation>
+														<xs:documentation>Exxemplos: FRETE PESO, FRETE VALOR, SEC/CAT, ADEME, AGENDAMENTO, etc</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="15"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="vComp" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do componente</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="imp">
+							<xs:annotation>
+								<xs:documentation>Informações relativas aos Impostos</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="ICMS" type="TImpOS">
+										<xs:annotation>
+											<xs:documentation>Informações relativas ao ICMS</xs:documentation>
+											<xs:documentation/>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vTotTrib" type="TDec_1302" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor Total dos Tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="infAdFisco" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações adicionais de interesse do Fisco</xs:documentation>
+											<xs:documentation>Norma referenciada, informações complementares, etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="2000"/>
+												<xs:minLength value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="ICMSUFFim" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações do ICMS de partilha com a UF de término do serviço de transporte na operação interestadual</xs:documentation>
+											<xs:documentation>Grupo a ser informado nas prestações interestaduais para consumidor final, não contribuinte do ICMS</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="vBCUFFim" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor da BC do ICMS na UF de término da prestação do serviço de transporte</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pFCPUFFim" type="TDec_0302">
+													<xs:annotation>
+														<xs:documentation>Percentual do ICMS relativo ao Fundo de Combate à pobreza (FCP) na UF de término da prestação do serviço de transporte</xs:documentation>
+														<xs:documentation>Alíquota adotada nas operações internas na UF do destinatário</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pICMSUFFim" type="TDec_0302">
+													<xs:annotation>
+														<xs:documentation>Alíquota interna da UF de término da prestação do serviço de transporte</xs:documentation>
+														<xs:documentation>Alíquota adotada nas operações internas na UF do destinatário</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pICMSInter" type="TDec_0302">
+													<xs:annotation>
+														<xs:documentation>Alíquota interestadual das UF envolvidas</xs:documentation>
+														<xs:documentation>Alíquota interestadual das UF envolvidas
+</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vFCPUFFim" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS relativo ao Fundo de Combate á Pobreza (FCP) da UF de término da prestação</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSUFFim" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS de partilha para a UF de término da prestação do serviço de transporte</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSUFIni" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS de partilha para a UF de início da prestação do serviço de transporte</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="infTribFed" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações dos tributos federais</xs:documentation>
+											<xs:documentation>Grupo a ser informado nas prestações interestaduais para consumidor final, não contribuinte do ICMS</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="vPIS" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor do PIS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vCOFINS" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor COFINS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vIR" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor de Imposto de Renda</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vINSS" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor do INSS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vCSLL" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor do CSLL</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="IBSCBS" type="TTribCTe" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Grupo de informações do IBS e CBS</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vTotDFe" type="TDec_1302" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor total do documento fiscal 
+(vTPrest + total do IBS + total da CBS) 
+</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:choice>
+							<xs:element name="infCTeNorm">
+								<xs:annotation>
+									<xs:documentation>Grupo de informações do CT-e OS Normal</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="infServico">
+											<xs:annotation>
+												<xs:documentation>Informações da Prestação do Serviço</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="xDescServ">
+														<xs:annotation>
+															<xs:documentation>Descrição do Serviço prestado</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="30"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="infQ" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Informações de quantidades da Carga do CT-e</xs:documentation>
+															<xs:documentation>Para Transporte de Pessoas indicar número de passageiros, para excesso de bagagem e transporte de valores indicar número de Volumes/Malotes</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="qCarga" type="TDec_1104">
+																	<xs:annotation>
+																		<xs:documentation>Quantidade</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infDocRef" minOccurs="0" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>Informações dos documentos referenciados</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:choice>
+													<xs:sequence>
+														<xs:element name="nDoc">
+															<xs:annotation>
+																<xs:documentation>Número </xs:documentation>
+															</xs:annotation>
+															<xs:simpleType>
+																<xs:restriction base="TString">
+																	<xs:minLength value="1"/>
+																	<xs:maxLength value="20"/>
+																</xs:restriction>
+															</xs:simpleType>
+														</xs:element>
+														<xs:element name="serie" minOccurs="0">
+															<xs:annotation>
+																<xs:documentation>Série</xs:documentation>
+															</xs:annotation>
+															<xs:simpleType>
+																<xs:restriction base="TString">
+																	<xs:minLength value="1"/>
+																	<xs:maxLength value="3"/>
+																</xs:restriction>
+															</xs:simpleType>
+														</xs:element>
+														<xs:element name="subserie" minOccurs="0">
+															<xs:annotation>
+																<xs:documentation>Subsérie</xs:documentation>
+															</xs:annotation>
+															<xs:simpleType>
+																<xs:restriction base="TString">
+																	<xs:minLength value="1"/>
+																	<xs:maxLength value="3"/>
+																</xs:restriction>
+															</xs:simpleType>
+														</xs:element>
+														<xs:element name="dEmi" type="TData">
+															<xs:annotation>
+																<xs:documentation>Data de Emissão</xs:documentation>
+																<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+															</xs:annotation>
+														</xs:element>
+														<xs:element name="vDoc" type="TDec_1302" minOccurs="0">
+															<xs:annotation>
+																<xs:documentation>Valor Transportado</xs:documentation>
+															</xs:annotation>
+														</xs:element>
+													</xs:sequence>
+													<xs:element name="chBPe">
+														<xs:annotation>
+															<xs:documentation>Chave de acesso do BP-e que possui eventos excesso de bagagem</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TChDFe"/>
+														</xs:simpleType>
+													</xs:element>
+												</xs:choice>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="seg" minOccurs="0" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>Informações de Seguro da Carga</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="respSeg">
+														<xs:annotation>
+															<xs:documentation>Responsável pelo seguro</xs:documentation>
+															<xs:documentation>Preencher com:
+
+4 - Emitente do CT-e;
+
+5 - Tomador de Serviço.
+</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:whiteSpace value="preserve"/>
+																<xs:minLength value="1"/>
+																<xs:maxLength value="1"/>
+																<xs:enumeration value="4"/>
+																<xs:enumeration value="5"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="xSeg" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Nome da Seguradora</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="30"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="nApol" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Número da Apólice</xs:documentation>
+															<xs:documentation>Obrigatório pela lei 11.442/07 (RCTRC)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="20"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infModal" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Informações do modal
+Obrigatório para Pessoas e Bagagem</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:any processContents="skip">
+														<xs:annotation>
+															<xs:documentation>XML do modal
+Insira neste local o XML específico do modal</xs:documentation>
+															<xs:documentation>O elemento do tipo -any- permite estender o documento XML com elementos não especificados pelo schema.
+													Insira neste local - any- o XML específico do modal (rodoviário). A especificação do schema XML para cada modal pode ser encontrada nos arquivos que acompanham este pacote de liberação:
+											Rodoviário - ver arquivo CTeModalRodoviarioOS_v9.99
+
+Onde v9.99 é a a designação genérica para a versão do arquivo. Por exemplo, o arquivo para o schema do modal Rodoviário na versão 4.00 será denominado "CTeModalRodoviarioOS_v4.00".</xs:documentation>
+														</xs:annotation>
+													</xs:any>
+												</xs:sequence>
+												<xs:attribute name="versaoModal" use="required">
+													<xs:annotation>
+														<xs:documentation>Versão do leiaute específico para o Modal</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="4\.(0[0-9]|[1-9][0-9])"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:attribute>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infCteSub" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Informações do CT-e de substituição </xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="chCte">
+														<xs:annotation>
+															<xs:documentation>Chave de acesso do CT-e a ser substituído (original)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:pattern value="[0-9]{44}"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="refCTeCanc" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Chave de acesso do CT-e Cancelado
+Somente para Transporte de Valores</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TChDFe"/>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="cobr" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Dados da cobrança do CT-e</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="fat" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Dados da fatura</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="nFat" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Número da fatura</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="60"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="vOrig" type="TDec_1302Opc" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor original da fatura</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="vDesc" type="TDec_1302Opc" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor do desconto da fatura</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="vLiq" type="TDec_1302Opc" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor líquido da fatura</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="dup" minOccurs="0" maxOccurs="unbounded">
+														<xs:annotation>
+															<xs:documentation>Dados das duplicatas</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="nDup" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Número da duplicata</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:maxLength value="60"/>
+																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="dVenc" type="TData" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Data de vencimento da duplicata (AAAA-MM-DD)</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="vDup" type="TDec_1302Opc" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor da duplicata</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infGTVe" minOccurs="0" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>Informações das GTV-e relacionadas ao CT-e OS</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="chCTe">
+														<xs:annotation>
+															<xs:documentation>Chave de acesso da GTV-e</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:pattern value="[0-9]{44}"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="Comp" maxOccurs="unbounded">
+														<xs:annotation>
+															<xs:documentation>Componentes do Valor da GTVe</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="tpComp">
+																	<xs:annotation>
+																		<xs:documentation>Tipo do Componente</xs:documentation>
+																		<xs:documentation>1-Custodia
+2-Embarque
+3-Tempo de espera
+4-Malote
+5-Ad Valorem
+6-Outros</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="1"/>
+																			<xs:enumeration value="2"/>
+																			<xs:enumeration value="3"/>
+																			<xs:enumeration value="4"/>
+																			<xs:enumeration value="5"/>
+																			<xs:enumeration value="6"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="vComp" type="TDec_1302">
+																	<xs:annotation>
+																		<xs:documentation>Valor do componente</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="xComp" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Nome do componente (informar apenas para outros)</xs:documentation>
+																		<xs:documentation>Exemplos: FRETE PESO, FRETE VALOR, SEC/CAT, ADEME, AGENDAMENTO, etc</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:maxLength value="15"/>
+																			<xs:minLength value="0"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="infCteComp" maxOccurs="10">
+								<xs:annotation>
+									<xs:documentation>Detalhamento do CT-e complementado</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="chCTe" type="TChDFe">
+											<xs:annotation>
+												<xs:documentation>Chave do CT-e complementado</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:choice>
+						<xs:element name="autXML" minOccurs="0" maxOccurs="10">
+							<xs:annotation>
+								<xs:documentation>Autorizados para download do XML do DF-e</xs:documentation>
+								<xs:documentation>Informar CNPJ ou CPF. Preencher os zeros não significativos.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpj">
+											<xs:annotation>
+												<xs:documentation>CNPJ do autorizado</xs:documentation>
+												<xs:documentation>Informar zeros não significativos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>CPF do autorizado</xs:documentation>
+												<xs:documentation>Informar zeros não significativos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infRespTec" type="TRespTec" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do Responsável Técnico pela emissão do DF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="versao" use="required">
+						<xs:annotation>
+							<xs:documentation>Versão do leiaute</xs:documentation>
+							<xs:documentation>Ex: "4.00"</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="TVerCTe"/>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="Id" use="required">
+						<xs:annotation>
+							<xs:documentation>Identificador da tag a ser assinada</xs:documentation>
+							<xs:documentation>Informar a chave de acesso do CT-e OS e precedida do literal "CTe"</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:ID">
+								<xs:pattern value="CTe[0-9]{6}[A-Z0-9]{12}[0-9]{26}"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="infCTeSupl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informações suplementares do CT-e</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="qrCodCTe">
+							<xs:annotation>
+								<xs:documentation>Texto com o QR-Code impresso no DACTE</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:minLength value="50"/>
+									<xs:maxLength value="1000"/>
+									<xs:pattern value="((HTTPS?|https?)://.*\?chCTe=[0-9]{44}&amp;tpAmb=[1-2](&amp;sign=[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1})?)"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature"/>
+		</xs:sequence>
+		<xs:attribute name="versao" use="required">
+			<xs:annotation>
+				<xs:documentation>Versão do leiaute</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="TVerCTe"/>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="TEndeEmi">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Endereço</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="xLgr">
+				<xs:annotation>
+					<xs:documentation>Logradouro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="nro">
+				<xs:annotation>
+					<xs:documentation>Número</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xCpl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Complemento</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xBairro">
+				<xs:annotation>
+					<xs:documentation>Bairro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cMun" type="TCodMunIBGE">
+				<xs:annotation>
+					<xs:documentation>Código do município (utilizar a tabela do IBGE)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMun">
+				<xs:annotation>
+					<xs:documentation>Nome do município</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="CEP" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>CEP</xs:documentation>
+					<xs:documentation>Informar zeros não significativos</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{8}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUF_sem_EX">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="fone" type="TFone" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Telefone</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TEndereco">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Endereço</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="xLgr">
+				<xs:annotation>
+					<xs:documentation>Logradouro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="255"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="nro">
+				<xs:annotation>
+					<xs:documentation>Número</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xCpl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Complemento</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xBairro">
+				<xs:annotation>
+					<xs:documentation>Bairro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cMun" type="TCodMunIBGE">
+				<xs:annotation>
+					<xs:documentation>Código do município (utilizar a tabela do IBGE)</xs:documentation>
+					<xs:documentation>Informar 9999999 para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMun">
+				<xs:annotation>
+					<xs:documentation>Nome do município</xs:documentation>
+					<xs:documentation>Informar EXTERIOR para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="CEP" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>CEP</xs:documentation>
+					<xs:documentation>Informar os zeros não significativos</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{8}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUf">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF</xs:documentation>
+					<xs:documentation>Informar EX para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cPais" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Código do país</xs:documentation>
+					<xs:documentation>Utilizar a tabela do BACEN</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{1,4}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xPais" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Nome do país</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TEndernac">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Endereço</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="xLgr">
+				<xs:annotation>
+					<xs:documentation>Logradouro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="255"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="nro">
+				<xs:annotation>
+					<xs:documentation>Número</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xCpl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Complemento</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xBairro">
+				<xs:annotation>
+					<xs:documentation>Bairro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cMun" type="TCodMunIBGE">
+				<xs:annotation>
+					<xs:documentation>Código do município (utilizar a tabela do IBGE), informar 9999999 para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMun">
+				<xs:annotation>
+					<xs:documentation>Nome do município, , informar EXTERIOR para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="CEP" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>CEP</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{8}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUf">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF</xs:documentation>
+					<xs:documentation>Informar EX para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TEndOrg">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Endereço</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="xLgr">
+				<xs:annotation>
+					<xs:documentation>Logradouro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="nro">
+				<xs:annotation>
+					<xs:documentation>Número</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xCpl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Complemento</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xBairro">
+				<xs:annotation>
+					<xs:documentation>Bairro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cMun" type="TCodMunIBGE">
+				<xs:annotation>
+					<xs:documentation>Código do município (utilizar a tabela do IBGE), informar 9999999 para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMun">
+				<xs:annotation>
+					<xs:documentation>Nome do município</xs:documentation>
+					<xs:documentation>Informar EXTERIOR para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="CEP" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>CEP</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{8}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUf">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF</xs:documentation>
+					<xs:documentation>Informar EX para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cPais" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Código do país</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{1,4}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xPais" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Nome do país</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="fone" type="TFone" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Telefone</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TLocal">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Local de Origem ou Destino</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="cMun" type="TCodMunIBGE">
+				<xs:annotation>
+					<xs:documentation>Código do município (utilizar a tabela do IBGE)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMun">
+				<xs:annotation>
+					<xs:documentation>Nome do município</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUf">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TEndReEnt">
+		<xs:annotation>
+			<xs:documentation> Tipo Dados do Local de Retirada ou Entrega</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="CNPJ" type="TCnpj">
+					<xs:annotation>
+						<xs:documentation>Número do CNPJ</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="CPF" type="TCpf">
+					<xs:annotation>
+						<xs:documentation>Número do CPF</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+			<xs:element name="xNome">
+				<xs:annotation>
+					<xs:documentation>Razão Social ou Nome</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xLgr">
+				<xs:annotation>
+					<xs:documentation>Logradouro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="255"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="nro">
+				<xs:annotation>
+					<xs:documentation>Número</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xCpl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Complemento</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xBairro">
+				<xs:annotation>
+					<xs:documentation>Bairro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cMun" type="TCodMunIBGE">
+				<xs:annotation>
+					<xs:documentation>Código do município (utilizar a tabela do IBGE) </xs:documentation>
+					<xs:documentation>Informar 9999999 para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMun">
+				<xs:annotation>
+					<xs:documentation>Nome do município</xs:documentation>
+					<xs:documentation>Informar EXTERIOR para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUf">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF</xs:documentation>
+					<xs:documentation>Informar EX para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TImp">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Imposto CT-e</xs:documentation>
+		</xs:annotation>
+		<xs:choice>
+			<xs:element name="ICMS00">
+				<xs:annotation>
+					<xs:documentation>Prestação sujeito à tributação normal do ICMS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation>00 - tributação normal ICMS</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="00"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="vBC" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor da BC do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="pICMS" type="TDec_0302">
+							<xs:annotation>
+								<xs:documentation>Alíquota do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vICMS" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMS20">
+				<xs:annotation>
+					<xs:documentation>Prestação sujeito à tributação com redução de BC do ICMS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do serviço</xs:documentation>
+								<xs:documentation>20 - tributação com BC reduzida do ICMS</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="20"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="pRedBC" type="TDec_0302Opc">
+							<xs:annotation>
+								<xs:documentation>Percentual de redução da BC</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vBC" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor da BC do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="pICMS" type="TDec_0302">
+							<xs:annotation>
+								<xs:documentation>Alíquota do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vICMS" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:sequence minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Sequencia XML</xs:documentation>
+							</xs:annotation>
+							<xs:element name="vICMSDeson" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="cBenef">
+								<xs:annotation>
+									<xs:documentation>Código de Benefício Fiscal na UF</xs:documentation>
+									<xs:documentation>Código de Benefício Fiscal utilizado pela UF
+</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:whiteSpace value="preserve"/>
+										<xs:maxLength value="10"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMS45">
+				<xs:annotation>
+					<xs:documentation>ICMS  Isento, não Tributado ou diferido</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation>Preencher com:
+								40 - ICMS isenção;
+								41 - ICMS não tributada;
+								51 - ICMS diferido</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="40"/>
+									<xs:enumeration value="41"/>
+									<xs:enumeration value="51"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:sequence minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Sequencia XML</xs:documentation>
+							</xs:annotation>
+							<xs:element name="vICMSDeson" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="cBenef">
+								<xs:annotation>
+									<xs:documentation>Código de Benefício Fiscal na UF</xs:documentation>
+									<xs:documentation>Código de Benefício Fiscal utilizado pela UF
+</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:whiteSpace value="preserve"/>
+										<xs:maxLength value="10"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMS60">
+				<xs:annotation>
+					<xs:documentation>Tributação pelo ICMS60 - ICMS cobrado por substituição tributária.Responsabilidade do recolhimento do ICMS atribuído ao tomador ou 3º por ST</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation>60 - ICMS cobrado por substituição tributária</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="60"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="vBCSTRet" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor da BC do ICMS ST retido</xs:documentation>
+								<xs:documentation>Valor do frete sobre o qual será calculado o ICMS a ser substituído na Prestação. </xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vICMSSTRet" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor do ICMS ST retido</xs:documentation>
+								<xs:documentation>Resultado da multiplicação do “vBCSTRet” x “pICMSSTRet” – que será valor do ICMS a ser retido pelo Substituto. Podendo o valor do ICMS a ser retido efetivamente, sofrer ajustes conforme a opção tributaria do transportador substituído. </xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="pICMSSTRet" type="TDec_0302">
+							<xs:annotation>
+								<xs:documentation>Alíquota do ICMS</xs:documentation>
+								<xs:documentation>Percentual de Alíquota incidente na prestação de serviço de transporte.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCred" type="TDec_1302" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Valor do Crédito outorgado/Presumido</xs:documentation>
+								<xs:documentation>Preencher somente quando o transportador substituído, for optante pelo crédito outorgado previsto no Convênio 106/96 e corresponde ao percentual de 20% do valor do ICMS ST retido. </xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:sequence minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Sequencia XML</xs:documentation>
+							</xs:annotation>
+							<xs:element name="vICMSDeson" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="cBenef">
+								<xs:annotation>
+									<xs:documentation>Código de Benefício Fiscal na UF</xs:documentation>
+									<xs:documentation>Código de Benefício Fiscal utilizado pela UF
+</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:whiteSpace value="preserve"/>
+										<xs:maxLength value="10"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMS90">
+				<xs:annotation>
+					<xs:documentation>ICMS Outros</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation> 90 - ICMS outros</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="90"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="pRedBC" type="TDec_0302Opc" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Percentual de redução da BC</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vBC" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor da BC do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="pICMS" type="TDec_0302">
+							<xs:annotation>
+								<xs:documentation>Alíquota do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vICMS" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCred" type="TDec_1302" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Valor do Crédito Outorgado/Presumido</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:sequence minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Sequencia XML</xs:documentation>
+							</xs:annotation>
+							<xs:element name="vICMSDeson" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="cBenef">
+								<xs:annotation>
+									<xs:documentation>Código de Benefício Fiscal na UF</xs:documentation>
+									<xs:documentation>Código de Benefício Fiscal utilizado pela UF
+</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:whiteSpace value="preserve"/>
+										<xs:maxLength value="10"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMSOutraUF">
+				<xs:annotation>
+					<xs:documentation>ICMS devido à UF de origem da prestação, quando  diferente da UF do emitente</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation>90 - ICMS Outra UF</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="90"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="pRedBCOutraUF" type="TDec_0302Opc" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Percentual de redução da BC</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vBCOutraUF" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor da BC do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="pICMSOutraUF" type="TDec_0302">
+							<xs:annotation>
+								<xs:documentation>Alíquota do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vICMSOutraUF" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor do ICMS devido outra UF</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:sequence minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Sequencia XML</xs:documentation>
+							</xs:annotation>
+							<xs:element name="vICMSDeson" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="cBenef">
+								<xs:annotation>
+									<xs:documentation>Código de Benefício Fiscal na UF</xs:documentation>
+									<xs:documentation>Código de Benefício Fiscal utilizado pela UF
+</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:whiteSpace value="preserve"/>
+										<xs:maxLength value="10"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMSSN">
+				<xs:annotation>
+					<xs:documentation>Simples Nacional</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation>90 - ICMS Simples Nacional</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="90"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="indSN">
+							<xs:annotation>
+								<xs:documentation>Indica se o contribuinte é Simples Nacional			1=Sim</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="1"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="TImpOS">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Imposto para CT-e OS</xs:documentation>
+		</xs:annotation>
+		<xs:choice>
+			<xs:element name="ICMS00">
+				<xs:annotation>
+					<xs:documentation>Prestação sujeito à tributação normal do ICMS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation>00 - tributação normal ICMS</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="00"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="vBC" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor da BC do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="pICMS" type="TDec_0302">
+							<xs:annotation>
+								<xs:documentation>Alíquota do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vICMS" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMS20">
+				<xs:annotation>
+					<xs:documentation>Prestação sujeito à tributação com redução de BC do ICMS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do serviço</xs:documentation>
+								<xs:documentation>20 - tributação com BC reduzida do ICMS</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="20"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="pRedBC" type="TDec_0302Opc">
+							<xs:annotation>
+								<xs:documentation>Percentual de redução da BC</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vBC" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor da BC do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="pICMS" type="TDec_0302">
+							<xs:annotation>
+								<xs:documentation>Alíquota do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vICMS" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:sequence minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Sequencia XML</xs:documentation>
+							</xs:annotation>
+							<xs:element name="vICMSDeson" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="cBenef">
+								<xs:annotation>
+									<xs:documentation>Código de Benefício Fiscal na UF</xs:documentation>
+									<xs:documentation>Código de Benefício Fiscal utilizado pela UF
+</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:whiteSpace value="preserve"/>
+										<xs:maxLength value="10"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMS45">
+				<xs:annotation>
+					<xs:documentation>ICMS  Isento, não Tributado ou diferido</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation>Preencher com:
+								40 - ICMS isenção;
+								41 - ICMS não tributada;
+								51 - ICMS diferido</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="40"/>
+									<xs:enumeration value="41"/>
+									<xs:enumeration value="51"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:sequence minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Sequencia XML</xs:documentation>
+							</xs:annotation>
+							<xs:element name="vICMSDeson" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="cBenef">
+								<xs:annotation>
+									<xs:documentation>Código de Benefício Fiscal na UF</xs:documentation>
+									<xs:documentation>Código de Benefício Fiscal utilizado pela UF
+</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:whiteSpace value="preserve"/>
+										<xs:maxLength value="10"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMS90">
+				<xs:annotation>
+					<xs:documentation>ICMS Outros</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation> 90 - Outros</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="90"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="pRedBC" type="TDec_0302Opc" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Percentual de redução da BC</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vBC" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor da BC do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="pICMS" type="TDec_0302">
+							<xs:annotation>
+								<xs:documentation>Alíquota do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vICMS" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCred" type="TDec_1302" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Valor do Crédito Outorgado/Presumido</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:sequence minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Sequencia XML</xs:documentation>
+							</xs:annotation>
+							<xs:element name="vICMSDeson" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="cBenef">
+								<xs:annotation>
+									<xs:documentation>Código de Benefício Fiscal na UF</xs:documentation>
+									<xs:documentation>Código de Benefício Fiscal utilizado pela UF
+</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:whiteSpace value="preserve"/>
+										<xs:maxLength value="10"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMSOutraUF">
+				<xs:annotation>
+					<xs:documentation>ICMS devido à UF de origem da prestação, quando  diferente da UF do emitente</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation>90 - ICMS Outra UF</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="90"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="pRedBCOutraUF" type="TDec_0302Opc" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Percentual de redução da BC</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vBCOutraUF" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor da BC do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="pICMSOutraUF" type="TDec_0302">
+							<xs:annotation>
+								<xs:documentation>Alíquota do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vICMSOutraUF" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor do ICMS devido outra UF</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:sequence minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Sequencia XML</xs:documentation>
+							</xs:annotation>
+							<xs:element name="vICMSDeson" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="cBenef">
+								<xs:annotation>
+									<xs:documentation>Código de Benefício Fiscal na UF</xs:documentation>
+									<xs:documentation>Código de Benefício Fiscal utilizado pela UF
+</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:whiteSpace value="preserve"/>
+										<xs:maxLength value="10"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMSSN">
+				<xs:annotation>
+					<xs:documentation>Simples Nacional</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation>90 - ICMS Simples Nacional</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="90"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="indSN">
+							<xs:annotation>
+								<xs:documentation>Indica se o contribuinte é Simples Nacional			1=Sim</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="1"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="TUnidadeTransp">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados Unidade de Transporte</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpUnidTransp" type="TtipoUnidTransp">
+				<xs:annotation>
+					<xs:documentation>Tipo da Unidade de Transporte</xs:documentation>
+					<xs:documentation>1 - Rodoviário Tração
+2 - Rodoviário Reboque
+3 - Navio
+4 - Balsa
+5 - Aeronave
+6 - Vagão
+7 - Outros</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="idUnidTransp" type="TContainer">
+				<xs:annotation>
+					<xs:documentation>Identificação da Unidade de Transporte</xs:documentation>
+					<xs:documentation>Informar a identificação conforme o tipo de unidade de transporte.
+Por exemplo: para rodoviário tração ou reboque deverá preencher com a placa do veículo.
+</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="lacUnidTransp" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Lacres das Unidades de Transporte</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="nLacre">
+							<xs:annotation>
+								<xs:documentation>Número do lacre</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TString">
+									<xs:minLength value="1"/>
+									<xs:maxLength value="20"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="infUnidCarga" type="TUnidCarga" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Informações das Unidades de Carga (Containeres/ULD/Outros)</xs:documentation>
+					<xs:documentation>Dispositivo de carga utilizada (Unit Load Device - ULD) significa todo tipo de contêiner de carga, vagão, contêiner de avião, palete de aeronave com rede ou palete de aeronave com rede sobre um iglu. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="qtdRat" type="TDec_0302_0303" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Quantidade rateada (Peso,Volume)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TUnidCarga">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados Unidade de Carga</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpUnidCarga" type="TtipoUnidCarga">
+				<xs:annotation>
+					<xs:documentation>Tipo da Unidade de Carga</xs:documentation>
+					<xs:documentation>1 - Container
+2 - ULD
+3 - Pallet
+4 - Outros</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="idUnidCarga" type="TContainer">
+				<xs:annotation>
+					<xs:documentation>Identificação da Unidade de Carga</xs:documentation>
+					<xs:documentation>Informar a identificação da unidade de carga, por exemplo: número do container.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="lacUnidCarga" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Lacres das Unidades de Carga</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="nLacre">
+							<xs:annotation>
+								<xs:documentation>Número do lacre</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TString">
+									<xs:minLength value="1"/>
+									<xs:maxLength value="20"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="qtdRat" type="TDec_0302_0303" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Quantidade rateada (Peso,Volume)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TRespTec">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados da Responsável Técnico</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CNPJ" type="TCnpj">
+				<xs:annotation>
+					<xs:documentation>CNPJ da pessoa jurídica responsável técnica pelo sistema utilizado na emissão do documento fiscal eletrônico</xs:documentation>
+					<xs:documentation>Informar o CNPJ da pessoa jurídica desenvolvedora do sistema utilizado na emissão do documento fiscal eletrônico.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xContato">
+				<xs:annotation>
+					<xs:documentation>Nome da pessoa a ser contatada</xs:documentation>
+					<xs:documentation>Informar o nome da pessoa a ser contatada na empresa desenvolvedora do sistema utilizado na emissão do documento fiscal eletrônico. No caso de pessoa física, informar o respectivo nome.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="email" type="TEmail">
+				<xs:annotation>
+					<xs:documentation>Email da pessoa jurídica a ser contatada</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="fone">
+				<xs:annotation>
+					<xs:documentation>Telefone da pessoa jurídica a ser contatada</xs:documentation>
+					<xs:documentation>Preencher com o Código DDD + número do telefone.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{7,12}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:sequence minOccurs="0">
+				<xs:element name="idCSRT">
+					<xs:annotation>
+						<xs:documentation>Identificador do código de segurança do responsável técnico</xs:documentation>
+						<xs:documentation>Identificador do CSRT utilizado para geração do hash</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:pattern value="[0-9]{3}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="hashCSRT">
+					<xs:annotation>
+						<xs:documentation>Hash do token do código de segurança do responsável técnico</xs:documentation>
+						<xs:documentation>O hashCSRT é o resultado das funções SHA-1 e base64 do token CSRT fornecido pelo fisco + chave de acesso do DF-e. (Implementação em futura NT)
+
+Observação: 28 caracteres são representados no schema como 20 bytes do tipo base64Binary</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:base64Binary">
+							<xs:length value="20"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="TCfop">
+		<xs:annotation>
+			<xs:documentation>Tipo CFOP</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[123567][0-9]([0-9][1-9]|[1-9][0-9])"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCListServ">
+		<xs:annotation>
+			<xs:documentation>Tipo Código da Lista de Serviços LC 116/2003</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="101"/>
+			<xs:enumeration value="102"/>
+			<xs:enumeration value="103"/>
+			<xs:enumeration value="104"/>
+			<xs:enumeration value="105"/>
+			<xs:enumeration value="106"/>
+			<xs:enumeration value="107"/>
+			<xs:enumeration value="108"/>
+			<xs:enumeration value="201"/>
+			<xs:enumeration value="302"/>
+			<xs:enumeration value="303"/>
+			<xs:enumeration value="304"/>
+			<xs:enumeration value="305"/>
+			<xs:enumeration value="401"/>
+			<xs:enumeration value="402"/>
+			<xs:enumeration value="403"/>
+			<xs:enumeration value="404"/>
+			<xs:enumeration value="405"/>
+			<xs:enumeration value="406"/>
+			<xs:enumeration value="407"/>
+			<xs:enumeration value="408"/>
+			<xs:enumeration value="409"/>
+			<xs:enumeration value="410"/>
+			<xs:enumeration value="411"/>
+			<xs:enumeration value="412"/>
+			<xs:enumeration value="413"/>
+			<xs:enumeration value="414"/>
+			<xs:enumeration value="415"/>
+			<xs:enumeration value="416"/>
+			<xs:enumeration value="417"/>
+			<xs:enumeration value="418"/>
+			<xs:enumeration value="419"/>
+			<xs:enumeration value="420"/>
+			<xs:enumeration value="421"/>
+			<xs:enumeration value="422"/>
+			<xs:enumeration value="423"/>
+			<xs:enumeration value="501"/>
+			<xs:enumeration value="502"/>
+			<xs:enumeration value="503"/>
+			<xs:enumeration value="504"/>
+			<xs:enumeration value="505"/>
+			<xs:enumeration value="506"/>
+			<xs:enumeration value="507"/>
+			<xs:enumeration value="508"/>
+			<xs:enumeration value="509"/>
+			<xs:enumeration value="601"/>
+			<xs:enumeration value="602"/>
+			<xs:enumeration value="603"/>
+			<xs:enumeration value="604"/>
+			<xs:enumeration value="605"/>
+			<xs:enumeration value="701"/>
+			<xs:enumeration value="702"/>
+			<xs:enumeration value="703"/>
+			<xs:enumeration value="704"/>
+			<xs:enumeration value="705"/>
+			<xs:enumeration value="706"/>
+			<xs:enumeration value="707"/>
+			<xs:enumeration value="708"/>
+			<xs:enumeration value="709"/>
+			<xs:enumeration value="710"/>
+			<xs:enumeration value="711"/>
+			<xs:enumeration value="712"/>
+			<xs:enumeration value="713"/>
+			<xs:enumeration value="716"/>
+			<xs:enumeration value="717"/>
+			<xs:enumeration value="718"/>
+			<xs:enumeration value="719"/>
+			<xs:enumeration value="720"/>
+			<xs:enumeration value="721"/>
+			<xs:enumeration value="722"/>
+			<xs:enumeration value="801"/>
+			<xs:enumeration value="802"/>
+			<xs:enumeration value="901"/>
+			<xs:enumeration value="902"/>
+			<xs:enumeration value="903"/>
+			<xs:enumeration value="1001"/>
+			<xs:enumeration value="1002"/>
+			<xs:enumeration value="1003"/>
+			<xs:enumeration value="1004"/>
+			<xs:enumeration value="1005"/>
+			<xs:enumeration value="1006"/>
+			<xs:enumeration value="1007"/>
+			<xs:enumeration value="1008"/>
+			<xs:enumeration value="1009"/>
+			<xs:enumeration value="1010"/>
+			<xs:enumeration value="1101"/>
+			<xs:enumeration value="1102"/>
+			<xs:enumeration value="1103"/>
+			<xs:enumeration value="1104"/>
+			<xs:enumeration value="1201"/>
+			<xs:enumeration value="1202"/>
+			<xs:enumeration value="1203"/>
+			<xs:enumeration value="1204"/>
+			<xs:enumeration value="1205"/>
+			<xs:enumeration value="1206"/>
+			<xs:enumeration value="1207"/>
+			<xs:enumeration value="1208"/>
+			<xs:enumeration value="1209"/>
+			<xs:enumeration value="1210"/>
+			<xs:enumeration value="1211"/>
+			<xs:enumeration value="1212"/>
+			<xs:enumeration value="1213"/>
+			<xs:enumeration value="1214"/>
+			<xs:enumeration value="1215"/>
+			<xs:enumeration value="1216"/>
+			<xs:enumeration value="1217"/>
+			<xs:enumeration value="1302"/>
+			<xs:enumeration value="1303"/>
+			<xs:enumeration value="1304"/>
+			<xs:enumeration value="1305"/>
+			<xs:enumeration value="1401"/>
+			<xs:enumeration value="1402"/>
+			<xs:enumeration value="1403"/>
+			<xs:enumeration value="1404"/>
+			<xs:enumeration value="1405"/>
+			<xs:enumeration value="1406"/>
+			<xs:enumeration value="1407"/>
+			<xs:enumeration value="1408"/>
+			<xs:enumeration value="1409"/>
+			<xs:enumeration value="1410"/>
+			<xs:enumeration value="1411"/>
+			<xs:enumeration value="1412"/>
+			<xs:enumeration value="1413"/>
+			<xs:enumeration value="1501"/>
+			<xs:enumeration value="1502"/>
+			<xs:enumeration value="1503"/>
+			<xs:enumeration value="1504"/>
+			<xs:enumeration value="1505"/>
+			<xs:enumeration value="1506"/>
+			<xs:enumeration value="1507"/>
+			<xs:enumeration value="1508"/>
+			<xs:enumeration value="1509"/>
+			<xs:enumeration value="1510"/>
+			<xs:enumeration value="1511"/>
+			<xs:enumeration value="1512"/>
+			<xs:enumeration value="1513"/>
+			<xs:enumeration value="1514"/>
+			<xs:enumeration value="1515"/>
+			<xs:enumeration value="1516"/>
+			<xs:enumeration value="1517"/>
+			<xs:enumeration value="1518"/>
+			<xs:enumeration value="1601"/>
+			<xs:enumeration value="1701"/>
+			<xs:enumeration value="1702"/>
+			<xs:enumeration value="1703"/>
+			<xs:enumeration value="1704"/>
+			<xs:enumeration value="1705"/>
+			<xs:enumeration value="1706"/>
+			<xs:enumeration value="1708"/>
+			<xs:enumeration value="1709"/>
+			<xs:enumeration value="1710"/>
+			<xs:enumeration value="1711"/>
+			<xs:enumeration value="1712"/>
+			<xs:enumeration value="1713"/>
+			<xs:enumeration value="1714"/>
+			<xs:enumeration value="1715"/>
+			<xs:enumeration value="1716"/>
+			<xs:enumeration value="1717"/>
+			<xs:enumeration value="1718"/>
+			<xs:enumeration value="1719"/>
+			<xs:enumeration value="1720"/>
+			<xs:enumeration value="1721"/>
+			<xs:enumeration value="1722"/>
+			<xs:enumeration value="1723"/>
+			<xs:enumeration value="1724"/>
+			<xs:enumeration value="1801"/>
+			<xs:enumeration value="1901"/>
+			<xs:enumeration value="2001"/>
+			<xs:enumeration value="2002"/>
+			<xs:enumeration value="2003"/>
+			<xs:enumeration value="2101"/>
+			<xs:enumeration value="2201"/>
+			<xs:enumeration value="2301"/>
+			<xs:enumeration value="2401"/>
+			<xs:enumeration value="2501"/>
+			<xs:enumeration value="2502"/>
+			<xs:enumeration value="2503"/>
+			<xs:enumeration value="2504"/>
+			<xs:enumeration value="2601"/>
+			<xs:enumeration value="2701"/>
+			<xs:enumeration value="2801"/>
+			<xs:enumeration value="2901"/>
+			<xs:enumeration value="3001"/>
+			<xs:enumeration value="3101"/>
+			<xs:enumeration value="3201"/>
+			<xs:enumeration value="3301"/>
+			<xs:enumeration value="3401"/>
+			<xs:enumeration value="3501"/>
+			<xs:enumeration value="3601"/>
+			<xs:enumeration value="3701"/>
+			<xs:enumeration value="3801"/>
+			<xs:enumeration value="3901"/>
+			<xs:enumeration value="4001"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TContainer">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do Container</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="20"/>
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[A-Z0-9]+"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDocAssoc">
+		<xs:annotation>
+			<xs:documentation> Tipo Documento Associado</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="07"/>
+			<xs:enumeration value="08"/>
+			<xs:enumeration value="09"/>
+			<xs:enumeration value="10"/>
+			<xs:enumeration value="11"/>
+			<xs:enumeration value="12"/>
+			<xs:enumeration value="13"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TEmail">
+		<xs:annotation>
+			<xs:documentation>Tipo Email</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:minLength value="1"/>
+			<xs:maxLength value="60"/>
+			<xs:pattern value="[^@]+@[^\.]+\..+"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TFinCTe">
+		<xs:annotation>
+			<xs:documentation>Tipo Finalidade da CT-e</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="0"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="3"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TFinCTeSimp">
+		<xs:annotation>
+			<xs:documentation>Tipos Finalidade de CT-e Simplificado</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="5"/>
+			<xs:enumeration value="6"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TIdLote">
+		<xs:annotation>
+			<xs:documentation>Tipo Identificador de controle do envio do lote. Número seqüencial auto-incremental, de controle correspondente ao identificador único do lote enviado. A responsabilidade de gerar e controlar esse número é do próprio contribuinte.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{1,15}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TModDoc">
+		<xs:annotation>
+			<xs:documentation> Tipo Modelo do Documento</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="01"/>
+			<xs:enumeration value="1B"/>
+			<xs:enumeration value="02"/>
+			<xs:enumeration value="2D"/>
+			<xs:enumeration value="2E"/>
+			<xs:enumeration value="04"/>
+			<xs:enumeration value="06"/>
+			<xs:enumeration value="07"/>
+			<xs:enumeration value="08"/>
+			<xs:enumeration value="8B"/>
+			<xs:enumeration value="09"/>
+			<xs:enumeration value="10"/>
+			<xs:enumeration value="11"/>
+			<xs:enumeration value="13"/>
+			<xs:enumeration value="14"/>
+			<xs:enumeration value="15"/>
+			<xs:enumeration value="16"/>
+			<xs:enumeration value="17"/>
+			<xs:enumeration value="18"/>
+			<xs:enumeration value="20"/>
+			<xs:enumeration value="21"/>
+			<xs:enumeration value="22"/>
+			<xs:enumeration value="23"/>
+			<xs:enumeration value="24"/>
+			<xs:enumeration value="25"/>
+			<xs:enumeration value="26"/>
+			<xs:enumeration value="27"/>
+			<xs:enumeration value="28"/>
+			<xs:enumeration value="55"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TModTranspOS">
+		<xs:annotation>
+			<xs:documentation> Tipo Modal transporte Outros Serviços</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="01"/>
+			<xs:enumeration value="02"/>
+			<xs:enumeration value="03"/>
+			<xs:enumeration value="04"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TModTransp">
+		<xs:annotation>
+			<xs:documentation> Tipo Modal transporte</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="01"/>
+			<xs:enumeration value="02"/>
+			<xs:enumeration value="03"/>
+			<xs:enumeration value="04"/>
+			<xs:enumeration value="05"/>
+			<xs:enumeration value="06"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TModTranspSimp">
+		<xs:annotation>
+			<xs:documentation> Tipo Modal transporte do CTe Simplificado</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="01"/>
+			<xs:enumeration value="02"/>
+			<xs:enumeration value="03"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TRNTRC">
+		<xs:annotation>
+			<xs:documentation>Tipo RNTRC - Registro Nacional Transportadores Rodoviários de Carga</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{8}|ISENTO"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCIOT">
+		<xs:annotation>
+			<xs:documentation>Tipo CIOT - Código Identificador da Operação de Transporte</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{12}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCRT">
+		<xs:annotation>
+			<xs:documentation>Tipo Código Regime Tributário</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:minLength value="1"/>
+			<xs:maxLength value="1"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+			<xs:enumeration value="3"/>
+			<xs:enumeration value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TProcEmi">
+		<xs:annotation>
+			<xs:documentation>Tipo processo de emissão do CT-e</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="0"/>
+			<xs:enumeration value="3"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TTime">
+		<xs:annotation>
+			<xs:documentation>Tipo hora</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="(([0-1][0-9])|([2][0-3])):([0-5][0-9]):([0-5][0-9])"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TVerCTe">
+		<xs:annotation>
+			<xs:documentation>Tipo Versão do CT-e - 4.00</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="4\.00"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cte_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/cte_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="CTe" type="TCTe">
+		<xs:annotation>
+			<xs:documentation>Conhecimento de Transporte Eletrônico</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evCCeCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evCCeCTe_v4.00.xsd
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evCCeCTe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento carta de correção 
+110110</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “Carta de Correção”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="Carta de Correção"/>
+							<xs:enumeration value="Carta de Correcao"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="infCorrecao" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Grupo de Informações de Correção</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="grupoAlterado">
+								<xs:annotation>
+									<xs:documentation>Indicar o grupo de informações que pertence o campoAlterado. Ex: ide</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:minLength value="1"/>
+										<xs:maxLength value="20"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="campoAlterado">
+								<xs:annotation>
+									<xs:documentation>Nome do campo modificado do CT-e Original.</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:minLength value="1"/>
+										<xs:maxLength value="20"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="valorAlterado">
+								<xs:annotation>
+									<xs:documentation>Valor correspondente à alteração.</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:minLength value="1"/>
+										<xs:maxLength value="500"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="nroItemAlterado" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Preencher com o indice do item alterado caso a alteração ocorra em uma lista. 
+OBS: O indice inicia sempre  em 1</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:pattern value="[1-9][0-9]|0?[1-9]"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="xCondUso">
+					<xs:annotation>
+						<xs:documentation>Condições de uso da Carta de Correção,</xs:documentation>
+						<xs:documentation>informar a literal :Condições de uso da Carta de Correção, informar a literal:
+“A Carta de Correção é disciplinada pelo Art. 58-B do CONVÊNIO/SINIEF 06/89: Fica permitida a utilização de carta de correção, para regularização de erro ocorrido na emissão de documentos fiscais relativos à prestação de serviço de transporte, desde que o erro não esteja relacionado com: I - as variáveis que determinam o valor do imposto tais como: base de cálculo, alíquota, diferença de preço, quantidade, valor da prestação;II - a correção de dados cadastrais que implique mudança do emitente, tomador, remetente ou do destinatário;III - a data de emissão ou de saída.” (texto com acentuação)  ou “A Carta de Correcao e disciplinada pelo Art. 58-B do CONVENIO/SINIEF 06/89: Fica permitida a utilizacao de carta de correcao, para regularizacao de erro ocorrido na emissao de documentos fiscais relativos a prestacao de servico de transporte, desde que o erro nao esteja relacionado com: I - as variaveis que determinam o valor do imposto tais como: base de calculo, aliquota, diferenca de preco, quantidade, valor da prestacao;II - a correcao de dados cadastrais que implique mudança do emitente, tomador, remetente ou do destinatario;III - a data de emissao ou de saida.” (texto sem acentuação)</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="A Carta de Correção é disciplinada pelo Art. 58-B do CONVÊNIO/SINIEF 06/89: Fica permitida a utilização de carta de correção, para regularização de erro ocorrido na emissão de documentos fiscais relativos à prestação de serviço de transporte, desde que o erro não esteja relacionado com: I - as variáveis que determinam o valor do imposto tais como: base de cálculo, alíquota, diferença de preço, quantidade, valor da prestação;II - a correção de dados cadastrais que implique mudança do emitente, tomador, remetente ou do destinatário;III - a data de emissão ou de saída."/>
+							<xs:enumeration value="A Carta de Correcao e disciplinada pelo Art. 58-B do CONVENIO/SINIEF 06/89: Fica permitida a utilizacao de carta de correcao, para regularizacao de erro ocorrido na emissao de documentos fiscais relativos a prestacao de servico de transporte, desde que o erro nao esteja relacionado com: I - as variaveis que determinam o valor do imposto tais como: base de calculo, aliquota, diferenca de preco, quantidade, valor da prestacao;II - a correcao de dados cadastrais que implique mudanca do emitente, tomador, remetente ou do destinatario;III - a data de emissao ou de saida."/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evCECTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evCECTe_v4.00.xsd
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evCECTe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento comprovante de entrega eletrônico do CT-e 
+110180</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “Comprovante de Entrega do CT-e”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="Comprovante de Entrega do CT-e"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nProt" type="TProt">
+					<xs:annotation>
+						<xs:documentation>Número do Protocolo de autorização do CT-e</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="dhEntrega">
+					<xs:annotation>
+						<xs:documentation>Data e hora de conclusão da entrega da NF-e</xs:documentation>
+						<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TDateTimeUTC"/>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nDoc">
+					<xs:annotation>
+						<xs:documentation>Número do Documento de identificação da pessoa que recebeu a entrega</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TString">
+							<xs:minLength value="2"/>
+							<xs:maxLength value="20"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="xNome">
+					<xs:annotation>
+						<xs:documentation>Nome da pessoa que recebeu a entrega</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TString">
+							<xs:maxLength value="60"/>
+							<xs:minLength value="2"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="latitude" type="TLatitude" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Latitude do ponto de entrega</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="longitude" type="TLongitude" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Longitude do ponto de entrega</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="hashEntrega">
+					<xs:annotation>
+						<xs:documentation>Hash (SHA1) no formato Base64 resultante da concatenação: Chave de acesso do CT-e + Base64 da imagem capturada da entrega (Exemplo: imagem capturada da assinatura eletrônica, digital do recebedor, foto, etc)</xs:documentation>
+						<xs:documentation>O hashCSRT é o resultado das funções SHA-1 e base64 do token CSRT fornecido pelo fisco + chave de acesso do DF-e. (Implementação em futura NT)
+Observação: 28 caracteres são representados no schema como 20 bytes do tipo base64Binary</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:base64Binary">
+							<xs:length value="20"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="dhHashEntrega">
+					<xs:annotation>
+						<xs:documentation>Data e hora de geração do hash entrega</xs:documentation>
+						<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TDateTimeUTC"/>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="infEntrega" minOccurs="0" maxOccurs="2000">
+					<xs:annotation>
+						<xs:documentation>Grupo de informações das NF-e que foram entregues ao Destinatário</xs:documentation>
+						<xs:documentation>Informar o grupo apenas para CT-e com tipo de serviço Normal</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="chNFe" type="TChDFe">
+								<xs:annotation>
+									<xs:documentation>Chave de acesso da NF-e entregue</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evCancCECTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evCancCECTe_v4.00.xsd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evCancCECTe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento cancelamento do comprovante de entrega eletrônico do CT-e 
+110181</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “Cancelamento do Comprovante de Entrega do CT-e”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="Cancelamento do Comprovante de Entrega do CT-e"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nProt" type="TProt">
+					<xs:annotation>
+						<xs:documentation>Número do Protocolo de autorização do CT-e</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="nProtCE" type="TProt">
+					<xs:annotation>
+						<xs:documentation>Número do Protocolo de autorização do evento a ser cancelado </xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evCancCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evCancCTe_v4.00.xsd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evCancCTe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento do cancelamento 
+110111</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “Cancelamento”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="Cancelamento"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nProt" type="TProt">
+					<xs:annotation>
+						<xs:documentation>Número do Protocolo de Status do CT-e</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="xJust" type="TJust">
+					<xs:annotation>
+						<xs:documentation>Justificativa do Cancelamento</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evCancIECTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evCancIECTe_v4.00.xsd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2014 rel. 2 (http://www.altova.com) by private (private) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evCancIECTe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento cancelamento do insucesso de entrega eletrônico do CT-e 
+110191</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “Cancelamento do Insucesso de Entrega do CT-e”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="Cancelamento do Insucesso de Entrega do CT-e"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nProt" type="TProt">
+					<xs:annotation>
+						<xs:documentation>Número do Protocolo de autorização do CT-e</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="nProtIE" type="TProt">
+					<xs:annotation>
+						<xs:documentation>Número do Protocolo de autorização do evento a ser cancelado </xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evCancPrestDesacordo_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evCancPrestDesacordo_v4.00.xsd
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evCancPrestDesacordo">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento Cancelamento Prestação do Serviço em Desacordo 610111</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “Cancelamento Prestação do Serviço em Desacordo”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="Cancelamento Prestação do Serviço em Desacordo"/>
+							<xs:enumeration value="Cancelamento Prestacao do Servico em Desacordo"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nProtEvPrestDes" type="TProt">
+					<xs:annotation>
+						<xs:documentation>Protocolo do evento que será cancelado</xs:documentation>
+						<xs:documentation>Informar o número do protocolo de autorização do evento de prestação de serviço em desacordo que será cancelado </xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evEPECCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evEPECCTe_v4.00.xsd
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ns1="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evEPECCTe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento de emissão prévia de emissão em contingência 
+110113</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “EPEC”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="EPEC"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="xJust" type="TJust">
+					<xs:annotation>
+						<xs:documentation>Justificativa da Entrada em Contingencia</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vICMS" type="TDec_1302">
+					<xs:annotation>
+						<xs:documentation>Valor do ICMS</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vICMSST" type="TDec_1302" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Valor do ICMS ST</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vTPrest" type="TDec_1302">
+					<xs:annotation>
+						<xs:documentation>Valor Total da Prestação do Serviço</xs:documentation>
+						<xs:documentation>Pode conter zeros quando o CT-e for de complemento de ICMS</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vCarga" type="TDec_1302">
+					<xs:annotation>
+						<xs:documentation>Valor total da carga</xs:documentation>
+						<xs:documentation>Dever ser informado para todos os modais, com exceção para o Dutoviário.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="toma4">
+					<xs:annotation>
+						<xs:documentation>Indicador do "papel" do tomador do serviço no CT-e</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="toma">
+								<xs:annotation>
+									<xs:documentation>Tomador do Serviço</xs:documentation>
+									<xs:documentation>Preencher com: 
+0-Remetente;
+1-Expedidor;2-Recebedor;3-Destinatário
+;4 - Outros</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:enumeration value="0"/>
+										<xs:enumeration value="1"/>
+										<xs:enumeration value="2"/>
+										<xs:enumeration value="3"/>
+										<xs:enumeration value="4"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="UF" type="TUf">
+								<xs:annotation>
+									<xs:documentation>UF do tomador do serviço</xs:documentation>
+									<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:choice>
+								<xs:element name="CNPJ" type="TCnpjOpc">
+									<xs:annotation>
+										<xs:documentation>Número do CNPJ</xs:documentation>
+										<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.															
+Informar os zeros não significativos.</xs:documentation>
+									</xs:annotation>
+								</xs:element>
+								<xs:element name="CPF" type="TCpf">
+									<xs:annotation>
+										<xs:documentation>Número do CPF</xs:documentation>
+										<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+									</xs:annotation>
+								</xs:element>
+							</xs:choice>
+							<xs:element name="IE" type="TIeDest" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Inscrição Estadual</xs:documentation>
+									<xs:documentation>Informar a IE do tomador ou ISENTO se tomador é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o tomador não seja contribuinte do ICMS não informar o conteúdo.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="modal" type="TModTransp">
+					<xs:annotation>
+						<xs:documentation>Modal</xs:documentation>
+						<xs:documentation>Preencher com:
+ 
+01-Rodoviário;
+
+02-Aéreo;
+03-Aquaviário;
+
+04-Ferroviário;
+
+05-Dutoviário;
+06-Multimodal;</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="UFIni" type="TUf">
+					<xs:annotation>
+						<xs:documentation>UF do início da prestação</xs:documentation>
+						<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="UFFim" type="TUf">
+					<xs:annotation>
+						<xs:documentation>UF do término da prestação</xs:documentation>
+						<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="tpCTe">
+					<xs:annotation>
+						<xs:documentation>Tipo do CT-e - Aceitar apenas Tipo Normal = 0</xs:documentation>
+						<xs:documentation>Preencher com:
+	0 - CT-e Normal;
+ 1 - CT-e de Complemento de Valores;	2 - CT-e de Anulação;
+ 3 - CT-e Substituto</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:length value="1"/>
+							<xs:enumeration value="0"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="dhEmi">
+					<xs:annotation>
+						<xs:documentation>Data e hora de emissão do CT-e</xs:documentation>
+						<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TDateTimeUTC"/>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evGTV_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evGTV_v4.00.xsd
@@ -1,0 +1,255 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evGTV">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento informações da GTV 110170</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “Informações da GTV”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="Informações da GTV"/>
+							<xs:enumeration value="Informacoes da GTV"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="infGTV" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Grupo de Informações das GTV</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="nDoc">
+								<xs:annotation>
+									<xs:documentation>Número da GTV</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="20"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="id">
+								<xs:annotation>
+									<xs:documentation>Identificador para diferenciar GTV de mesmo número (Usar número do AIDF ou  identificador interno da empresa),</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="20"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="serie" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Série</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="3"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="subserie" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Subsérie</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="3"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="dEmi" type="TData">
+								<xs:annotation>
+									<xs:documentation>Data de Emissão</xs:documentation>
+									<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="nDV">
+								<xs:annotation>
+									<xs:documentation>Número Dígito Verificador </xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="1"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="qCarga" type="TDec_1104">
+								<xs:annotation>
+									<xs:documentation>Quantidade de volumes/malotes</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="infEspecie" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>Informações das Espécies transportadas</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="tpEspecie">
+											<xs:annotation>
+												<xs:documentation>Tipo da Espécie</xs:documentation>
+												<xs:documentation>1 - Numerário
+2 - Cheque
+3 - Moeda
+4 - Outros</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:whiteSpace value="preserve"/>
+													<xs:enumeration value="1"/>
+													<xs:enumeration value="2"/>
+													<xs:enumeration value="3"/>
+													<xs:enumeration value="4"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="vEspecie" type="TDec_1302" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor Transportada em Espécie indicada</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="rem">
+								<xs:annotation>
+									<xs:documentation>Informações do Remetente da GTV</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:choice>
+											<xs:element name="CNPJ" type="TCnpjOpc">
+												<xs:annotation>
+													<xs:documentation>Número do CNPJ</xs:documentation>
+													<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.
+												Informar os zeros não significativos.</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+											<xs:element name="CPF" type="TCpf">
+												<xs:annotation>
+													<xs:documentation>Número do CPF</xs:documentation>
+													<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+										</xs:choice>
+										<xs:element name="IE" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Inscrição Estadual</xs:documentation>
+												<xs:documentation>Informar a IE do remetente ou ISENTO se remetente é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o remetente não seja contribuinte do ICMS não informar o conteúdo.</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TIeDest"/>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="UF" type="TUf">
+											<xs:annotation>
+												<xs:documentation>Sigla da UF</xs:documentation>
+												<xs:documentation>Informar EX para operações com o exterior.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="xNome">
+											<xs:annotation>
+												<xs:documentation>Razão social ou nome do remetente</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:maxLength value="60"/>
+													<xs:minLength value="2"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="dest">
+								<xs:annotation>
+									<xs:documentation>Informações do Destinatário da GTV</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:choice>
+											<xs:element name="CNPJ" type="TCnpjOpc">
+												<xs:annotation>
+													<xs:documentation>Número do CNPJ</xs:documentation>
+													<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.
+							Informar os zeros não significativos.</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+											<xs:element name="CPF" type="TCpf">
+												<xs:annotation>
+													<xs:documentation>Número do CPF</xs:documentation>
+													<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+										</xs:choice>
+										<xs:element name="IE" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Inscrição Estadual</xs:documentation>
+												<xs:documentation>Informar a IE do destinatário ou ISENTO se remetente é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o remetente não seja contribuinte do ICMS não informar o conteúdo.</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TIeDest"/>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="UF" type="TUf">
+											<xs:annotation>
+												<xs:documentation>Sigla da UF</xs:documentation>
+												<xs:documentation>Informar EX para operações com o exterior.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="xNome">
+											<xs:annotation>
+												<xs:documentation>Razão social ou nome do destinatário</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:maxLength value="60"/>
+													<xs:minLength value="2"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="placa" type="TPlaca" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Placa do veículo </xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="UF" type="TUf" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>UF em que veículo está licenciado</xs:documentation>
+									<xs:documentation>Sigla da UF de licenciamento do veículo.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="RNTRC" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>RNTRC do transportador</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:pattern value="[0-9]{8}|ISENTO"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evIECTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evIECTe_v4.00.xsd
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2014 rel. 2 (http://www.altova.com) by private (private) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evIECTe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento insucesso na entrega eletrônico do CT-e 
+110190</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “Insucesso na Entrega do CT-e”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="Insucesso na Entrega do CT-e"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nProt" type="TProt">
+					<xs:annotation>
+						<xs:documentation>Número do Protocolo de autorização do CT-e</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="dhTentativaEntrega">
+					<xs:annotation>
+						<xs:documentation>Data e hora da tentativa da entrega da NF-e</xs:documentation>
+						<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TDateTimeUTC"/>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nTentativa" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Número da tentativa de entrega que não teve insucesso</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:pattern value="[0-9]{3}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="tpMotivo">
+					<xs:annotation>
+						<xs:documentation>Motivo do insucesso</xs:documentation>
+						<xs:documentation>1- Recebedor não encontrado;
+2- Recusa do recebedor;
+3- Endereço inexistente;
+4- Outros (exige informar justificativa)</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="1"/>
+							<xs:enumeration value="2"/>
+							<xs:enumeration value="3"/>
+							<xs:enumeration value="4"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="xJustMotivo" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Justificativa do Motivo de insucesso, informar apenas para tpMotivo = 4</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TString">
+							<xs:minLength value="15"/>
+							<xs:maxLength value="256"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="latitude" type="TLatitude" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Latitude do ponto de entrega</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="longitude" type="TLongitude" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Longitude do ponto de entrega</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="hashTentativaEntrega" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Hash (SHA1) no formato Base64 resultante da concatenação: Chave de acesso do CT-e + Base64 da imagem capturada da tentativa com insucesso da entrega (Exemplo: foto do local que não recebeu a entrega ou do local sem recebedor)</xs:documentation>
+						<xs:documentation>O hashCSRT é o resultado das funções SHA-1 e base64 do token CSRT fornecido pelo fisco + chave de acesso do DF-e. (Implementação em futura NT)
+Observação: 28 caracteres são representados no schema como 20 bytes do tipo base64Binary</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:base64Binary">
+							<xs:length value="20"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="dhHashTentativaEntrega" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Data e hora de geração do hash tentativa entrega</xs:documentation>
+						<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TDateTimeUTC"/>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="infEntrega" minOccurs="0" maxOccurs="2000">
+					<xs:annotation>
+						<xs:documentation>Grupo de informações das NF-e que não tiveram sucesso na entrega ao Destinatário</xs:documentation>
+						<xs:documentation>Informar o grupo apenas para CT-e com tipo de serviço Normal</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="chNFe" type="TChDFe">
+								<xs:annotation>
+									<xs:documentation>Chave de acesso da NF-e com insucesso na tentativa de entrega</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evPrestDesacordo_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evPrestDesacordo_v4.00.xsd
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evPrestDesacordo">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento Prestação do Serviço em Desacordo 610110</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “Prestação do Serviço em Desacordo”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="Prestação do Serviço em Desacordo"/>
+							<xs:enumeration value="Prestacao do Servico em Desacordo"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="indDesacordoOper">
+					<xs:annotation>
+						<xs:documentation>Indicador de operação em desacordo</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="1"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="xObs">
+					<xs:annotation>
+						<xs:documentation>Observações do tomador</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:minLength value="15"/>
+							<xs:maxLength value="255"/>
+							<xs:whiteSpace value="preserve"/>
+							<xs:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evRegMultimodal_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/evRegMultimodal_v4.00.xsd
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evRegMultimodal">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento Registro Multimodal 110160</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “Registro Multimodal”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="Registro Multimodal"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="xRegistro">
+					<xs:annotation>
+						<xs:documentation>Informação complementar sobre o registro, indicação do tipo de documento utilizado e demais situações ocorridas no Multimodal (Texto Livre).</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:minLength value="15"/>
+							<xs:maxLength value="1000"/>
+							<xs:whiteSpace value="preserve"/>
+							<xs:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nDoc" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Numero do Documento lançado no CT-e Multimodal</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:minLength value="1"/>
+							<xs:maxLength value="44"/>
+							<xs:whiteSpace value="preserve"/>
+							<xs:pattern value="[0-9]{1,44}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/eventoCTeTiposBasico_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/eventoCTeTiposBasico_v4.00.xsd
@@ -1,0 +1,331 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2014 rel. 2 (http://www.altova.com) by private (private) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v1.01.xsd"/>
+	<xs:include schemaLocation="tiposGeralCTe_v4.00.xsd"/>
+	<xs:complexType name="TEvento">
+		<xs:annotation>
+			<xs:documentation>Tipo Evento</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infEvento">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="cOrgao" type="TCOrgaoIBGE">
+							<xs:annotation>
+								<xs:documentation>Código do órgão de recepção do Evento. Utilizar a Tabela do IBGE extendida, utilizar 90 para identificar SUFRAMA</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:choice>
+							<xs:element name="CNPJ" type="TCnpj">
+								<xs:annotation>
+									<xs:documentation>CNPJ do emissor do evento</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="CPF" type="TCpf">
+								<xs:annotation>
+									<xs:documentation>CPF do emissor do evento</xs:documentation>
+									<xs:documentation>Informar zeros não significativos.
+
+Usar com série específica 920-969 para emitente pessoa física com inscrição estadual</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:choice>
+						<xs:element name="chCTe" type="TChDFe">
+							<xs:annotation>
+								<xs:documentation>Chave de Acesso do CT-e vinculado ao evento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="dhEvento" type="TDateTimeUTC">
+							<xs:annotation>
+								<xs:documentation>Data e Hora do Evento, formato UTC (AAAA-MM-DDThh:mm:ssTZD)</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="tpEvento">
+							<xs:annotation>
+								<xs:documentation>Tipo do Evento</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:pattern value="[0-9]{6}"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="nSeqEvento">
+							<xs:annotation>
+								<xs:documentation>Seqüencial do evento para o mesmo tipo de evento.  Para maioria dos eventos será 1, nos casos em que possa existir mais de um evento o autor do evento deve numerar de forma seqüencial.</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:pattern value="[0-9]{1,3}"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="detEvento">
+							<xs:annotation>
+								<xs:documentation>Detalhamento do evento específico</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:any processContents="skip">
+										<xs:annotation>
+											<xs:documentation>XML do evento
+Insira neste local o XML específico do tipo de evento (cancelamento, encerramento, registro de passagem).  </xs:documentation>
+										</xs:annotation>
+									</xs:any>
+								</xs:sequence>
+								<xs:attribute name="versaoEvento" use="required">
+									<xs:simpleType>
+										<xs:restriction base="xs:string">
+											<xs:whiteSpace value="preserve"/>
+											<xs:pattern value="4\.(0[0-9]|[1-9][0-9])"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infSolicNFF" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de informações do pedido de registro de evento da Nota Fiscal Fácil</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="xSolic">
+										<xs:annotation>
+											<xs:documentation>Solicitação do pedido de registro de evento da NFF.</xs:documentation>
+											<xs:documentation>Será preenchido com a totalidade de campos informados no aplicativo emissor serializado.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="8000"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infPAA" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de Informação do Provedor de Assinatura e Autorização</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="CNPJPAA" type="TCnpj">
+										<xs:annotation>
+											<xs:documentation>CNPJ do Provedor de Assinatura e Autorização</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="PAASignature">
+										<xs:annotation>
+											<xs:documentation>Assinatura RSA do Emitente para DFe gerados por PAA</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="SignatureValue" type="xs:base64Binary">
+													<xs:annotation>
+														<xs:documentation>Assinatura digital padrão RSA</xs:documentation>
+														<xs:documentation>Converter o atributo Id do DFe para array de bytes e assinar com a chave privada do RSA com algoritmo SHA1 gerando um valor no formato base64.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="RSAKeyValue" type="TRSAKeyValueType">
+													<xs:annotation>
+														<xs:documentation>Chave Publica no padrão XML RSA Key</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" use="required">
+						<xs:annotation>
+							<xs:documentation>Identificador da TAG a ser assinada, a regra de formação do Id é:
+“ID” + tpEvento +  chave do CT-e + nSeqEvento</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:ID">
+								<xs:pattern value="ID[0-9]{12}[A-Z0-9]{12}[0-9]{29}"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerEvento" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetEvento">
+		<xs:annotation>
+			<xs:documentation>Tipo retorno do Evento</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infEvento">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="verAplic" type="TVerAplic">
+							<xs:annotation>
+								<xs:documentation>Versão do Aplicativo que recebeu o Evento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cOrgao" type="TCOrgaoIBGE">
+							<xs:annotation>
+								<xs:documentation>Código do órgão de recepção do Evento. Utilizar a Tabela do IBGE extendida, utilizar 90 para identificar SUFRAMA</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cStat" type="TStat">
+							<xs:annotation>
+								<xs:documentation>Código do status da registro do Evento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="xMotivo" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Descrição literal do status do registro do Evento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="chCTe" type="TChDFe" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Chave de Acesso CT-e vinculado</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="tpEvento" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Tipo do Evento vinculado</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:pattern value="[0-9]{6}"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="xEvento" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Descrição do Evento</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TString">
+									<xs:minLength value="4"/>
+									<xs:maxLength value="60"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="nSeqEvento" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Seqüencial do evento</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:pattern value="[0-9]{1,3}"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="dhRegEvento" type="TDateTimeUTC" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Data e Hora de do recebimento do evento ou do registro do evento formato AAAA-MM-DDThh:mm:ssTZD</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nProt" type="TProt" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número do protocolo de registro do evento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" use="optional">
+						<xs:simpleType>
+							<xs:restriction base="xs:ID">
+								<xs:pattern value="ID[0-9]{15}"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="versao" use="required">
+			<xs:simpleType>
+				<xs:restriction base="TVerEvento"/>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="TProcEvento">
+		<xs:annotation>
+			<xs:documentation>Tipo procEvento</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="eventoCTe" type="TEvento"/>
+			<xs:element name="retEventoCTe" type="TRetEvento"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerEvento" use="required"/>
+		<xs:attribute name="ipTransmissor" type="TIPv4" use="optional">
+			<xs:annotation>
+				<xs:documentation>IP do transmissor do documento fiscal para o ambiente autorizador</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="nPortaCon" use="optional">
+			<xs:annotation>
+				<xs:documentation>Porta de origem utilizada na conexão (De 0 a 65535)</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:pattern value="[0-9]{1,5}"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="dhConexao" type="TDateTimeUTC" use="optional">
+			<xs:annotation>
+				<xs:documentation>Data e Hora da Conexão de Origem</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:simpleType name="TVerEvento">
+		<xs:annotation>
+			<xs:documentation>Tipo Versão do Evento</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="4\.00"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TModTransp">
+		<xs:annotation>
+			<xs:documentation> Tipo Modal transporte</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="01"/>
+			<xs:enumeration value="02"/>
+			<xs:enumeration value="03"/>
+			<xs:enumeration value="04"/>
+			<xs:enumeration value="05"/>
+			<xs:enumeration value="06"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TNSU">
+		<xs:annotation>
+			<xs:documentation> Tipo número sequencial único do AN</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9]{15}"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/eventoCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/eventoCTe_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="eventoCTe" type="TEvento">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do Pedido de Registro de Evento do CT-e</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/procCTeOS_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/procCTeOS_v4.00.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="cteOSProc">
+		<xs:annotation>
+			<xs:documentation> CT-e OS processado</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="CTeOS" type="TCTeOS"/>
+				<xs:element name="protCTe" type="TProtCTeOS"/>
+			</xs:sequence>
+			<xs:attribute name="versao" type="TVerCTe" use="required"/>
+			<xs:attribute name="ipTransmissor" type="TIPv4" use="optional">
+				<xs:annotation>
+					<xs:documentation>IP do transmissor do documento fiscal para o ambiente autorizador</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="nPortaCon" use="optional">
+				<xs:annotation>
+					<xs:documentation>Porta de origem utilizada na conexão (De 0 a 65535)</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:pattern value="[0-9]{1,5}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="dhConexao" type="TDateTimeUTC" use="optional">
+				<xs:annotation>
+					<xs:documentation>Data e Hora da Conexão de Origem</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/procCTeSimp_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/procCTeSimp_v4.00.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="cteSimpProc">
+		<xs:annotation>
+			<xs:documentation> CT-e Simplificado processado</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="CTeSimp" type="TCTeSimp"/>
+				<xs:element name="protCTe" type="TProtCTe"/>
+			</xs:sequence>
+			<xs:attribute name="versao" type="TVerCTe" use="required"/>
+			<xs:attribute name="ipTransmissor" type="TIPv4" use="optional">
+				<xs:annotation>
+					<xs:documentation>IP do transmissor do documento fiscal para o ambiente autorizador</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="nPortaCon" use="optional">
+				<xs:annotation>
+					<xs:documentation>Porta de origem utilizada na conexão (De 0 a 65535)</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:pattern value="[0-9]{1,5}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="dhConexao" type="TDateTimeUTC" use="optional">
+				<xs:annotation>
+					<xs:documentation>Data e Hora da Conexão de Origem</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/procCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/procCTe_v4.00.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="cteProc">
+		<xs:annotation>
+			<xs:documentation> CT-e processado</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="CTe" type="TCTe"/>
+				<xs:element name="protCTe" type="TProtCTe"/>
+			</xs:sequence>
+			<xs:attribute name="versao" type="TVerCTe" use="required"/>
+			<xs:attribute name="ipTransmissor" type="TIPv4" use="optional">
+				<xs:annotation>
+					<xs:documentation>IP do transmissor do documento fiscal para o ambiente autorizador</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="nPortaCon" use="optional">
+				<xs:annotation>
+					<xs:documentation>Porta de origem utilizada na conexão (De 0 a 65535)</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:pattern value="[0-9]{1,5}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="dhConexao" type="TDateTimeUTC" use="optional">
+				<xs:annotation>
+					<xs:documentation>Data e Hora da Conexão de Origem</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/procEventoCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/procEventoCTe_v4.00.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="procEventoCTe">
+		<xs:annotation>
+			<xs:documentation>Pedido de Registro de Eventos de CT-e processado</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="TProcEvento"/>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/procGTVe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/procGTVe_v4.00.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="GTVeProc">
+		<xs:annotation>
+			<xs:documentation> GTV-e processada</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="GTVe" type="TGTVe"/>
+				<xs:element name="protCTe" type="TProtGTVe"/>
+			</xs:sequence>
+			<xs:attribute name="versao" type="TVerCTe" use="required"/>
+			<xs:attribute name="ipTransmissor" type="TIPv4" use="optional">
+				<xs:annotation>
+					<xs:documentation>IP do transmissor do documento fiscal para o ambiente autorizador</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="nPortaCon" use="optional">
+				<xs:annotation>
+					<xs:documentation>Porta de origem utilizada na conexão (De 0 a 65535)</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:pattern value="[0-9]{1,5}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="dhConexao" type="TDateTimeUTC" use="optional">
+				<xs:annotation>
+					<xs:documentation>Data e Hora da Conexão de Origem</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/retCTeOS_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/retCTeOS_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="retCTeOS" type="TRetCTeOS">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do retorno do recibo de envio do CT-e OS (Modelo 67)</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/retCTeSimp_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/retCTeSimp_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="retCTeSimp" type="TRetCTeSimp">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do retorno do recibo de envio do CT-e Simplificado (Modelo 57)</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/retCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/retCTe_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="retCTe" type="TRetCTe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do retorno do recibo de envio do CT-e (Modelo 57)</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/retConsSitCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/retConsSitCTe_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="consSitCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="retConsSitCTe" type="TRetConsSitCTe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do retorno da consulta da situação atual do CT-e.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/retConsStatServCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/retConsStatServCTe_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="consStatServTiposBasico_v4.00.xsd"/>
+	<xs:element name="retConsStatServCTe" type="TRetConsStatServ">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do Resultado da Consulta do Status do Serviço de CT-e</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/retEventoCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/retEventoCTe_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="retEventoCTe" type="TRetEvento">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do retorno Pedido de Evento do CT-e</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/retGTVe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/retGTVe_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="retGTVe" type="TRetGTVe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do retorno do recibo de envio da GTV-e (Modelo 64)</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/tiposGeralCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/tiposGeralCTe_v4.00.xsd
@@ -1,0 +1,638 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:simpleType name="TDateTimeUTC">
+		<xs:annotation>
+			<xs:documentation>Data e Hora, formato UTC (AAAA-MM-DDThh:mm:ssTZD, onde TZD = +hh:mm ou -hh:mm)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="(((20(([02468][048])|([13579][26]))-02-29))|(20[0-9][0-9])-((((0[1-9])|(1[0-2]))-((0[1-9])|(1\d)|(2[0-8])))|((((0[13578])|(1[02]))-31)|(((0[1,3-9])|(1[0-2]))-(29|30)))))T(20|21|22|23|[0-1]\d):[0-5]\d:[0-5]\d([\-,\+](0[0-9]|10|11):00|([\+](12):00))"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TAmb">
+		<xs:annotation>
+			<xs:documentation>Tipo Ambiente</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Tano">
+		<xs:annotation>
+			<xs:documentation> Tipo ano</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCodUfIBGE">
+		<xs:annotation>
+			<xs:documentation>Tipo Código da UF da tabela do IBGE</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="11"/>
+			<xs:enumeration value="12"/>
+			<xs:enumeration value="13"/>
+			<xs:enumeration value="14"/>
+			<xs:enumeration value="15"/>
+			<xs:enumeration value="16"/>
+			<xs:enumeration value="17"/>
+			<xs:enumeration value="21"/>
+			<xs:enumeration value="22"/>
+			<xs:enumeration value="23"/>
+			<xs:enumeration value="24"/>
+			<xs:enumeration value="25"/>
+			<xs:enumeration value="26"/>
+			<xs:enumeration value="27"/>
+			<xs:enumeration value="28"/>
+			<xs:enumeration value="29"/>
+			<xs:enumeration value="31"/>
+			<xs:enumeration value="32"/>
+			<xs:enumeration value="33"/>
+			<xs:enumeration value="35"/>
+			<xs:enumeration value="41"/>
+			<xs:enumeration value="42"/>
+			<xs:enumeration value="43"/>
+			<xs:enumeration value="50"/>
+			<xs:enumeration value="51"/>
+			<xs:enumeration value="52"/>
+			<xs:enumeration value="53"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCodMunIBGE">
+		<xs:annotation>
+			<xs:documentation>Tipo Código do Município da tabela do IBGE</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{7}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCOrgaoIBGE">
+		<xs:annotation>
+			<xs:documentation>Tipo Código de orgão (UF da tabela do IBGE + 90 SUFRAMA + 91 RFB +  94 SVC-RS + 95 SVC-SP + 96  Sinc. Chaves do RS para SVSP </xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="11"/>
+			<xs:enumeration value="12"/>
+			<xs:enumeration value="13"/>
+			<xs:enumeration value="14"/>
+			<xs:enumeration value="15"/>
+			<xs:enumeration value="16"/>
+			<xs:enumeration value="17"/>
+			<xs:enumeration value="21"/>
+			<xs:enumeration value="22"/>
+			<xs:enumeration value="23"/>
+			<xs:enumeration value="24"/>
+			<xs:enumeration value="25"/>
+			<xs:enumeration value="26"/>
+			<xs:enumeration value="27"/>
+			<xs:enumeration value="28"/>
+			<xs:enumeration value="29"/>
+			<xs:enumeration value="31"/>
+			<xs:enumeration value="32"/>
+			<xs:enumeration value="33"/>
+			<xs:enumeration value="35"/>
+			<xs:enumeration value="41"/>
+			<xs:enumeration value="42"/>
+			<xs:enumeration value="43"/>
+			<xs:enumeration value="50"/>
+			<xs:enumeration value="51"/>
+			<xs:enumeration value="52"/>
+			<xs:enumeration value="53"/>
+			<xs:enumeration value="90"/>
+			<xs:enumeration value="91"/>
+			<xs:enumeration value="93"/>
+			<xs:enumeration value="94"/>
+			<xs:enumeration value="95"/>
+			<xs:enumeration value="96"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TChDFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Chave de Documento Fiscal Eletrônico</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="44"/>
+			<xs:pattern value="[0-9]{6}[A-Z0-9]{12}[0-9]{26}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCnpj">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do CNPJ</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[A-Z0-9]{12}[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TFone">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do Telefone</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{6,14}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCnpjOpc">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do CNPJ Opcional</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{0}|[A-Z0-9]{12}[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCpf">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do CPF</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{11}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCpfVar">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do CPF de tamanho variável (3-11)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{3,11}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TData">
+		<xs:annotation>
+			<xs:documentation> Tipo data AAAA-MM-DD</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="(((20(([02468][048])|([13579][26]))-02-29))|(20[0-9][0-9])-((((0[1-9])|(1[0-2]))-((0[1-9])|(1\d)|(2[0-8])))|((((0[13578])|(1[02]))-31)|(((0[1,3-9])|(1[0-2]))-(29|30)))))"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0302">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 5 dígitos, sendo 3 de corpo e 2 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,2}(\.[0-9]{2})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0303">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 6 dígitos, sendo 3 de corpo e 3 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{3}|[1-9]{1}[0-9]{0,2}(\.[0-9]{3})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0302_0303">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 6  ou 5 dígitos, sendo 3 de corpo e 3 ou 2 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{1,3}(\.[0-9]{2,3})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0302Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 5 dígitos, sendo 3 de corpo e 2 decimais, utilizado em tags opcionais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[0-9]{1}[1-9]{1}|0\.[1-9]{1}[0-9]{1}|[1-9]{1}[0-9]{0,2}(\.[0-9]{2})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0803">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 11 dígitos, sendo 8 de corpo e 3 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{3}|[1-9]{1}[0-9]{0,7}(\.[0-9]{3})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0803Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 11 dígitos, sendo 8 de corpo e 3 decimais utilizado em tags opcionais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[1-9]{1}[0-9]{2}|0\.[0-9]{2}[1-9]{1}|0\.[0-9]{1}[1-9]{1}[0-9]{1}|[1-9]{1}[0-9]{0,7}(\.[0-9]{3})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0804">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 12 dígitos, sendo 8 de corpo e 4decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{4}|[1-9]{1}[0-9]{0,7}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0804Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 12 dígitos, sendo 8 de corpo e 4 decimais, utilizado em tags opcionais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[1-9]{1}[0-9]{3}|0\.[0-9]{3}[1-9]{1}|0\.[0-9]{2}[1-9]{1}[0-9]{1}|0\.[0-9]{1}[1-9]{1}[0-9]{2}|[1-9]{1}[0-9]{0,7}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0906Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 9 de corpo e 6 decimais, utilizado em tags opcionais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[1-9]{1}[0-9]{5}|0\.[0-9]{1}[1-9]{1}[0-9]{4}|0\.[0-9]{2}[1-9]{1}[0-9]{3}|0\.[0-9]{3}[1-9]{1}[0-9]{2}|0\.[0-9]{4}[1-9]{1}[0-9]{1}|0\.[0-9]{5}[1-9]{1}|[1-9]{1}[0-9]{0,8}(\.[0-9]{6})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1104">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 11 de corpo e 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{4}|[1-9]{1}[0-9]{0,10}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1104Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 11 de corpo e 4 decimais, utilizado em tags opcionais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[1-9]{1}[0-9]{3}|0\.[0-9]{3}[1-9]{1}|0\.[0-9]{2}[1-9]{1}[0-9]{1}|0\.[0-9]{1}[1-9]{1}[0-9]{2}|[1-9]{1}[0-9]{0,10}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1203">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 12 de corpo e 3 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{3}|[1-9]{1}[0-9]{0,11}(\.[0-9]{3})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1203Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 12 de corpo e 3 decimais, utilizado em tags opcionais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[1-9]{1}[0-9]{2}|0\.[0-9]{2}[1-9]{1}|0\.[0-9]{1}[1-9]{1}[0-9]{1}|[1-9]{1}[0-9]{0,11}(\.[0-9]{3})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1204">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 16 dígitos, sendo 12 de corpo e 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{4}|[1-9]{1}[0-9]{0,11}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1204Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 16 dígitos, sendo 12 de corpo e 4 decimais, utilizado em tags opcionais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[1-9]{1}[0-9]{3}|0\.[0-9]{3}[1-9]{1}|0\.[0-9]{2}[1-9]{1}[0-9]{1}|0\.[0-9]{1}[1-9]{1}[0-9]{2}|[1-9]{1}[0-9]{0,11}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1302">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 13 de corpo e 2 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1302Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 13 de corpo e 2 decimais, utilizado em tags opcionais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[0-9]{1}[1-9]{1}|0\.[1-9]{1}[0-9]{1}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TIe">
+		<xs:annotation>
+			<xs:documentation>Tipo Inscrição Estadual do Emitente</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="14"/>
+			<xs:pattern value="[0-9]{2,14}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TIeDest">
+		<xs:annotation>
+			<xs:documentation>Tipo Inscrição Estadual do Destinatário</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="14"/>
+			<xs:pattern value="[0-9]{0,14}|ISENTO"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TJust">
+		<xs:annotation>
+			<xs:documentation>Tipo Justificativa</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="TString">
+			<xs:minLength value="15"/>
+			<xs:maxLength value="255"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TMed">
+		<xs:annotation>
+			<xs:documentation> Tipo temp médio em segundos</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{1,4}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TModCTOS">
+		<xs:annotation>
+			<xs:documentation>Tipo Modelo Documento Fiscal</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="67"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TModGTVe">
+		<xs:annotation>
+			<xs:documentation>Tipo Modelo Documento Fiscal</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="64"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TModCT_Carga_OS">
+		<xs:annotation>
+			<xs:documentation>Tipo Modelo Documento Fiscal</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="57"/>
+			<xs:enumeration value="67"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TModCT">
+		<xs:annotation>
+			<xs:documentation>Tipo Modelo Documento Fiscal</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="57"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TModNF">
+		<xs:annotation>
+			<xs:documentation>Tipo Modelo Documento Fiscal - NF Remetente</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="01"/>
+			<xs:enumeration value="04"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TtipoUnidTransp">
+		<xs:annotation>
+			<xs:documentation>Tipo da Unidade de Transporte</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+			<xs:enumeration value="3"/>
+			<xs:enumeration value="4"/>
+			<xs:enumeration value="5"/>
+			<xs:enumeration value="6"/>
+			<xs:enumeration value="7"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TtipoUnidCarga">
+		<xs:annotation>
+			<xs:documentation>Tipo da Unidade de Carga</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+			<xs:enumeration value="3"/>
+			<xs:enumeration value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TMotivo">
+		<xs:annotation>
+			<xs:documentation>Tipo Motivo</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="TString">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="255"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TNF">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do Documento Fiscal</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[1-9]{1}[0-9]{0,8}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TProt">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do Protocolo de Status</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{15}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TRec">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do Recibo do envio de lote de NF-e</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{15}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TSerie">
+		<xs:annotation>
+			<xs:documentation>Tipo Série do Documento Fiscal </xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|[1-9]{1}[0-9]{0,2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TServ">
+		<xs:annotation>
+			<xs:documentation>Tipo Serviço solicitado</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="TString"/>
+	</xs:simpleType>
+	<xs:simpleType name="TStat">
+		<xs:annotation>
+			<xs:documentation>Tipo Código da Mensagem enviada</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{3,4}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TString">
+		<xs:annotation>
+			<xs:documentation> Tipo string genérico</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TUf">
+		<xs:annotation>
+			<xs:documentation>Tipo Sigla da UF</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="AC"/>
+			<xs:enumeration value="AL"/>
+			<xs:enumeration value="AM"/>
+			<xs:enumeration value="AP"/>
+			<xs:enumeration value="BA"/>
+			<xs:enumeration value="CE"/>
+			<xs:enumeration value="DF"/>
+			<xs:enumeration value="ES"/>
+			<xs:enumeration value="GO"/>
+			<xs:enumeration value="MA"/>
+			<xs:enumeration value="MG"/>
+			<xs:enumeration value="MS"/>
+			<xs:enumeration value="MT"/>
+			<xs:enumeration value="PA"/>
+			<xs:enumeration value="PB"/>
+			<xs:enumeration value="PE"/>
+			<xs:enumeration value="PI"/>
+			<xs:enumeration value="PR"/>
+			<xs:enumeration value="RJ"/>
+			<xs:enumeration value="RN"/>
+			<xs:enumeration value="RO"/>
+			<xs:enumeration value="RR"/>
+			<xs:enumeration value="RS"/>
+			<xs:enumeration value="SC"/>
+			<xs:enumeration value="SE"/>
+			<xs:enumeration value="SP"/>
+			<xs:enumeration value="TO"/>
+			<xs:enumeration value="EX"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TUF_sem_EX">
+		<xs:annotation>
+			<xs:documentation>Tipo Sigla da UF, sem Exterior</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="AC"/>
+			<xs:enumeration value="AL"/>
+			<xs:enumeration value="AM"/>
+			<xs:enumeration value="AP"/>
+			<xs:enumeration value="BA"/>
+			<xs:enumeration value="CE"/>
+			<xs:enumeration value="DF"/>
+			<xs:enumeration value="ES"/>
+			<xs:enumeration value="GO"/>
+			<xs:enumeration value="MA"/>
+			<xs:enumeration value="MG"/>
+			<xs:enumeration value="MS"/>
+			<xs:enumeration value="MT"/>
+			<xs:enumeration value="PA"/>
+			<xs:enumeration value="PB"/>
+			<xs:enumeration value="PE"/>
+			<xs:enumeration value="PI"/>
+			<xs:enumeration value="PR"/>
+			<xs:enumeration value="RJ"/>
+			<xs:enumeration value="RN"/>
+			<xs:enumeration value="RO"/>
+			<xs:enumeration value="RR"/>
+			<xs:enumeration value="RS"/>
+			<xs:enumeration value="SC"/>
+			<xs:enumeration value="SE"/>
+			<xs:enumeration value="SP"/>
+			<xs:enumeration value="TO"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TVerAplic">
+		<xs:annotation>
+			<xs:documentation>Tipo Versão do Aplicativo</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="TString">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="20"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TLatitude">
+		<xs:annotation>
+			<xs:documentation>Coordenada geográfica Latitude</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="TString">
+			<xs:pattern value="[0-9]\.[0-9]{6}|[1-8][0-9]\.[0-9]{6}|90\.[0-9]{6}|-[0-9]\.[0-9]{6}|-[1-8][0-9]\.[0-9]{6}|-90\.[0-9]{6}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TLongitude">
+		<xs:annotation>
+			<xs:documentation>Coordenada geográfica Longitude</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="TString">
+			<xs:pattern value="[0-9]\.[0-9]{6}|[1-9][0-9]\.[0-9]{6}|1[0-7][0-9]\.[0-9]{6}|180\.[0-9]{6}|-[0-9]\.[0-9]{6}|-[1-9][0-9]\.[0-9]{6}|-1[0-7][0-9]\.[0-9]{6}|-180\.[0-9]{6}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TIPv4">
+		<xs:annotation>
+			<xs:documentation>Tipo IP versão 4</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TPlaca">
+		<xs:annotation>
+			<xs:documentation>Tipo Placa </xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[A-Z]{2,3}[0-9]{4}|[A-Z]{3,4}[0-9]{3}|[A-Z0-9]{7}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="TRSAKeyValueType">
+		<xs:annotation>
+			<xs:documentation>Tipo que representa uma chave publica padrão RSA</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Modulus" type="xs:base64Binary"/>
+			<xs:element name="Exponent" type="xs:base64Binary"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/xmldsig-core-schema_v1.01.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001_RTC_1.05/xmldsig-core-schema_v1.01.xsd
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- ***************************************************-->
+<!-- ***   Schema específico para assinaturas XML    ***-->
+<!-- *** a partir de certificados do padrão (X509)   ***-->
+<!-- *** ICP-Brasil - Projeto Nota Fiscal Eletrônica ***-->
+<!-- ***************************************************-->
+<!-- Schema for XML Signatures-->
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.w3.org/2000/09/xmldsig#" elementFormDefault="qualified" attributeFormDefault="unqualified" version="0.1">
+	<element name="Signature" type="ds:SignatureType"/>
+	<complexType name="SignatureType">
+		<sequence>
+			<element name="SignedInfo" type="ds:SignedInfoType"/>
+			<element name="SignatureValue" type="ds:SignatureValueType"/>
+			<element name="KeyInfo" type="ds:KeyInfoType"/>
+		</sequence>
+		<attribute name="Id" type="ID" use="optional"/>
+	</complexType>
+	<complexType name="SignatureValueType">
+		<simpleContent>
+			<extension base="base64Binary">
+				<attribute name="Id" type="ID" use="optional"/>
+			</extension>
+		</simpleContent>
+	</complexType>
+	<complexType name="SignedInfoType">
+		<sequence>
+			<element name="CanonicalizationMethod">
+				<complexType>
+					<attribute name="Algorithm" type="anyURI" use="required" fixed="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+				</complexType>
+			</element>
+			<element name="SignatureMethod">
+				<complexType>
+					<attribute name="Algorithm" type="anyURI" use="required" fixed="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+				</complexType>
+			</element>
+			<element name="Reference" type="ds:ReferenceType"/>
+		</sequence>
+		<attribute name="Id" type="ID" use="optional"/>
+	</complexType>
+	<complexType name="ReferenceType">
+		<sequence>
+			<element name="Transforms" type="ds:TransformsType">
+				<!-- Garante a unicidade do atributo -->
+				<unique name="unique_Transf_Alg">
+					<selector xpath="./*"/>
+					<field xpath="@Algorithm"/>
+				</unique>
+			</element>
+			<element name="DigestMethod">
+				<complexType>
+					<attribute name="Algorithm" type="anyURI" use="required" fixed="http://www.w3.org/2000/09/xmldsig#sha1"/>
+				</complexType>
+			</element>
+			<element name="DigestValue" type="ds:DigestValueType"/>
+		</sequence>
+		<attribute name="Id" type="ID" use="optional"/>
+		<attribute name="URI" use="required">
+			<simpleType>
+				<restriction base="anyURI">
+					<minLength value="2"/>
+				</restriction>
+			</simpleType>
+		</attribute>
+		<attribute name="Type" type="anyURI" use="optional"/>
+	</complexType>
+	<complexType name="TransformsType">
+		<sequence>
+			<element name="Transform" type="ds:TransformType" minOccurs="2" maxOccurs="2"/>
+		</sequence>
+	</complexType>
+	<complexType name="TransformType">
+		<sequence minOccurs="0" maxOccurs="unbounded">
+			<element name="XPath" type="string"/>
+		</sequence>
+		<attribute name="Algorithm" type="ds:TTransformURI" use="required"/>
+	</complexType>
+	<complexType name="KeyInfoType">
+		<sequence>
+			<element name="X509Data" type="ds:X509DataType"/>
+		</sequence>
+		<attribute name="Id" type="ID" use="optional"/>
+	</complexType>
+	<complexType name="X509DataType">
+		<sequence>
+			<element name="X509Certificate" type="base64Binary"/>
+		</sequence>
+	</complexType>
+	<simpleType name="DigestValueType">
+		<restriction base="base64Binary"/>
+	</simpleType>
+	<simpleType name="TTransformURI">
+		<restriction base="anyURI">
+			<enumeration value="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+			<enumeration value="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+		</restriction>
+	</simpleType>
+</schema>


### PR DESCRIPTION
Implementação NF-e/NFC-e Nota Técnica 2025.002-RTC - Versão 1.10 e CT-e Nota Técnica 2025.001 – Reforma Tributária do Consumo Versão 1.05

Foi implementado apenas os novos campos, não foi alterado as classes de eventos onde cStat passa a de 3 para 4 dígitos e nProt de 15 para 17 dígitos.