### PR TITLE
ajustado tamanho protocolo nf

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/cancelamento/NFInfoCancelamento.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/cancelamento/NFInfoCancelamento.java
@@ -56,7 +56,7 @@ public class NFInfoCancelamento extends NFTipoEvento {
     }
 
     public void setProtocoloAutorizacao(final String protocoloAutorizacao) {
-        DFStringValidador.exatamente15N(protocoloAutorizacao, "Protocolo de Autorizacao");
+        DFStringValidador.tamanho25N(protocoloAutorizacao, "Protocolo de Autorizacao");
         this.protocoloAutorizacao = protocoloAutorizacao;
     }
 

--- a/src/test/java/com/fincatto/documentofiscal/nfe400/classes/evento/cancelamento/NFInfoCancelamentoTest.java
+++ b/src/test/java/com/fincatto/documentofiscal/nfe400/classes/evento/cancelamento/NFInfoCancelamentoTest.java
@@ -32,7 +32,7 @@ public class NFInfoCancelamentoTest {
     @Test(expected = IllegalStateException.class)
     public void naoDevePermitirProtocoloAutorizacaoComTamanhoExtrapolado() {
         final NFInfoCancelamento infoCancelamento = new NFInfoCancelamento();
-        final String protocoloAutorizacao = "1234567890123456";
+        final String protocoloAutorizacao = "12345678901234567890123456";
         infoCancelamento.setProtocoloAutorizacao(protocoloAutorizacao);
     }
 


### PR DESCRIPTION
ajuste feito por conta de uma situação que peguei em produção, cliente possui uma NF autorizada e o protocolo tem 17 caracteres. No manual não encontrei a limitação de 15.