### PR TITLE
Ajuste validação tamanho protocolo cancelamento NFC-e

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/cancelamento/NFInfoCancelamento.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/cancelamento/NFInfoCancelamento.java
@@ -56,7 +56,7 @@ public class NFInfoCancelamento extends NFTipoEvento {
     }
 
     public void setProtocoloAutorizacao(final String protocoloAutorizacao) {
-        DFStringValidador.tamanho15ou17(protocoloAutorizacao, "Protocolo de Autorizacao");
+        DFStringValidador.tamanho15ou17N(protocoloAutorizacao, "Protocolo de Autorizacao");
         this.protocoloAutorizacao = protocoloAutorizacao;
     }
 

--- a/src/main/java/com/fincatto/documentofiscal/validadores/DFStringValidador.java
+++ b/src/main/java/com/fincatto/documentofiscal/validadores/DFStringValidador.java
@@ -355,8 +355,9 @@ public abstract class DFStringValidador {
         }
     }
 
-    public static void tamanho15ou17(final String string, final String info) {
+    public static void tamanho15ou17N(final String string, final String info) {
         if (string != null) {
+            DFStringValidador.apenasNumerico(string, info);
             if (string.length() != 15 && string.length() != 17) {
                 throw new IllegalStateException(String.format("%s \"%s\" deve possuir 15 ou 17 caracteres", info, string));
             }


### PR DESCRIPTION
Olá,
Estava testando cancelamento de NFC-e e percebi que aqui em SP já está retornando protocolo de autorização com tamanho 17, retornando erro de validação de tamanho (igual a 15), dei uma pesquisada e achei a NT_2025.002_v1 que aborda essa mudança em alguns estados.