### PR TITLE
Adequação do mapeamento de infLocalCarrega e infLocalDescarrega ao xs:choice do schema MDF-e

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.wmixvideo</groupId>
     <artifactId>nfe</artifactId>
-    <version>4.0.92-SNAPSHOT</version>
+    <version>4.0.93-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>nfe</name>
     <description>Biblioteca de comunicacao de nota fiscal eletronica brasileira</description>

--- a/src/main/java/com/fincatto/documentofiscal/mdfe3/classes/nota/MDFInfoProdutoPredominanteInfLotacaoLocalCarrega.java
+++ b/src/main/java/com/fincatto/documentofiscal/mdfe3/classes/nota/MDFInfoProdutoPredominanteInfLotacaoLocalCarrega.java
@@ -18,10 +18,10 @@ public class MDFInfoProdutoPredominanteInfLotacaoLocalCarrega extends DFBase {
     @Element(name = "CEP", required = false)
     private String CEP;
     
-    @Element(name = "latitude", required = true)
+    @Element(name = "latitude", required = false)
     private Float latitude;
     
-    @Element(name = "longitude", required = true)
+    @Element(name = "longitude", required = false)
     private Float longitude;
 
     public String getCEP() {
@@ -30,6 +30,8 @@ public class MDFInfoProdutoPredominanteInfLotacaoLocalCarrega extends DFBase {
 
     public void setCEP(String CEP) {
         this.CEP = CEP;
+        this.latitude = null;
+        this.longitude = null;
     }
 
     public Float getLatitude() {
@@ -38,6 +40,7 @@ public class MDFInfoProdutoPredominanteInfLotacaoLocalCarrega extends DFBase {
 
     public void setLatitude(Float latitude) {
         this.latitude = latitude;
+        this.CEP = null;
     }
 
     public Float getLongitude() {
@@ -46,7 +49,7 @@ public class MDFInfoProdutoPredominanteInfLotacaoLocalCarrega extends DFBase {
 
     public void setLongitude(Float longitude) {
         this.longitude = longitude;
+        this.CEP = null;
     }
-    
-    
+
 }

--- a/src/main/java/com/fincatto/documentofiscal/mdfe3/classes/nota/MDFInfoProdutoPredominanteInfLotacaoLocalDescarrega.java
+++ b/src/main/java/com/fincatto/documentofiscal/mdfe3/classes/nota/MDFInfoProdutoPredominanteInfLotacaoLocalDescarrega.java
@@ -18,10 +18,10 @@ public class MDFInfoProdutoPredominanteInfLotacaoLocalDescarrega extends DFBase 
     @Element(name = "CEP", required = false)
     private String CEP;
     
-    @Element(name = "latitude", required = true)
+    @Element(name = "latitude", required = false)
     private Float latitude;
     
-    @Element(name = "longitude", required = true)
+    @Element(name = "longitude", required = false)
     private Float longitude;
 
     public String getCEP() {
@@ -30,6 +30,8 @@ public class MDFInfoProdutoPredominanteInfLotacaoLocalDescarrega extends DFBase 
 
     public void setCEP(String CEP) {
         this.CEP = CEP;
+        this.latitude = null;
+        this.longitude = null;
     }
 
     public Float getLatitude() {
@@ -38,6 +40,7 @@ public class MDFInfoProdutoPredominanteInfLotacaoLocalDescarrega extends DFBase 
 
     public void setLatitude(Float latitude) {
         this.latitude = latitude;
+        this.CEP = null;
     }
 
     public Float getLongitude() {
@@ -46,6 +49,7 @@ public class MDFInfoProdutoPredominanteInfLotacaoLocalDescarrega extends DFBase 
 
     public void setLongitude(Float longitude) {
         this.longitude = longitude;
+        this.CEP = null;
     }
     
 }


### PR DESCRIPTION
Ajustado o mapeamento da classe **MDFInfoProdutoPredominanteInfLotacaoLocalCarrega** e **MDFInfoProdutoPredominanteInfLotacaoLocalDescarrega** para refletir corretamente a estrutura xs:choice definida no schema XML do MDF-e.

Segundo o schema, deve-se informar apenas:

o campo **CEP**, ou os campos **latitude** e **longitude**.

Foi validado que é possível autorizar o documento informando apenas o campo CEP nos elementos MDFInfoProdutoPredominanteInfLotacaoLocalCarrega e MDFInfoProdutoPredominanteInfLotacaoLocalDescarrega, conforme permitido pelo schema XML. No entanto, o mapeamento anterior da classe Java impedia essa abordagem, exigindo indevidamente os campos de coordenadas geográficas.

Para garantir isso programaticamente, os setters foram ajustados para limpar os campos conflitantes, evitando que ambas as opções sejam usadas simultaneamente. Todos os campos foram definidos como required = false, respeitando a lógica do schema de validação.

Essa mudança evita falhas de validação XSD e garante conformidade com o schema oficial.