### PR TITLE
Classes referente ao Qr-Code 3.0 conforme Nota Técnica 2025.001 v.1.01

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoSuplementar.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoSuplementar.java
@@ -18,7 +18,7 @@ public class NFNotaInfoSuplementar extends DFBase {
     private String urlConsultaChaveAcesso;
 
     public void setQrCode(final String qrCode) {
-        DFStringValidador.tamanho100a600(qrCode, "QR Code");
+        DFStringValidador.tamanho60a1000(qrCode, "QR Code");
         this.qrCode = qrCode;
     }
 

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/utils/qrcode30/NFGeraQRCode30.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/utils/qrcode30/NFGeraQRCode30.java
@@ -1,0 +1,50 @@
+package com.fincatto.documentofiscal.nfe400.utils.qrcode30;
+
+import com.fincatto.documentofiscal.DFAmbiente;
+import com.fincatto.documentofiscal.nfe.NFeConfig;
+import com.fincatto.documentofiscal.nfe400.classes.nota.NFNota;
+import com.fincatto.documentofiscal.utils.DFAssinaturaDigital;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Classe abstrata para a implementação da geração do QRCode 3.0.
+ * Deve ser feita a implementação para emissão normal (1) e para contingência offline (9).
+ */
+public abstract class NFGeraQRCode30 {
+
+    public static final String VERSAO_QRCODE = "3";
+
+    protected final NFNota nota;
+    protected final NFeConfig config;
+
+    public NFGeraQRCode30(final NFNota nota, final NFeConfig config) {
+        this.nota = nota;
+        this.config = config;
+    }
+
+    /**
+     * Método responsável pela geração do qrcode.
+     *
+     * @return URL para consulta da nota via qrcode30.
+     * @throws Exception
+     */
+    public abstract String getQRCode() throws Exception;
+
+    public String getUrlQRCode() {
+        String url = this.config.getAmbiente().equals(DFAmbiente.PRODUCAO) ? this.nota.getInfo().getIdentificacao().getUf().getQrCodeProducao() : this.nota.getInfo().getIdentificacao().getUf().getQrCodeHomologacao();
+
+        if (StringUtils.isBlank(url)) {
+            throw new IllegalArgumentException("URL para consulta do QRCode nao informada para uf " + this.nota.getInfo().getIdentificacao().getUf() + "!");
+        }
+
+        return url;
+    }
+
+    public String assinar(final String parametros) throws Exception {
+        return new DFAssinaturaDigital(config).assinarString(parametros);
+    }
+
+    public String urlConsultaChaveAcesso() {
+        return this.config.getAmbiente().equals(DFAmbiente.PRODUCAO) ? this.nota.getInfo().getIdentificacao().getUf().getConsultaChaveAcessoProducao() : this.nota.getInfo().getIdentificacao().getUf().getConsultaChaveAcessoHomologacao();
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/utils/qrcode30/NFGeraQRCodeContingenciaOffline30.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/utils/qrcode30/NFGeraQRCodeContingenciaOffline30.java
@@ -1,0 +1,50 @@
+package com.fincatto.documentofiscal.nfe400.utils.qrcode30;
+
+import com.fincatto.documentofiscal.nfe.NFeConfig;
+import com.fincatto.documentofiscal.nfe400.classes.nota.NFNota;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+/**
+ * Implementação QRCode contingência offline (9).
+ */
+public class NFGeraQRCodeContingenciaOffline30 extends NFGeraQRCode30 {
+
+    public NFGeraQRCodeContingenciaOffline30(final NFNota nota, final NFeConfig config) {
+        super(nota, config);
+    }
+
+    public String getQRCode() throws Exception {
+        String url = getUrlQRCode();
+
+        final ZonedDateTime dt = nota.getInfo().getIdentificacao().getDataHoraEmissao();
+        final String diaEmissao = DateTimeFormatter.ofPattern("dd").format(dt);
+
+        String tpIdDest = "";
+        String idDest = "";
+        if (nota.getInfo().getDestinatario() != null) {
+            if (nota.getInfo().getDestinatario().getCnpj() != null) {
+                tpIdDest = "1";
+                idDest = nota.getInfo().getDestinatario().getCnpj();
+            } else if (nota.getInfo().getDestinatario().getCpf() != null) {
+                tpIdDest = "2";
+                idDest = nota.getInfo().getDestinatario().getCpf();
+            } else if (nota.getInfo().getDestinatario().getIdEstrangeiro() != null) {
+                tpIdDest = "3";
+            }
+        }
+
+        // Monta os parametros do qrcode: http://www.sefazexemplo.gov.br/nfce/qrcode?p=<chave_acesso>|<3>|<tpAmb>|<dia_data_emissao>|<vNF>|<tp_idDest>|<idDest>|ZZSKiypy7fkg22MUv6TUh71EI+wLYWr/fUHJy3PyWnL7d5mzEqtxu6bVbhE7AeNiDTirh1u9gVfC2Hw+Lsno2XNL5FRUc5NcuMTT2hA6E9HYC9gryvtWAIgiCZUNG5cWWLCh0G62QdnNe8iSrlSooQu9Z5g1vbGaTFMxaugzzvo==
+        final StringBuilder parametros = new StringBuilder();
+        parametros.append(nota.getInfo().getChaveAcesso()).append("|");                 // Chave de Acesso da NFC-e
+        parametros.append(VERSAO_QRCODE).append("|");                                   // Versao do QRCode
+        parametros.append(config.getAmbiente().getCodigo()).append("|");                // Ambiente
+        parametros.append(diaEmissao).append("|");                                      // Data e Hora de Emissão da NFC-e
+        parametros.append(nota.getInfo().getTotal().getIcmsTotal().getValorTotalNFe()).append("|"); // Valor Total da NFC-e
+        parametros.append(tpIdDest).append("|"); // Tipo de Identificação do Destinatário; 1=CNPJ; 2=CPF; 3=idEstrangeiro; Caso Destinatário não identificado, informar apenas o separador “|”
+        parametros.append(idDest); // Identificação do Destinatário CPF ou CNPJ na NFC-e. Caso Destinatário estrangeiro ou não identificado, informar apenas o separador “|”
+
+        return url + "?p=" + parametros.toString() + "|" + assinar(parametros.toString());
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/utils/qrcode30/NFGeraQRCodeEmissaoNormal30.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/utils/qrcode30/NFGeraQRCodeEmissaoNormal30.java
@@ -1,0 +1,27 @@
+package com.fincatto.documentofiscal.nfe400.utils.qrcode30;
+
+import com.fincatto.documentofiscal.nfe.NFeConfig;
+import com.fincatto.documentofiscal.nfe400.classes.nota.NFNota;
+
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Implementação geração qrcode emissão normal (1).
+ */
+public class NFGeraQRCodeEmissaoNormal30 extends NFGeraQRCode30 {
+
+    public NFGeraQRCodeEmissaoNormal30(final NFNota nota, final NFeConfig config) {
+        super(nota, config);
+    }
+
+    public String getQRCode() throws NoSuchAlgorithmException {
+        String url = getUrlQRCode();
+
+        final StringBuilder parametros = new StringBuilder();
+        parametros.append(nota.getInfo().getChaveAcesso()).append("|"); // Chave de Acesso da NFC-e
+        parametros.append(VERSAO_QRCODE).append("|");                   // Versao do QRCode
+        parametros.append(config.getAmbiente().getCodigo());            // Tipo de Ambiente Homolog / Producao
+
+        return url + "?p=" + parametros.toString();
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/validadores/DFStringValidador.java
+++ b/src/main/java/com/fincatto/documentofiscal/validadores/DFStringValidador.java
@@ -535,6 +535,12 @@ public abstract class DFStringValidador {
         }
     }
 
+    public static void tamanho60a1000(final String string, final String info) {
+        if (string != null) {
+            DFStringValidador.intervalo(string, 60, 1000, info);
+        }
+    }
+
     public static void tamanho2a95(final String string, final String info) {
         if (string != null) {
             DFStringValidador.intervalo(string, 2, 95, info);


### PR DESCRIPTION
Implementamos as Classe para o Qr-Code 3.0 conforme a nova nota técnica referida.
Atualizamos a validação do tamanho do Qr-Code conforme a nova regra da NT.
Não atualizamos a chamada do Qr-Code no método getLoteAssinado da classe WSLoteEnvio no pacote com.fincatto.documentofiscal.nfe400.webservices. Mantivemos o uso do Qr-Code 2.0 porque não sabemos como deveria ser feita a parametrização conforme os padrões do projeto.