### PR TITLE
Adiciona método para envio de MDF-e com XML já assinado

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/mdfe3/webservices/WSFacade.java
+++ b/src/main/java/com/fincatto/documentofiscal/mdfe3/webservices/WSFacade.java
@@ -92,6 +92,19 @@ public class WSFacade {
     }
 
     /**
+     * Faz o envio sincronizado para a SEFAZ com o evento já assinado
+     *
+     * @param mdfEnvioAssinado a ser eviado para a SEFAZ
+     * @return dados do retorno do envio do MDFE e o xml assinado
+     * @throws Exception caso nao consiga gerar o xml ou problema de conexao com
+     * o sefaz
+     *
+     */
+    public MDFEnvioRetornoDados envioRecepcaoSincAssinado(final String mdfEnvioAssinado) throws Exception {
+        return this.wsRecepcaoSinc.envioRecepcaoSincAssinado(mdfEnvioAssinado);
+    }
+
+    /**
      * Faz a consulta de status responsavel pela UF, no caso apenas o RS está
      * disponível
      *

--- a/src/main/java/com/fincatto/documentofiscal/mdfe3/webservices/WSRecepcaoSinc.java
+++ b/src/main/java/com/fincatto/documentofiscal/mdfe3/webservices/WSRecepcaoSinc.java
@@ -41,6 +41,14 @@ class WSRecepcaoSinc implements DFLog {
         final MDFEnvioRetorno retorno = comunicaSinc(documentoAssinado);
         return new MDFEnvioRetornoDados(retorno, mdfeAssinado);
     }
+
+    public MDFEnvioRetornoDados envioRecepcaoSincAssinado(final String mdfeEnvioXmlAssinado) throws Exception {
+        final MDFe mdfeAssinado = this.config.getPersister().read(MDFe.class, mdfeEnvioXmlAssinado);
+
+        //comunica o mdfe
+        final MDFEnvioRetorno retorno = comunicaSinc(mdfeEnvioXmlAssinado);
+        return new MDFEnvioRetornoDados(retorno, mdfeAssinado);
+    }
     
     private MDFEnvioRetorno comunicaSinc(final String mdfeAssinadoXml) throws Exception {
         //devido a limitacao padrao de 5000 da jdk


### PR DESCRIPTION
Este PR introduz uma melhoria na forma como o envio do MDF-e é realizado, permitindo maior flexibilidade e controle por parte de quem consome a funcionalidade.

✅ Alterações principais:
Adicionado um novo método que recebe o XML do MDF-e já assinado como String, permitindo que a assinatura seja realizada fora da classe de envio.

O método atual, que realiza a assinatura internamente, foi mantido para compatibilidade com chamadas existentes.

🎯 Motivação:
Anteriormente, a assinatura do XML era encapsulada dentro do método de envio, impedindo o acesso ao conteúdo assinado por quem chama a função. Com essa nova abordagem, torna-se possível:

Armazenar o XML assinado para futuras consultas ou auditoria.

Reutilizar o XML assinado em outros contextos antes do envio.

Aplicar estratégias customizadas de assinatura se necessário.

⚠️ Observações:
Não houve alteração na lógica de envio para o método original.

A nova sobrecarga é opcional e visa apenas ampliar a usabilidade da funcionalidade existente.