### PR TITLE
fix: define codBanco e codAgencia como required=false para refletir x…

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/mdfe3/classes/nota/MDFInfoModalRodoviarioInfPagBanco.java
+++ b/src/main/java/com/fincatto/documentofiscal/mdfe3/classes/nota/MDFInfoModalRodoviarioInfPagBanco.java
@@ -18,13 +18,13 @@ public class MDFInfoModalRodoviarioInfPagBanco extends DFBase {
     /**
      * Número do banco
      */
-    @Element(name = "codBanco")
+    @Element(name = "codBanco", required = false)
     private String codBanco;
 
     /**
      * Número da agência bancária
      */
-    @Element(name = "codAgencia")
+    @Element(name = "codAgencia", required = false)
     private String codAgencia;
 
     /**


### PR DESCRIPTION
O XSD define um <xs:choice> entre (codBanco/codAgencia), CNPJIPEF e PIX, permitindo apenas uma das opções por vez. s campos foram marcados como required=false para evitar erro de serialização quando outra opção for utilizada.