### PR TITLE
chore: Atualizado os esquemas para o Pacote de Liberação nº 010b v. 1.30

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/validadores/DFXMLValidador.java
+++ b/src/main/java/com/fincatto/documentofiscal/validadores/DFXMLValidador.java
@@ -28,7 +28,7 @@ public final class DFXMLValidador {
     }
 
     public static boolean valida400(final String xml, final String xsd) throws IOException, SAXException, URISyntaxException {
-        final URL xsdPath = DFXMLValidador.class.getClassLoader().getResource(String.format("schemas/PL_010b_NT2025_002_v1.20/%s", xsd));
+        final URL xsdPath = DFXMLValidador.class.getClassLoader().getResource(String.format("schemas/PL_010b_NT2025_002_v1.30/%s", xsd));
         final SchemaFactory schemaFactory = SchemaFactory.newInstance("http://www.w3.org/2001/XMLSchema");
         final Schema schema = schemaFactory.newSchema(new StreamSource(xsdPath.toURI().toString()));
         schema.newValidator().validate(new StreamSource(new StringReader(xml)));

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/DFeTiposBasicos_v1.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/DFeTiposBasicos_v1.00.xsd
@@ -1,0 +1,1293 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2025 rel. 2 (x64) (https://www.altova.com) by PROCERGS (Procergs - Centro de Tecnologia da Informação e Comunicação do Estado do Rio Grande do Sul S.A.) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+	<xs:simpleType name="TStringRTC">
+		<xs:annotation>
+			<xs:documentation> Tipo string genérico</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCST">
+		<xs:annotation>
+			<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="\d{3}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TcClassTrib">
+		<xs:annotation>
+			<xs:documentation>Código de Classificação Tributária do IBS e da CBS</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="\d{6}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TcCredPres">
+		<xs:annotation>
+			<xs:documentation>Código de Classificação do Crédito Presumido do IBS e da CBS, conforme tabela cCredPres</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="\d{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec1104RTC">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 11 de corpo e 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{4}|[1-9]{1}[0-9]{0,10}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1104OpRTC">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 11 inteiros, podendo ter 4 decimais (utilizado em tags opcionais)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[1-9]{1}[0-9]{3}|0\.[0-9]{3}[1-9]{1}|0\.[0-9]{2}[1-9]{1}[0-9]{1}|0\.[0-9]{1}[1-9]{1}[0-9]{2}|[1-9]{1}[0-9]{0,10}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec1302RTC">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 13 de corpo e 2 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0302_04RTC">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com até 3 dígitos inteiros, podendo ter de 2 até 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{2,4}|[1-9]{1}[0-9]{0,2}(\.[0-9]{2,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TOperCompraGov">
+		<xs:annotation>
+			<xs:documentation>Tipo da Operação com Ente Governamental</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TEnteGov">
+		<xs:annotation>
+			<xs:documentation>Tipo de Ente Governamental</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+			<xs:enumeration value="3"/>
+			<xs:enumeration value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TTpCredPresIBSZFM">
+		<xs:annotation>
+			<xs:documentation>Tipo de classificação do Crédito Presumido IBS ZFM</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="0"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+			<xs:enumeration value="3"/>
+			<xs:enumeration value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TIndDoacao">
+		<xs:annotation>
+			<xs:documentation>Tipo Indicador de Doação</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="TTribNFCom">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NFCom</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Indica se a operação é de doação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+			<xs:element name="gEstornoCred" type="TEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informado conforme indicador no cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribNF3e">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NF3e</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Indica se a operação é de doação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+			<xs:element name="gEstornoCred" type="TEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informado conforme indicador no cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribNFAg">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NFAg</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0"/>
+			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+			<xs:element name="gEstornoCred" type="TEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informado conforme indicador no cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribCTe">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação do CTe</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0"/>
+			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+			<xs:element name="gEstornoCred" type="TEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informado conforme indicador no cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribBPe">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação do BPe</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0"/>
+			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+			<xs:element name="gEstornoCred" type="TEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informado conforme indicador no cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribNFCe">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NFCe</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Indica se a operação é de doação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice minOccurs="0">
+				<xs:element name="gIBSCBS" type="TCIBS"/>
+				<xs:element name="gIBSCBSMono" type="TMonofasia"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribNFe">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NFe</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Indica se a operação é de doação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice minOccurs="0">
+				<xs:element name="gIBSCBS" type="TCIBS"/>
+				<xs:element name="gIBSCBSMono" type="TMonofasia">
+					<xs:annotation>
+						<xs:documentation>Informar essa opção da Choice para Monofasia (CST 620)</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="gTransfCred" type="TTransfCred">
+					<xs:annotation>
+						<xs:documentation>Informar essa opção da Choice para o CST 800</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="gAjusteCompet" type="TAjusteCompet">
+					<xs:annotation>
+						<xs:documentation>Informar essa opção da Choice para o CST 811</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+			<xs:element name="gEstornoCred" type="TEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informado conforme indicador no cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice minOccurs="0">
+				<xs:element name="gCredPresOper" type="TCredPresOper">
+					<xs:annotation>
+						<xs:documentation>Crédito Presumido da Operação. Informado conforme indicador no cClassTrib.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="gCredPresIBSZFM" type="TCredPresIBSZFM">
+					<xs:annotation>
+						<xs:documentation>Classificação de acordo com o art. 450, § 1º, da LC 214/25 para o cálculo do crédito presumido na ZFM. Informado conforme indicador no cClassTrib.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribNFGas">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NFGas</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0"/>
+			<xs:choice minOccurs="0">
+				<xs:element name="gIBSCBS" type="TCIBS"/>
+				<xs:element name="gIBSCBSMono" type="TMonofasia">
+					<xs:annotation>
+						<xs:documentation>Informar essa opção da Choice para Monofasia</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+			<xs:element name="gEstornoCred" type="TEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informado conforme indicador no cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TIS">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações do Imposto Seletivo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CSTIS" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do Imposto Seletivo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTribIS" type="TcClassTrib"/>
+			<xs:sequence minOccurs="0">
+				<xs:element name="vBCIS" type="TDec1302RTC">
+					<xs:annotation>
+						<xs:documentation>Valor do BC</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="pIS" type="TDec_0302_04RTC">
+					<xs:annotation>
+						<xs:documentation>Alíquota do Imposto Seletivo (percentual)</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="pISEspec" type="TDec_0302_04RTC" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Alíquota do Imposto Seletivo (por valor)</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:sequence minOccurs="0">
+					<xs:element name="uTrib">
+						<xs:annotation>
+							<xs:documentation>Unidade de medida apropriada especificada em Lei Ordinaria para fins de apuração do Imposto Seletivo</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="TStringRTC">
+								<xs:minLength value="1"/>
+								<xs:maxLength value="6"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:element>
+					<xs:element name="qTrib" type="TDec_1104OpRTC">
+						<xs:annotation>
+							<xs:documentation>Quantidade com abse no campo uTrib informado</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+				</xs:sequence>
+				<xs:element name="vIS" type="TDec1302RTC">
+					<xs:annotation>
+						<xs:documentation>Valor do Imposto Seletivo calculado</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TISTot">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações de totais do Imposto Seletivo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vIS" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor Total do Imposto Seletivo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TIBSCBSTot">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações de totais da CBS/IBS</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vBCIBSCBS" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Total Base de Calculo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gIBS">
+				<xs:annotation>
+					<xs:documentation>Totalização do IBS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="gIBSUF">
+							<xs:annotation>
+								<xs:documentation>Totalização do IBS de competência da UF</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vDif" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Total do Diferimento</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vDevTrib" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Total de devoluções de tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vIBSUF" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Valor total do IBS Estadual</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="gIBSMun">
+							<xs:annotation>
+								<xs:documentation>Totalização do IBS de competência Municipal</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vDif" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Total do Diferimento</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vDevTrib" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Total de devoluções de tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vIBSMun" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Valor total do IBS Municipal</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="vIBS" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total do IBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gCBS">
+				<xs:annotation>
+					<xs:documentation>Totalização da CBS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="vDif" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Total do Diferimento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vDevTrib" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Total de devoluções de tributos</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBS" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total da CBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Totalização do estorno de crédito</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="vIBSEstCred" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total do IBS estornado</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSEstCred" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total da CBS estornada</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TIBSCBSMonoTot">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações de totais da CBS/IBS com monofasia</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vBCIBSCBS" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Total Base de Calculo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gIBS" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Totalização do IBS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="gIBSUF">
+							<xs:annotation>
+								<xs:documentation>Totalização do IBS de competência da UF</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vDif" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Total do Diferimento</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vDevTrib" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Total de devoluções de tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vIBSUF" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Valor total do IBS Estadual</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="gIBSMun">
+							<xs:annotation>
+								<xs:documentation>Totalização do IBS de competência Municipal</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vDif" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Total do Diferimento</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vDevTrib" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Total de devoluções de tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vIBSMun" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Valor total do IBS Municipal</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="vIBS" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total do IBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPres" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPresCondSus" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido Condição Suspensiva</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gCBS" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Totalização da CBS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="vDif" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Total do Diferimento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vDevTrib" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Total de devoluções de tributos</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBS" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total da CBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPres" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPresCondSus" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido Condição Suspensiva</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gMono" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Totais da Monofasia</xs:documentation>
+					<xs:documentation>Só deverá ser utilizado para DFe modelos 55 e 65</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="vIBSMono" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total do IBS monofásico</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSMono" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total da CBS monofásica</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vIBSMonoReten" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total do IBS monofásico sujeito a retenção</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSMonoReten" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total da CBS monofásica sujeita a retenção</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vIBSMonoRet" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor do IBS monofásico retido anteriormente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSMonoRet" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor da CBS monofásica retida anteriormente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Totalização do estorno de crédito</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="vIBSEstCred" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total do IBS estornado</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSEstCred" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total da CBS estornada</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TMonofasia">
+		<xs:annotation>
+			<xs:documentation>Tipo Monofasia</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:annotation>
+				<xs:documentation>Monofasia</xs:documentation>
+			</xs:annotation>
+			<xs:element name="gMonoPadrao" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de informações da Tributação Monofásica padrão</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="qBCMono" type="TDec1104RTC">
+							<xs:annotation>
+								<xs:documentation>Quantidade tributada na monofasia</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="adRemIBS" type="TDec_0302_04RTC">
+							<xs:annotation>
+								<xs:documentation>Alíquota ad rem do IBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="adRemCBS" type="TDec_0302_04RTC">
+							<xs:annotation>
+								<xs:documentation>Alíquota ad rem da CBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vIBSMono" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor do IBS monofásico</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSMono" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor da CBS monofásica</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gMonoReten" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de informações da Tributação Monofásica sujeita a retenção</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="qBCMonoReten" type="TDec1104RTC">
+							<xs:annotation>
+								<xs:documentation>Quantidade tributada sujeita a retenção.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="adRemIBSReten" type="TDec_0302_04RTC">
+							<xs:annotation>
+								<xs:documentation>Alíquota ad rem do IBS sujeito a retenção</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vIBSMonoReten" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor do IBS monofásico sujeito a retenção</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="adRemCBSReten" type="TDec_0302_04RTC">
+							<xs:annotation>
+								<xs:documentation>Alíquota ad rem da CBS sujeita a retenção</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSMonoReten" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor da CBS monofásica sujeita a retenção</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gMonoRet" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de informações da Tributação Monofásica retida anteriormente</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="qBCMonoRet" type="TDec1104RTC">
+							<xs:annotation>
+								<xs:documentation>Quantidade tributada retida anteriormente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="adRemIBSRet" type="TDec_0302_04RTC">
+							<xs:annotation>
+								<xs:documentation>Alíquota ad rem do IBS retido anteriormente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vIBSMonoRet" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor do IBS retido anteriormente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="adRemCBSRet" type="TDec_0302_04RTC">
+							<xs:annotation>
+								<xs:documentation>Alíquota ad rem da CBS retida anteriormente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSMonoRet" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor da CBS retida anteriormente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gMonoDif" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de informações do diferimento da Tributação Monofásica</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="pDifIBS" type="TDec_0302_04RTC">
+							<xs:annotation>
+								<xs:documentation>Percentual do diferimento do imposto monofásico</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vIBSMonoDif" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor do IBS monofásico diferido</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="pDifCBS" type="TDec_0302_04RTC">
+							<xs:annotation>
+								<xs:documentation>Percentual do diferimento do imposto monofásico</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSMonoDif" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor da CBS monofásica diferida</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="vTotIBSMonoItem" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Total de IBS monofásico do item</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vTotCBSMonoItem" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Total da CBS monofásica do item</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCIBS">
+		<xs:annotation>
+			<xs:documentation>Tipo CBS IBS Completo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:annotation>
+				<xs:documentation>IBS / CBS</xs:documentation>
+			</xs:annotation>
+			<xs:element name="vBC" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor do BC</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:sequence>
+				<xs:element name="gIBSUF">
+					<xs:annotation>
+						<xs:documentation>Grupo de informações do IBS na UF</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="pIBSUF" type="TDec_0302_04RTC">
+								<xs:annotation>
+									<xs:documentation>Aliquota do IBS de competência das UF (em percentual)</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="gDif" type="TDif" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Grupo de campos do Diferimento</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="gDevTrib" type="TDevTrib" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Grupo de Informações da devolução de tributos</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="gRed" type="TRed" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Grupo de campos da redução de aliquota</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="vIBSUF" type="TDec1302RTC">
+								<xs:annotation>
+									<xs:documentation>Valor do IBS de competência das UF</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="gIBSMun">
+					<xs:annotation>
+						<xs:documentation>Grupo de Informações do IBS no Município</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="pIBSMun" type="TDec_0302_04RTC">
+								<xs:annotation>
+									<xs:documentation>Aliquota do IBS Municipal (em percentual)</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="gDif" type="TDif" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Grupo de campos do Diferimento</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="gDevTrib" type="TDevTrib" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Grupo de Informações da devolução de tributos</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="gRed" type="TRed" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Grupo de campos da redução de aliquota</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="vIBSMun" type="TDec1302RTC">
+								<xs:annotation>
+									<xs:documentation>Valor do IBS Municipal</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="vIBS" type="TDec1302RTC">
+					<xs:annotation>
+						<xs:documentation>Valor do IBS</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+			<xs:element name="gCBS">
+				<xs:annotation>
+					<xs:documentation>Grupo de Tributação da CBS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="pCBS" type="TDec_0302_04RTC">
+							<xs:annotation>
+								<xs:documentation>Aliquota da CBS (em percentual)</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gDif" type="TDif" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de campos do Diferimento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gDevTrib" type="TDevTrib" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de Informações da devolução de tributos</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gRed" type="TRed" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de campos da redução de aliquota</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBS" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor da CBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gTribRegular" type="TTribRegular" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de informações da Tributação Regular. Informar como seria a tributação caso não cumprida a condição resolutória/suspensiva. Exemplo 1: Art. 442, §4. Operações com ZFM e ALC. Exemplo 2: Operações com suspensão do tributo.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gTribCompraGov" type="TTribCompraGov" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de informações da composição do valor do IBS e da CBS em compras governamental</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TRed">
+		<xs:annotation>
+			<xs:documentation>Tipo Redução Base de Cálculo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="pRedAliq" type="TDec_0302_04RTC">
+				<xs:annotation>
+					<xs:documentation>Percentual de redução de aliquota do cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqEfet" type="TDec_0302_04RTC">
+				<xs:annotation>
+					<xs:documentation>Aliquota Efetiva que será aplicada a Base de Calculo (em percentual)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCredPres">
+		<xs:annotation>
+			<xs:documentation>Tipo Crédito Presumido</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="pCredPres" type="TDec_0302_04RTC">
+				<xs:annotation>
+					<xs:documentation>Percentual do Crédito Presumido</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice>
+				<xs:element name="vCredPres" type="TDec1302RTC">
+					<xs:annotation>
+						<xs:documentation>Valor do Crédito Presumido</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vCredPresCondSus" type="TDec1302RTC">
+					<xs:annotation>
+						<xs:documentation>Valor do Crédito Presumido Condição Suspensiva, preencher apenas para cCredPres que possui indicação de Condição Suspensiva</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TDif">
+		<xs:annotation>
+			<xs:documentation>Tipo Diferimento</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="pDif" type="TDec_0302_04RTC">
+				<xs:annotation>
+					<xs:documentation>Percentual do diferimento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vDif" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor do diferimento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TDevTrib">
+		<xs:annotation>
+			<xs:documentation>Tipo Devolução Tributo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vDevTrib" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor do tributo devolvido. No fornecimento de energia elétrica, água, esgoto e
+gás natural e em outras hipóteses definidas no regulamento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribRegular">
+		<xs:annotation>
+			<xs:documentation>Tipo Tributação Regular</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CSTReg" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código da Situação Tributária do IBS e CBS</xs:documentation>
+					<xs:documentation>Informar qual seria o CST caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTribReg" type="TcClassTrib">
+				<xs:annotation>
+					<xs:documentation>Informar qual seria o cClassTrib caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqEfetRegIBSUF" type="TDec_0302_04RTC">
+				<xs:annotation>
+					<xs:documentation>Alíquota do IBS da UF</xs:documentation>
+					<xs:documentation>Informar como seria a Alíquota caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vTribRegIBSUF" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor do IBS da UF</xs:documentation>
+					<xs:documentation>Informar como seria o valor do Tributo caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqEfetRegIBSMun" type="TDec_0302_04RTC">
+				<xs:annotation>
+					<xs:documentation>Alíquota do IBS do Município</xs:documentation>
+					<xs:documentation>Informar como seria a Alíquota caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vTribRegIBSMun" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor do IBS do Município</xs:documentation>
+					<xs:documentation>Informar como seria o valor do Tributo caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqEfetRegCBS" type="TDec_0302_04RTC">
+				<xs:annotation>
+					<xs:documentation>Alíquota da CBS</xs:documentation>
+					<xs:documentation>Informar como seria a Alíquota caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vTribRegCBS" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor da CBS</xs:documentation>
+					<xs:documentation>Informar como seria o valor do Tributo caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribCompraGov">
+		<xs:annotation>
+			<xs:documentation>Tipo Tributação Compra Governamental</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="pAliqIBSUF" type="TDec_0302_04RTC"/>
+			<xs:element name="vTribIBSUF" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor que seria devido a UF, sem aplicação do Art. 473. da LC 214/2025</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqIBSMun" type="TDec_0302_04RTC"/>
+			<xs:element name="vTribIBSMun" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor que seria devido ao município, sem aplicação do Art. 473. da LC 214/2025</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqCBS" type="TDec_0302_04RTC"/>
+			<xs:element name="vTribCBS" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor que seria devido a CBS, sem aplicação do Art. 473. da LC 214/2025</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCompraGovReduzido">
+		<xs:annotation>
+			<xs:documentation>Tipo Compras Governamentais</xs:documentation>
+			<xs:documentation>Cada DFe que utilizar deverá utilizar esses tipo no grupo ide</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpEnteGov" type="TEnteGov">
+				<xs:annotation>
+					<xs:documentation>Para administração pública direta e suas autarquias e fundações:
+1=União
+2=Estados
+3=Distrito Federal
+4=Municípios</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pRedutor" type="TDec_0302_04RTC">
+				<xs:annotation>
+					<xs:documentation>Percentual de redução de aliquota em compra governamental</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCompraGov">
+		<xs:annotation>
+			<xs:documentation>Tipo Compras Governamentais</xs:documentation>
+			<xs:documentation>Cada DFe que utilizar deverá utilizar esses tipo no grupo ide</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpEnteGov" type="TEnteGov">
+				<xs:annotation>
+					<xs:documentation>Para administração pública direta e suas autarquias e fundações:
+1=União
+2=Estados
+3=Distrito Federal
+4=Municípios</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pRedutor" type="TDec_0302_04RTC">
+				<xs:annotation>
+					<xs:documentation>Percentual de redução de aliquota em compra governamental</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="tpOperGov" type="TOperCompraGov">
+				<xs:annotation>
+					<xs:documentation>Tipo da operação com ente governamental:
+1 - Fornecimento
+2 - Recebimento do Pagamento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTransfCred">
+		<xs:annotation>
+			<xs:documentation>Tipo Transferência de Crédito</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vIBS" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor do IBS a ser transferido</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vCBS" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor da CBS a ser transferida</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TEstornoCred">
+		<xs:annotation>
+			<xs:documentation>Tipo Estorno de Crédito</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vIBSEstCred" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor do IBS a ser estornado</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vCBSEstCred" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor da CBS a ser estornada</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="TCompetApur">
+		<xs:annotation>
+			<xs:documentation>Ano e mês referência do período de apuração (AAAA-MM)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:gYearMonth">
+			<xs:minInclusive value="2025-01"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="TAjusteCompet">
+		<xs:annotation>
+			<xs:documentation>Tipo Ajuste de Competência</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="competApur" type="TCompetApur">
+				<xs:annotation>
+					<xs:documentation>Ano e mês referência do período de apuração (AAAA-MM)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vIBS" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor do IBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vCBS" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor da CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCredPresOper">
+		<xs:annotation>
+			<xs:documentation>Tipo Crédito Presumido da Operação</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vBCCredPres" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor da Base de Cálculo do Crédito Presumido da Operação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cCredPres" type="TcCredPres">
+				<xs:annotation>
+					<xs:documentation>Código de Classificação do Crédito Presumido do IBS e da CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gIBSCredPres" type="TCredPres" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de Informações do Crédito Presumido referente ao IBS, quando aproveitado pelo emitente do documento. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gCBSCredPres" type="TCredPres" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de Informações do Crédito Presumido referente a CBS, quando aproveitado pelo emitente do documento. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCredPresIBSZFM">
+		<xs:annotation>
+			<xs:documentation>Tipo Informações do crédito presumido de IBS para fornecimentos a partir da ZFM</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="competApur" type="TCompetApur">
+				<xs:annotation>
+					<xs:documentation>Ano e mês referência do período de apuração (AAAA-MM)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="tpCredPresIBSZFM" type="TTpCredPresIBSZFM">
+				<xs:annotation>
+					<xs:documentation>Classificação de acordo com o art. 450, § 1º, da LC 214/25 para o cálculo do crédito presumido na ZFM</xs:documentation>
+					<xs:documentation>0 - Sem crédito presumido;
+1 - Bens de consumo final (55%);
+2 - Bens de capital (75%);
+3 - Bens intermediários (90,25%);
+4 - Bens de informática e outros definidos em legislação (100%).
+OBS: Percentuais definidos no art. 450, § 1º, da LC 214/25 para o cálculo do crédito presumido
+</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vCredPresIBSZFM" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor do crédito presumido calculado sobre o saldo devedor apurado</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/consReciNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/consReciNFe_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteNFe_v4.00.xsd"/>
+	<xs:element name="consReciNFe" type="TConsReciNFe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do Pedido de Consulta do Recido do Lote de Notas Fiscais Eletrônicas</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/consSitNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/consSitNFe_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteConsSitNFe_v4.00.xsd"/>
+	<xs:element name="consSitNFe" type="TConsSitNFe">
+		<xs:annotation>
+			<xs:documentation>Schema de validação XML dp Pedido de Consulta da Situação Atual da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/consStatServ_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/consStatServ_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteConsStatServ_v4.00.xsd"/>
+	<xs:element name="consStatServ" type="TConsStatServ">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do Pedido de Consulta do Status do Serviço</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/enviNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/enviNFe_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteNFe_v4.00.xsd"/>
+	<xs:element name="enviNFe" type="TEnviNFe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do Pedido de Concessão de Autorização da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/inutNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/inutNFe_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteInutNFe_v4.00.xsd"/>
+	<xs:element name="inutNFe" type="TInutNFe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do Pedido de Inutilização de Numeração da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/leiauteConsSitNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/leiauteConsSitNFe_v4.00.xsd
@@ -1,0 +1,502 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--  13-05-2011 - correcao do pattern da data para aceitar -4:00 -->
+<!--  03-03-2011 - alteracoes na enumeracao das versoes e no detalhamento do evento -->
+<!--  PL_006eventos versao alterada para consultar eventos 30/08/2010 -->
+<!--  PL_006f versao com correcoes no xServ para tornar a literal CONSULTAR obrigatoria 21/05/2010 -->
+<!--  PL_006c versao com correcoes 24/12/2009 -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposBasico_v4.00.xsd"/>
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v1.01.xsd"/>
+	<xs:complexType name="TConsSitNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Pedido de Consulta da Situação Atual da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xServ">
+				<xs:annotation>
+					<xs:documentation>Serviço Solicitado</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TServ">
+						<xs:enumeration value="CONSULTAR"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="chNFe" type="TChNFe">
+				<xs:annotation>
+					<xs:documentation>Chaves de acesso da NF-e, compostas por: UF do emitente, AAMM da emissão da NFe, CNPJ do emitente, modelo, série e número da NF-e e código numérico + DV.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerConsSitNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetConsSitNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Retorno de Pedido de Consulta da Situação Atual da Nota Fiscal Eletrônica </xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="verAplic" type="TVerAplic">
+				<xs:annotation>
+					<xs:documentation>Versão do Aplicativo que processou a NF-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cStat" type="TStat">
+				<xs:annotation>
+					<xs:documentation>Código do status da mensagem enviada.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMotivo" type="TMotivo">
+				<xs:annotation>
+					<xs:documentation>Descrição literal do status do serviço solicitado.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>código da UF de atendimento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="dhRecbto" type="TDateTimeUTC">
+				<xs:annotation>
+					<xs:documentation>AAAA-MM-DDTHH:MM:SSTZD</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="chNFe" type="TChNFe">
+				<xs:annotation>
+					<xs:documentation>Chaves de acesso da NF-e consultada</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="protNFe" type="TProtNFe" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Protocolo de autorização de uso da NF-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="retCancNFe" type="TRetCancNFe" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Protocolo de homologação de cancelamento de uso da NF-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="procEventoNFe" type="TProcEvento" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Protocolo de registro de evento da NF-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerConsSitNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TProtNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Protocolo de status resultado do processamento da NF-e</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infProt">
+				<xs:annotation>
+					<xs:documentation>Dados do protocolo de status</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="verAplic" type="TVerAplic">
+							<xs:annotation>
+								<xs:documentation>Versão do Aplicativo que processou a NF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="chNFe" type="TChNFe">
+							<xs:annotation>
+								<xs:documentation>Chaves de acesso da NF-e, compostas por: UF do emitente, AAMM da emissão da NFe, CNPJ do emitente, modelo, série e número da NF-e e código numérico+DV.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="dhRecbto" type="xs:dateTime">
+							<xs:annotation>
+								<xs:documentation>Data e hora de processamento, no formato AAAA-MM-DDTHH:MM:SS (ou AAAA-MM-DDTHH:MM:SSTZD, de acordo com versão). Deve ser preenchida com data e hora da gravação no Banco em caso de Confirmação. Em caso de Rejeição, com data e hora do recebimento do Lote de NF-e enviado.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nProt" type="TProt" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número do Protocolo de Status da NF-e. 1 posição (1 – Secretaria de Fazenda Estadual 2 – Receita Federal); 2 - códiga da UF - 2 posições ano; 10 seqüencial no ano.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="digVal" type="ds:DigestValueType" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Digest Value da NF-e processada. Utilizado para conferir a integridade da NF-e original.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cStat" type="TStat">
+							<xs:annotation>
+								<xs:documentation>Código do status da mensagem enviada.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="xMotivo" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Descrição literal do status do serviço solicitado.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" type="xs:ID" use="optional"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetCancNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo retorno Pedido de Cancelamento da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infCanc">
+				<xs:annotation>
+					<xs:documentation>Dados do Resultado do Pedido de Cancelamento da Nota Fiscal Eletrônica</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="verAplic" type="TVerAplic">
+							<xs:annotation>
+								<xs:documentation>Versão do Aplicativo que processou o pedido de cancelamento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cStat" type="TStat">
+							<xs:annotation>
+								<xs:documentation>Código do status da mensagem enviada.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="xMotivo" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Descrição literal do status do serviço solicitado.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cUF" type="TCodUfIBGE">
+							<xs:annotation>
+								<xs:documentation>código da UF de atendimento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="chNFe" type="TChNFe" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Chaves de acesso da NF-e, compostas por: UF do emitente, AAMM da emissão da NFe, CNPJ do emitente, modelo, série e número da NF-e e código numérico + DV.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="dhRecbto" type="xs:dateTime" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Data e hora de recebimento, no formato AAAA-MM-DDTHH:MM:SS. Deve ser preenchida com data e hora da gravação no Banco em caso de Confirmação.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nProt" type="TProt" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número do Protocolo de Status da NF-e. 1 posição (1 – Secretaria de Fazenda Estadual 2 – Receita Federal); 2 - código da UF - 2 posições ano; 10 seqüencial no ano.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" type="xs:ID" use="optional"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerCancNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TEvento">
+		<xs:annotation>
+			<xs:documentation>Tipo Evento</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infEvento">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="cOrgao" type="TCOrgaoIBGE">
+							<xs:annotation>
+								<xs:documentation>Código do órgão de recepção do Evento. Utilizar a Tabela do IBGE extendida, utilizar 90 para identificar o Ambiente Nacional</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:choice>
+							<xs:annotation>
+								<xs:documentation>Identificação do  autor do evento</xs:documentation>
+							</xs:annotation>
+							<xs:element name="CNPJ" type="TCnpjOpc">
+								<xs:annotation>
+									<xs:documentation>CNPJ</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="CPF" type="TCpf">
+								<xs:annotation>
+									<xs:documentation>CPF</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:choice>
+						<xs:element name="chNFe" type="TChNFe">
+							<xs:annotation>
+								<xs:documentation>Chave de Acesso da NF-e vinculada ao evento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="dhEvento" type="TDateTimeUTC">
+							<xs:annotation>
+								<xs:documentation>Data e Hora do Evento, formato UTC (AAAA-MM-DDThh:mm:ssTZD, onde TZD = +hh:mm ou -hh:mm)</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="tpEvento">
+							<xs:annotation>
+								<xs:documentation>Tipo do Evento</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:pattern value="[0-9]{6}"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="nSeqEvento">
+							<xs:annotation>
+								<xs:documentation>Seqüencial do evento para o mesmo tipo de evento.  Para maioria dos eventos será 1, nos casos em que possa existir mais de um evento, como é o caso da carta de correção, o autor do evento deve numerar de forma seqüencial.</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:pattern value="[1-9][0-9]{0,1}"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="verEvento">
+							<xs:annotation>
+								<xs:documentation>Versão do Tipo do Evento</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="detEvento">
+							<xs:annotation>
+								<xs:documentation>Detalhe Específico do Evento</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:any processContents="skip" maxOccurs="unbounded"/>
+								</xs:sequence>
+								<xs:anyAttribute processContents="skip"/>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" use="required">
+						<xs:annotation>
+							<xs:documentation>Identificador da TAG a ser assinada, a regra de formação do Id é:
+“ID” + tpEvento +  chave da NF-e + nSeqEvento</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:ID">
+								<xs:pattern value="ID[0-9]{52}"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerEvento" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetEvento">
+		<xs:annotation>
+			<xs:documentation>Tipo retorno do Evento</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infEvento">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="verAplic" type="TVerAplic">
+							<xs:annotation>
+								<xs:documentation>Versão do Aplicativo que recebeu o Evento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cOrgao" type="TCOrgaoIBGE">
+							<xs:annotation>
+								<xs:documentation>Código do órgão de recepção do Evento. Utilizar a Tabela do IBGE extendida, utilizar 90 para identificar o Ambiente Nacional</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cStat" type="TStat">
+							<xs:annotation>
+								<xs:documentation>Código do status da registro do Evento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="xMotivo" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Descrição literal do status do registro do Evento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="chNFe" type="TChNFe" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Chave de Acesso NF-e vinculada</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="tpEvento" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Tipo do Evento vinculado</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:pattern value="[0-9]{6}"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="xEvento" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Descrição do Evento</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TString">
+									<xs:minLength value="5"/>
+									<xs:maxLength value="60"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="nSeqEvento" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Seqüencial do evento</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:pattern value="[1-9][0-9]{0,1}"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:choice minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Identificação do  destinatpario da NF-e</xs:documentation>
+							</xs:annotation>
+							<xs:element name="CNPJDest" type="TCnpjOpc">
+								<xs:annotation>
+									<xs:documentation>CNPJ Destinatário</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="CPFDest" type="TCpf">
+								<xs:annotation>
+									<xs:documentation>CPF Destiantário</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:choice>
+						<xs:element name="emailDest" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>email do destinatário</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TString">
+									<xs:minLength value="1"/>
+									<xs:maxLength value="60"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="dhRegEvento" type="TDateTimeUTC">
+							<xs:annotation>
+								<xs:documentation>Data e Hora de registro do evento formato UTC AAAA-MM-DDTHH:MM:SSTZD</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nProt" type="TProt" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número do protocolo de registro do evento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" use="optional">
+						<xs:simpleType>
+							<xs:restriction base="xs:ID">
+								<xs:pattern value="ID[0-9]{15}"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TRetVerEvento" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TProcEvento">
+		<xs:annotation>
+			<xs:documentation>Tipo procEvento</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="evento" type="TEvento"/>
+			<xs:element name="retEvento" type="TRetEvento"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerEvento" use="required"/>
+	</xs:complexType>
+	<xs:simpleType name="TVerNFe">
+		<xs:annotation>
+			<xs:documentation> Tipo Versão da NF-e</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="TString">
+			<xs:pattern value="[1-9]{1}\.[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TVerCancNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Versão do leiaute de Cancelamento de NF-e - 2.00/1.07</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="TString">
+			<xs:pattern value="[1-9]{1}\.[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TVerEvento">
+		<xs:annotation>
+			<xs:documentation>Tipo Versão do Evento 1.00</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="TString">
+			<xs:pattern value="[1-9]{1}\.[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TRetVerEvento">
+		<xs:annotation>
+			<xs:documentation>Tipo Versão do Evento</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="TString">
+			<xs:pattern value="[1-9]{1}\.[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TVerConsSitNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Versão do Leiaute da Cosulta situação NF-e - 4.00</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="4.00"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/leiauteConsStatServ_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/leiauteConsStatServ_v4.00.xsd
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--  PL_006f versao com correcoes no xServ para tornar a literal STATUS obrigatoria 21/05/2010 -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposBasico_v4.00.xsd"/>
+	<xs:complexType name="TConsStatServ">
+		<xs:annotation>
+			<xs:documentation>Tipo Pedido de Consulta do Status do Serviço</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF consultada</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xServ">
+				<xs:annotation>
+					<xs:documentation>Serviço Solicitado</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TServ">
+						<xs:enumeration value="STATUS"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerConsStatServ" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetConsStatServ">
+		<xs:annotation>
+			<xs:documentation>Tipo Resultado da Consulta do Status do Serviço</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="verAplic" type="TVerAplic">
+				<xs:annotation>
+					<xs:documentation>Versão do Aplicativo que processou a NF-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cStat" type="TStat">
+				<xs:annotation>
+					<xs:documentation>Código do status da mensagem enviada.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMotivo" type="TMotivo">
+				<xs:annotation>
+					<xs:documentation>Descrição literal do status do serviço solicitado.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>Código da UF responsável pelo serviço</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="dhRecbto" type="TDateTimeUTC">
+				<xs:annotation>
+					<xs:documentation>Data e hora do recebimento da consulta no formato AAAA-MM-DDTHH:MM:SSTZD</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="tMed" type="TMed" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Tempo médio de resposta do serviço (em segundos) dos últimos 5 minutos</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="dhRetorno" type="TDateTimeUTC" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>AAAA-MM-DDTHH:MM:SSDeve ser preenchida com data e hora previstas para o retorno dos serviços prestados.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xObs" type="TMotivo" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Campo observação utilizado para incluir informações ao contribuinte</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerConsStatServ" use="required"/>
+	</xs:complexType>
+	<xs:simpleType name="TVerConsStatServ">
+		<xs:annotation>
+			<xs:documentation>Tipo versão do leiuate da Consulta Status do Serviço 4.00</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:token">
+			<xs:pattern value="4\.00"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/leiauteInutNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/leiauteInutNFe_v4.00.xsd
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--  PL_006f versao com correcoes no xServ para tornar a literal INUTILIZAR obrigatoria 21/05/2010 -->
+<!--  PL_006c versao com correcoes 24/12/2009 -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v1.01.xsd"/>
+	<xs:include schemaLocation="tiposBasico_v4.00.xsd"/>
+	<xs:complexType name="TInutNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Pedido de Inutilização de Numeração da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infInut">
+				<xs:annotation>
+					<xs:documentation>Dados do Pedido de Inutilização de Numeração da Nota Fiscal Eletrônica</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="xServ">
+							<xs:annotation>
+								<xs:documentation>Serviço Solicitado</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TServ">
+									<xs:enumeration value="INUTILIZAR"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="cUF" type="TCodUfIBGE">
+							<xs:annotation>
+								<xs:documentation>Código da UF do emitente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="ano" type="Tano">
+							<xs:annotation>
+								<xs:documentation>Ano de inutilização da numeração</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="CNPJ" type="TCnpj">
+							<xs:annotation>
+								<xs:documentation>CNPJ do emitente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="mod" type="TMod">
+							<xs:annotation>
+								<xs:documentation>Modelo da NF-e (55, 65 etc.)</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="serie" type="TSerie">
+							<xs:annotation>
+								<xs:documentation>Série da NF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nNFIni" type="TNF">
+							<xs:annotation>
+								<xs:documentation>Número da NF-e inicial</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nNFFin" type="TNF">
+							<xs:annotation>
+								<xs:documentation>Número da NF-e final</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="xJust" type="TJust">
+							<xs:annotation>
+								<xs:documentation>Justificativa do pedido de inutilização</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" use="required">
+						<xs:simpleType>
+							<xs:restriction base="xs:ID">
+								<xs:pattern value="ID[0-9]{41}"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerInutNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetInutNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo retorno do Pedido de Inutilização de Numeração da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infInut">
+				<xs:annotation>
+					<xs:documentation>Dados do Retorno do Pedido de Inutilização de Numeração da Nota Fiscal Eletrônica</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="verAplic" type="TVerAplic">
+							<xs:annotation>
+								<xs:documentation>Versão do Aplicativo que processou a NF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cStat" type="TStat">
+							<xs:annotation>
+								<xs:documentation>Código do status da mensagem enviada.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="xMotivo" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Descrição literal do status do serviço solicitado.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cUF" type="TCodUfIBGE">
+							<xs:annotation>
+								<xs:documentation>Código da UF que atendeu a solicitação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="ano" type="Tano" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Ano de inutilização da numeração</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="CNPJ" type="TCnpj" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>CNPJ do emitente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="mod" type="TMod" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Modelo da NF-e (55, etc.)</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="serie" type="TSerie" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Série da NF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nNFIni" type="TNF" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número da NF-e inicial</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nNFFin" type="TNF" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número da NF-e final</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="dhRecbto" type="TDateTimeUTC">
+							<xs:annotation>
+								<xs:documentation>Data e hora de recebimento, no formato AAAA-MM-DDTHH:MM:SS. Deve ser preenchida com data e hora da gravação no Banco em caso de Confirmação. Em caso de Rejeição, com data e hora do recebimento do Pedido de Inutilização.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nProt" type="TProt" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número do Protocolo de Status da NF-e. 1 posição (1 – Secretaria de Fazenda Estadual 2 – Receita Federal); 2 - código da UF - 2 posições ano; 10 seqüencial no ano.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" type="xs:ID" use="optional"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerInutNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TProcInutNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Pedido de inutilzação de númeração de  NF-e processado</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="inutNFe" type="TInutNFe"/>
+			<xs:element name="retInutNFe" type="TRetInutNFe"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerInutNFe" use="required"/>
+	</xs:complexType>
+	<xs:simpleType name="TVerInutNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Versão do leiaute de Inutilização 4.00</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:token">
+			<xs:pattern value="4\.00"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/leiauteNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/leiauteNFe_v4.00.xsd
@@ -1,0 +1,7579 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2025 rel. 2 (x64) (https://www.altova.com) by PROCERGS (Procergs - Centro de Tecnologia da Informação e Comunicação do Estado do Rio Grande do Sul S.A.) -->
+<!-- PL_009  alterações de esquema decorrentes da - NT2016.002 v1.20 - 31/05/2017 13:14hs-->
+<!-- PL_008g  alterações de esquema decorrentes da - NT2015.002  - 15/07/2015 -->
+<!-- PL_008h  alterações de esquema decorrentes da - NT2015.003 - 17/09/2015 -->
+<!-- PL_008i -->
+<!-- PL_009-v4  alterações de esquema decorrentes da - NT2016.002 - 10/2017 -->
+<!-- PL_009-v4a  alterações de esquema decorrentes da - NT2017.001 - 10/2017 -->
+<!-- PL_009-v4a  alterações de esquema decorrentes da - NT2016.002 v1.60 - 06/2018 -->
+<!-- PL_009-v4a.1  correções de esquema decorrentes da - NT2016.002 v1.60 - 06/2018 -->
+<!-- PL_009-v4a.2  adequação do campo placa para novo padrão do Mercosul - 06/2018 -->
+<!-- PL_009-v4a.3  adequação da lista TCListServ - 10/2018 -->
+<!-- PL_009-v4a.4  implementado alterações da NT 2018.005 -->
+<!-- PL_009-v4b  implementado alterações da NT 2020.006 -->
+<!-- PL_009-v5a  implementado alterações da NT  -->
+<!-- PL_009k_NT2023_001_v100 implementado alterações da NT 2023.001  -->
+<!-- PL_009l_NT2023_002_v100 - Alteração de Schema para evitar caracteres inválidos  -->
+<!-- PL_009m_NT2019_001_v155 - Inclusão de campos para Crédito Presumido e Redução da base de cálculo -->
+<!-- PL_009m_NT2023_004_v101 - Informações de Pagamentos e Outros -->
+<!-- PL_009p_NT2024_003_v103 - Produtos agropecuários -->
+<xs:schema xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:editix="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v1.01.xsd"/>
+	<xs:include schemaLocation="tiposBasico_v4.00.xsd"/>
+	<xs:include schemaLocation="DFeTiposBasicos_v1.00.xsd"/>
+	<xs:complexType name="TNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infNFe">
+				<xs:annotation>
+					<xs:documentation>Informações da Nota Fiscal eletrônica</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ide">
+							<xs:annotation>
+								<xs:documentation>identificação da NF-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="cUF" type="TCodUfIBGE">
+										<xs:annotation>
+											<xs:documentation>Código da UF do emitente do Documento Fiscal. Utilizar a Tabela do IBGE.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="cNF">
+										<xs:annotation>
+											<xs:documentation>Código numérico que compõe a Chave de Acesso. Número aleatório gerado pelo emitente para cada NF-e.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{8}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="natOp">
+										<xs:annotation>
+											<xs:documentation>Descrição da Natureza da Operação</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="mod" type="TMod">
+										<xs:annotation>
+											<xs:documentation>Código do modelo do Documento Fiscal. 55 = NF-e; 65 = NFC-e.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="serie" type="TSerie">
+										<xs:annotation>
+											<xs:documentation>Série do Documento Fiscal
+série normal 0-889
+Avulsa Fisco 890-899
+SCAN 900-999</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="nNF" type="TNF">
+										<xs:annotation>
+											<xs:documentation>Número do Documento Fiscal</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="dhEmi" type="TDateTimeUTC">
+										<xs:annotation>
+											<xs:documentation>Data e Hora de emissão do Documento Fiscal (AAAA-MM-DDThh:mm:ssTZD) ex.: 2012-09-01T13:00:00-03:00</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="dhSaiEnt" type="TDateTimeUTC" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Data e Hora da saída ou de entrada da mercadoria / produto (AAAA-MM-DDTHH:mm:ssTZD)</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="dPrevEntrega" type="TData" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Data da previsão de entrega ou disponibilização do bem (AAAA-MM-DD)</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpNF">
+										<xs:annotation>
+											<xs:documentation>Tipo do Documento Fiscal (0 - entrada; 1 - saída)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="idDest">
+										<xs:annotation>
+											<xs:documentation>Identificador de Local de destino da operação (1-Interna;2-Interestadual;3-Exterior)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="3"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cMunFG" type="TCodMunIBGE">
+										<xs:annotation>
+											<xs:documentation>Código do Município de Ocorrência do Fato Gerador (utilizar a tabela do IBGE)</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="cMunFGIBS" type="TCodMunIBGE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informar o município de ocorrência do fato gerador do fato gerador do IBS / CBS.
+Campo preenchido somente quando “indPres = 5 (Operação presencial, fora do estabelecimento) ”, e não tiver endereço do destinatário (Grupo: E05) ou local de entrega (Grupo: G01).</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpImp">
+										<xs:annotation>
+											<xs:documentation>Formato de impressão do DANFE (0-sem DANFE;1-DANFe Retrato; 2-DANFe Paisagem;3-DANFe Simplificado;
+											4-DANFe NFC-e;5-DANFe NFC-e em mensagem eletrônica)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="3"/>
+												<xs:enumeration value="4"/>
+												<xs:enumeration value="5"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpEmis">
+										<xs:annotation>
+											<xs:documentation>Forma de emissão da NF-e
+1 - Normal;
+2 - Contingência FS
+3 - Regime Especial NFF (NT 2021.002)
+4 - Contingência DPEC
+5 - Contingência FSDA
+6 - Contingência SVC - AN
+7 - Contingência SVC - RS
+9 - Contingência off-line NFC-e</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="3"/>
+												<xs:enumeration value="4"/>
+												<xs:enumeration value="5"/>
+												<xs:enumeration value="6"/>
+												<xs:enumeration value="7"/>
+												<xs:enumeration value="9"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cDV">
+										<xs:annotation>
+											<xs:documentation>Digito Verificador da Chave de Acesso da NF-e</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{1}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpAmb" type="TAmb">
+										<xs:annotation>
+											<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="finNFe" type="TFinNFe">
+										<xs:annotation>
+											<xs:documentation>Finalidade da emissão da NF-e:
+1 - NFe normal
+2 - NFe complementar
+3 - NFe de ajuste
+4 - Devolução/Retorno
+5 - Nota de crédito
+6 - Nota de débito</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpNFDebito" type="TTpNFDebito" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Tipo de Nota de Débito</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpNFCredito" type="TTpNFCredito" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Tipo de Nota de Crédito</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="indFinal">
+										<xs:annotation>
+											<xs:documentation>Indica operação com consumidor final (0-Não;1-Consumidor Final)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="indPres">
+										<xs:annotation>
+											<xs:documentation>Indicador de presença do comprador no estabelecimento comercial no momento da oepração
+											(0-Não se aplica (ex.: Nota Fiscal complementar ou de ajuste;1-Operação presencial;2-Não presencial, internet;3-Não presencial, teleatendimento;4-NFC-e entrega em domicílio;5-Operação presencial, fora do estabelecimento;9-Não presencial, outros)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="3"/>
+												<xs:enumeration value="4"/>
+												<xs:enumeration value="5"/>
+												<xs:enumeration value="9"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="indIntermed" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Indicador de intermediador/marketplace 
+											0=Operação sem intermediador (em site ou plataforma própria) 
+											1=Operação em site ou plataforma de terceiros (intermediadores/marketplace)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="procEmi" type="TProcEmi">
+										<xs:annotation>
+											<xs:documentation>Processo de emissão utilizado com a seguinte codificação:
+0 - emissão de NF-e com aplicativo do contribuinte;
+1 - emissão de NF-e avulsa pelo Fisco;
+2 - emissão de NF-e avulsa, pelo contribuinte com seu certificado digital, através do site
+do Fisco;
+3- emissão de NF-e pelo contribuinte com aplicativo fornecido pelo Fisco.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="verProc">
+										<xs:annotation>
+											<xs:documentation>versão do aplicativo utilizado no processo de
+emissão</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="20"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:sequence minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informar apenas
+para tpEmis diferente de 1</xs:documentation>
+										</xs:annotation>
+										<xs:element name="dhCont" type="TDateTimeUTC">
+											<xs:annotation>
+												<xs:documentation>Informar a data e hora de entrada em contingência contingência no formato  (AAAA-MM-DDThh:mm:ssTZD) ex.: 2012-09-01T13:00:00-03:00.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="xJust">
+											<xs:annotation>
+												<xs:documentation>Informar a Justificativa da entrada</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="15"/>
+													<xs:maxLength value="256"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+									<xs:element name="NFref" minOccurs="0" maxOccurs="999">
+										<xs:annotation>
+											<xs:documentation>Grupo de infromações da NF referenciada</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:choice>
+												<xs:element name="refNFe" type="TChNFe">
+													<xs:annotation>
+														<xs:documentation>Chave de acesso das NF-e referenciadas. Chave de acesso compostas por Código da UF (tabela do IBGE) + AAMM da emissão + CNPJ do Emitente + modelo, série e número da NF-e Referenciada + Código Numérico + DV.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="refNFeSig" type="TChNFe">
+													<xs:annotation>
+														<xs:documentation>Referencia uma NF-e (modelo 55) emitida anteriormente pela sua Chave de Acesso com código numérico zerado, permitindo manter o sigilo da NF-e referenciada.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="refNF">
+													<xs:annotation>
+														<xs:documentation>Dados da NF modelo 1/1A referenciada ou NF modelo 2 referenciada</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="cUF" type="TCodUfIBGE">
+																<xs:annotation>
+																	<xs:documentation>Código da UF do emitente do Documento Fiscal. Utilizar a Tabela do IBGE.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="AAMM">
+																<xs:annotation>
+																	<xs:documentation>AAMM da emissão</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:pattern value="[0-9]{2}[0]{1}[1-9]{1}|[0-9]{2}[1]{1}[0-2]{1}"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="CNPJ" type="TCnpj">
+																<xs:annotation>
+																	<xs:documentation>CNPJ do emitente do documento fiscal referenciado</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="mod">
+																<xs:annotation>
+																	<xs:documentation>Código do modelo do Documento Fiscal. Utilizar 01 para NF modelo 1/1A e 02 para NF modelo 02</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:enumeration value="01"/>
+																		<xs:enumeration value="02"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="serie" type="TSerie">
+																<xs:annotation>
+																	<xs:documentation>Série do Documento Fiscal, informar zero se inexistente</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="nNF" type="TNF">
+																<xs:annotation>
+																	<xs:documentation>Número do Documento Fiscal</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="refNFP">
+													<xs:annotation>
+														<xs:documentation>Grupo com as informações NF de produtor referenciada</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="cUF" type="TCodUfIBGE">
+																<xs:annotation>
+																	<xs:documentation>Código da UF do emitente do Documento FiscalUtilizar a Tabela do IBGE (Anexo IV - Tabela de UF, Município e País)</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="AAMM">
+																<xs:annotation>
+																	<xs:documentation>AAMM da emissão da NF de produtor</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:pattern value="[0-9]{2}[0]{1}[1-9]{1}|[0-9]{2}[1]{1}[0-2]{1}"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:choice>
+																<xs:element name="CNPJ" type="TCnpj">
+																	<xs:annotation>
+																		<xs:documentation>CNPJ do emitente da NF de produtor</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="CPF" type="TCpf">
+																	<xs:annotation>
+																		<xs:documentation>CPF do emitente da NF de produtor</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:choice>
+															<xs:element name="IE" type="TIeDest">
+																<xs:annotation>
+																	<xs:documentation>IE do emitente da NF de Produtor</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="mod">
+																<xs:annotation>
+																	<xs:documentation>Código do modelo do Documento Fiscal - utilizar 04 para NF de produtor  ou 01 para NF Avulsa</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:enumeration value="01"/>
+																		<xs:enumeration value="04"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="serie" type="TSerie">
+																<xs:annotation>
+																	<xs:documentation>Série do Documento Fiscal, informar zero se inexistentesérie</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="nNF" type="TNF">
+																<xs:annotation>
+																	<xs:documentation>Número do Documento Fiscal - 1 – 999999999</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="refCTe" type="TChNFe">
+													<xs:annotation>
+														<xs:documentation>Utilizar esta TAG para referenciar um CT-e emitido anteriormente, vinculada a NF-e atual</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="refECF">
+													<xs:annotation>
+														<xs:documentation>Grupo do Cupom Fiscal vinculado à NF-e</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="mod">
+																<xs:annotation>
+																	<xs:documentation>Código do modelo do Documento Fiscal 
+Preencher com &quot;2B&quot;, quando se tratar de Cupom Fiscal emitido por máquina registradora (não ECF), com &quot;2C&quot;, quando se tratar de Cupom Fiscal PDV, ou &quot;2D&quot;, quando se tratar de Cupom Fiscal (emitido por ECF)</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:enumeration value="2B"/>
+																		<xs:enumeration value="2C"/>
+																		<xs:enumeration value="2D"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="nECF">
+																<xs:annotation>
+																	<xs:documentation>Informar o número de ordem seqüencial do ECF que emitiu o Cupom Fiscal vinculado à NF-e</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:pattern value="[0-9]{1,3}"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="nCOO">
+																<xs:annotation>
+																	<xs:documentation>Informar o Número do Contador de Ordem de Operação - COO vinculado à NF-e</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:pattern value="[0-9]{1,6}"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+											</xs:choice>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="gCompraGov" type="TCompraGov" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Grupo de Compras Governamentais</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="gPagAntecipado" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informado para abater as parcelas de antecipação de pagamento, conforme Art. 10. § 4º</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="refNFe" type="TChNFe" minOccurs="1" maxOccurs="99">
+													<xs:annotation>
+														<xs:documentation>Chave de acesso da NF-e de antecipação de pagamento</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="emit">
+							<xs:annotation>
+								<xs:documentation>Identificação do emitente</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpj">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ do emitente</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>Número do CPF do emitente</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão Social ou Nome do emitente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xFant" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Nome fantasia</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="enderEmit" type="TEnderEmi">
+										<xs:annotation>
+											<xs:documentation>Endereço do emitente</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="IE" type="TIe">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual do Emitente</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="IEST" type="TIeST" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscricao Estadual do Substituto Tributário</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:sequence minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Grupo de informações de interesse da Prefeitura</xs:documentation>
+										</xs:annotation>
+										<xs:element name="IM">
+											<xs:annotation>
+												<xs:documentation>Inscrição Municipal</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="1"/>
+													<xs:maxLength value="15"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="CNAE" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>CNAE Fiscal</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:whiteSpace value="preserve"/>
+													<xs:pattern value="[0-9]{7}"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+									<xs:element name="CRT">
+										<xs:annotation>
+											<xs:documentation>Código de Regime Tributário. 
+Este campo será obrigatoriamente preenchido com:
+1 – Simples Nacional;
+2 – Simples Nacional – excesso de sublimite de receita bruta;
+3 – Regime Normal.
+4 - Simples Nacional - Microempreendedor individual - MEI</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="3"/>
+												<xs:enumeration value="4"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="avulsa" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Emissão de avulsa, informar os dados do Fisco emitente</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="CNPJ" type="TCnpj">
+										<xs:annotation>
+											<xs:documentation>CNPJ do Órgão emissor</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="xOrgao">
+										<xs:annotation>
+											<xs:documentation>Órgão emitente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="matr">
+										<xs:annotation>
+											<xs:documentation>Matrícula do agente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xAgente">
+										<xs:annotation>
+											<xs:documentation>Nome do agente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fone" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Telefone</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{6,14}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="UF" type="TUfEmi">
+										<xs:annotation>
+											<xs:documentation>Sigla da Unidade da Federação</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="nDAR" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Número do Documento de Arrecadação de Receita</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="dEmi" type="TData" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Data de emissão do DAR (AAAA-MM-DD)</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vDAR" type="TDec_1302" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor Total constante no DAR</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="repEmi">
+										<xs:annotation>
+											<xs:documentation>Repartição Fiscal emitente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="dPag" type="TData" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Data de pagamento do DAR (AAAA-MM-DD)</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="dest" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Identificação do Destinatário</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpj">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>Número do CPF</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="idEstrangeiro">
+											<xs:annotation>
+												<xs:documentation>Identificador do destinatário, em caso de comprador estrangeiro</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:whiteSpace value="preserve"/>
+													<xs:pattern value="([!-ÿ]{0}|[!-ÿ]{5,20})?"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="xNome" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Razão Social ou nome do destinatário</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="enderDest" type="TEndereco" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Dados do endereço</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="indIEDest">
+										<xs:annotation>
+											<xs:documentation>Indicador da IE do destinatário:
+1 – Contribuinte ICMSpagamento à vista;
+2 – Contribuinte isento de inscrição;
+9 – Não Contribuinte</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="9"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="IE" type="TIeDestNaoIsento" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual (obrigatório nas operações com contribuintes do ICMS)</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="ISUF" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição na SUFRAMA (Obrigatório nas operações com as áreas com benefícios de incentivos fiscais sob controle da SUFRAMA) PL_005d - 11/08/09 - alterado para aceitar 8 ou 9 dígitos</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{8,9}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="IM" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Municipal do tomador do serviço</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="15"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="email" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informar o e-mail do destinatário. O campo pode ser utilizado para informar o e-mail
+de recepção da NF-e indicada pelo destinatário</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:whiteSpace value="preserve"/>
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="retirada" type="TLocal" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Identificação do Local de Retirada (informar apenas quando for diferente do endereço do remetente)</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="entrega" type="TLocal" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Identificação do Local de Entrega (informar apenas quando for diferente do endereço do destinatário)</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="autXML" minOccurs="0" maxOccurs="10">
+							<xs:annotation>
+								<xs:documentation>Pessoas autorizadas para o download do XML da NF-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:choice>
+									<xs:element name="CNPJ" type="TCnpj">
+										<xs:annotation>
+											<xs:documentation>CNPJ Autorizado</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="CPF" type="TCpf">
+										<xs:annotation>
+											<xs:documentation>CPF Autorizado</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:choice>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="det" maxOccurs="990">
+							<xs:annotation>
+								<xs:documentation>Dados dos detalhes da NF-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="prod">
+										<xs:annotation>
+											<xs:documentation>Dados dos produtos e serviços da NF-e</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="cProd">
+													<xs:annotation>
+														<xs:documentation>Código do produto ou serviço. Preencher com CFOP caso se trate de itens não relacionados com mercadorias/produto e que o contribuinte não possua codificação própria
+Formato ”CFOP9999”.</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="60"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="cEAN">
+													<xs:annotation>
+														<xs:documentation>GTIN (Global Trade Item Number) do produto, antigo código EAN ou código de barras</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="SEM GTIN|[0-9]{0}|[0-9]{8}|[0-9]{12,14}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="cBarra" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Codigo de barras diferente do padrão GTIN</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="30"/>
+															<xs:minLength value="3"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="xProd">
+													<xs:annotation>
+														<xs:documentation>Descrição do produto ou serviço</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="120"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="NCM">
+													<xs:annotation>
+														<xs:documentation>Código NCM (8 posições), será permitida a informação do gênero (posição do capítulo do NCM) quando a operação não for de comércio exterior (importação/exportação) ou o produto não seja tributado pelo IPI. Em caso de item de serviço ou item que não tenham produto (Ex. transferência de crédito, crédito do ativo imobilizado, etc.), informar o código 00 (zeros) (v2.0)</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="[0-9]{2}|[0-9]{8}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="NVE" minOccurs="0" maxOccurs="8">
+													<xs:annotation>
+														<xs:documentation>Nomenclatura de Valor aduaneio e Estatístico</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="[A-Z]{2}[0-9]{4}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:sequence minOccurs="0">
+													<xs:element name="CEST">
+														<xs:annotation>
+															<xs:documentation>Codigo especificador da Substuicao Tributaria - CEST, que identifica a mercadoria sujeita aos regimes de  substituicao tributária e de antecipação do recolhimento  do imposto</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:whiteSpace value="preserve"/>
+																<xs:pattern value="[0-9]{7}"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="indEscala" minOccurs="0">
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:enumeration value="S"/>
+																<xs:enumeration value="N"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="CNPJFab" type="TCnpj" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>CNPJ do Fabricante da Mercadoria, obrigatório para produto em escala NÃO relevante.</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+												<xs:element name="cBenef" minOccurs="0">
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="([!-ÿ]{8}|[!-ÿ]{10}|SEM CBENEF)?"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="gCred" minOccurs="0" maxOccurs="4">
+													<xs:annotation>
+														<xs:documentation>Grupo de informações sobre o CréditoPresumido </xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="cCredPresumido">
+																<xs:annotation>
+																	<xs:documentation>Código de Benefício Fiscal de Crédito Presumido na UF aplicado ao item</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:pattern value="[!-ÿ]{8}|[!-ÿ]{10}"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="pCredPresumido" type="TDec_0302a04">
+																<xs:annotation>
+																	<xs:documentation>Percentual do Crédito Presumido</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="vCredPresumido" type="TDec_1302">
+																<xs:annotation>
+																	<xs:documentation>Valor do Crédito Presumido</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="tpCredPresIBSZFM" type="TTpCredPresIBSZFM" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Classificação para subapuração do IBS na ZFM</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="EXTIPI" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Código EX TIPI (3 posições)</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="[0-9]{2,3}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="CFOP">
+													<xs:annotation>
+														<xs:documentation>Cfop</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="[1,2,3,5,6,7]{1}[0-9]{3}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="uCom">
+													<xs:annotation>
+														<xs:documentation>Unidade comercial</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="6"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="qCom" type="TDec_1104v">
+													<xs:annotation>
+														<xs:documentation>Quantidade Comercial  do produto, alterado para aceitar de 0 a 4 casas decimais e 11 inteiros.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vUnCom" type="TDec_1110v">
+													<xs:annotation>
+														<xs:documentation>Valor unitário de comercialização  - alterado para aceitar 0 a 10 casas decimais e 11 inteiros</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vProd" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor bruto do produto ou serviço.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="cEANTrib">
+													<xs:annotation>
+														<xs:documentation>GTIN (Global Trade Item Number) da unidade tributável, antigo código EAN ou código de barras</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="SEM GTIN|[0-9]{0}|[0-9]{8}|[0-9]{12,14}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="cBarraTrib" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Código de barras da unidade tributável diferente do padrão GTIN</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="30"/>
+															<xs:minLength value="3"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="uTrib">
+													<xs:annotation>
+														<xs:documentation>Unidade Tributável</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="6"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="qTrib" type="TDec_1104v">
+													<xs:annotation>
+														<xs:documentation>Quantidade Tributável - alterado para aceitar de 0 a 4 casas decimais e 11 inteiros</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vUnTrib" type="TDec_1110v">
+													<xs:annotation>
+														<xs:documentation>Valor unitário de tributação - alterado para aceitar 0 a 10 casas decimais e 11 inteiros</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vFrete" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor Total do Frete</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vSeg" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor Total do Seguro</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vDesc" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor do Desconto</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vOutro" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Outras despesas acessórias</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="indTot">
+													<xs:annotation>
+														<xs:documentation>Este campo deverá ser preenchido com:
+ 0 – o valor do item (vProd) não compõe o valor total da NF-e (vProd)
+ 1  – o valor do item (vProd) compõe o valor total da NF-e (vProd)</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:enumeration value="0"/>
+															<xs:enumeration value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="indBemMovelUsado" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Indicador de fornecimento de bem móvel usado: 1-Bem Móvel Usado</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:enumeration value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="DI" minOccurs="0" maxOccurs="100">
+													<xs:annotation>
+														<xs:documentation>Declaração de Importação (NT 2011/004)</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="nDI">
+																<xs:annotation>
+																	<xs:documentation>Número do Documento de Importação (DI, DSI, DIRE, DUImp) (NT2011/004)</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="15"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="dDI" type="TData">
+																<xs:annotation>
+																	<xs:documentation>Data de registro da DI/DSI/DA (AAAA-MM-DD)</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="xLocDesemb">
+																<xs:annotation>
+																	<xs:documentation>Local do desembaraço aduaneiro</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="60"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="UFDesemb" type="TUfEmi">
+																<xs:annotation>
+																	<xs:documentation>UF onde ocorreu o desembaraço aduaneiro</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="dDesemb" type="TData">
+																<xs:annotation>
+																	<xs:documentation>Data do desembaraço aduaneiro (AAAA-MM-DD)</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="tpViaTransp">
+																<xs:annotation>
+																	<xs:documentation>Via de transporte internacional informada na DI ou na Declaração Única de Importação (DUImp):
+																	1-Maritima;2-Fluvial;3-Lacustre;4-Aerea;5-Postal;6-Ferroviaria;7-Rodoviaria;8-Conduto;9-Meios Proprios;10-Entrada/Saida Ficta;
+																	11-Courier;12-Em maos;13-Por reboque.</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:enumeration value="1"/>
+																		<xs:enumeration value="2"/>
+																		<xs:enumeration value="3"/>
+																		<xs:enumeration value="4"/>
+																		<xs:enumeration value="5"/>
+																		<xs:enumeration value="6"/>
+																		<xs:enumeration value="7"/>
+																		<xs:enumeration value="8"/>
+																		<xs:enumeration value="9"/>
+																		<xs:enumeration value="10"/>
+																		<xs:enumeration value="11"/>
+																		<xs:enumeration value="12"/>
+																		<xs:enumeration value="13"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="vAFRMM" type="TDec_1302" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Valor Adicional ao frete para renovação de marinha mercante</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="tpIntermedio">
+																<xs:annotation>
+																	<xs:documentation>Forma de Importação quanto a intermediação 
+																	1-por conta propria;2-por conta e ordem;3-encomenda</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:enumeration value="1"/>
+																		<xs:enumeration value="2"/>
+																		<xs:enumeration value="3"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:choice minOccurs="0">
+																<xs:element name="CNPJ" type="TCnpj">
+																	<xs:annotation>
+																		<xs:documentation>CNPJ do adquirente ou do encomendante</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="CPF" type="TCpf">
+																	<xs:annotation>
+																		<xs:documentation>CPF do adquirente ou do encomendante</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:choice>
+															<xs:element name="UFTerceiro" type="TUfEmi" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Sigla da UF do adquirente ou do encomendante</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="cExportador">
+																<xs:annotation>
+																	<xs:documentation>Código do exportador (usado nos sistemas internos de informação do emitente da NF-e)</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="60"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="adi" maxOccurs="999">
+																<xs:annotation>
+																	<xs:documentation>Adições (NT 2011/004)</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="nAdicao" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>Número da Adição</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:whiteSpace value="preserve"/>
+																					<xs:pattern value="[1-9]{1}[0-9]{0,2}"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																		<xs:element name="nSeqAdic">
+																			<xs:annotation>
+																				<xs:documentation>Número seqüencial do item</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:whiteSpace value="preserve"/>
+																					<xs:pattern value="[1-9]{1}[0-9]{0,4}"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																		<xs:element name="cFabricante">
+																			<xs:annotation>
+																				<xs:documentation>Código do fabricante estrangeiro (usado nos sistemas internos de informação do emitente da NF-e)</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="TString">
+																					<xs:minLength value="1"/>
+																					<xs:maxLength value="60"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																		<xs:element name="vDescDI" type="TDec_1302Opc" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>Valor do desconto do item</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="nDraw" minOccurs="0">
+																			<xs:annotation>
+																				<xs:documentation>Número do ato concessório de Drawback</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="TString">
+																					<xs:minLength value="1"/>
+																					<xs:maxLength value="20"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="detExport" minOccurs="0" maxOccurs="500">
+													<xs:annotation>
+														<xs:documentation>Detalhe da exportação</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="nDraw" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Número do ato concessório de Drawback</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="20"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="exportInd" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Exportação indireta</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="nRE">
+																			<xs:annotation>
+																				<xs:documentation>Registro de exportação</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:whiteSpace value="preserve"/>
+																					<xs:pattern value="[0-9]{0,12}"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																		<xs:element name="chNFe" type="TChNFe">
+																			<xs:annotation>
+																				<xs:documentation>Chave de acesso da NF-e recebida para exportação</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="qExport" type="TDec_1104v">
+																			<xs:annotation>
+																				<xs:documentation>Quantidade do item efetivamente exportado</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="xPed" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>pedido de compra - Informação de interesse do emissor para controle do B2B.</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="15"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="nItemPed" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Número do Item do Pedido de Compra - Identificação do número do item do pedido de Compra</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="[0-9]{1,6}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="nFCI" type="TGuid" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Número de controle da FCI - Ficha de Conteúdo de Importação.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="rastro" minOccurs="0" maxOccurs="500">
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="nLote">
+																<xs:annotation>
+																	<xs:documentation>Número do lote do produto.</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="20"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="qLote" type="TDec_0803v">
+																<xs:annotation>
+																	<xs:documentation>Quantidade de produto no lote.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="dFab" type="TData">
+																<xs:annotation>
+																	<xs:documentation>Data de fabricação/produção. Formato &quot;AAAA-MM-DD&quot;.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="dVal" type="TData">
+																<xs:annotation>
+																	<xs:documentation>Data de validade. Informar o último dia do mês caso a validade não especifique o dia. Formato &quot;AAAA-MM-DD&quot;.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="cAgreg" minOccurs="0">
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="20"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="infProdNFF" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Informações mais detalhadas do produto (usada na NFF)</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="cProdFisco">
+																<xs:annotation>
+																	<xs:documentation>Código Fiscal do Produto</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:length value="14"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="cOperNFF">
+																<xs:annotation>
+																	<xs:documentation>Código da operação selecionada na NFF e relacionada ao item</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:pattern value="[0-9]{1,5}"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="infProdEmb" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Informações mais detalhadas do produto (usada na NFF)</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="xEmb">
+																<xs:annotation>
+																	<xs:documentation>Embalagem do produto</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:maxLength value="8"/>
+																		<xs:minLength value="1"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="qVolEmb" type="TDec_0803v">
+																<xs:annotation>
+																	<xs:documentation>Volume do produto na embalagem</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="uEmb">
+																<xs:annotation>
+																	<xs:documentation>Unidade de Medida da Embalagem</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:maxLength value="8"/>
+																		<xs:minLength value="1"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:choice minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Informações específicas de produtos e serviços</xs:documentation>
+													</xs:annotation>
+													<xs:element name="veicProd">
+														<xs:annotation>
+															<xs:documentation>Veículos novos</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="tpOp">
+																	<xs:annotation>
+																		<xs:documentation>Tipo da Operação (1 - Venda concessionária; 2 - Faturamento direto; 3 - Venda direta; 0 - Outros)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="0"/>
+																			<xs:enumeration value="1"/>
+																			<xs:enumeration value="2"/>
+																			<xs:enumeration value="3"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="chassi">
+																	<xs:annotation>
+																		<xs:documentation>Chassi do veículo - VIN (código-identificação-veículo)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:length value="17"/>
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:pattern value="[A-Z0-9]+"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="cCor">
+																	<xs:annotation>
+																		<xs:documentation>Cor do veículo (código de cada montadora)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="4"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="xCor">
+																	<xs:annotation>
+																		<xs:documentation>Descrição da cor</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="40"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="pot">
+																	<xs:annotation>
+																		<xs:documentation>Potência máxima do motor do veículo em cavalo vapor (CV). (potência-veículo)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="4"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="cilin">
+																	<xs:annotation>
+																		<xs:documentation>Capacidade voluntária do motor expressa em centímetros cúbicos (CC). (cilindradas)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="4"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="pesoL">
+																	<xs:annotation>
+																		<xs:documentation>Peso líquido</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="9"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="pesoB">
+																	<xs:annotation>
+																		<xs:documentation>Peso bruto</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="9"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="nSerie">
+																	<xs:annotation>
+																		<xs:documentation>Serial (série)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="9"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="tpComb">
+																	<xs:annotation>
+																		<xs:documentation>Tipo de combustível-Tabela RENAVAM: 01-Álcool; 02-Gasolina; 03-Diesel; 16-Álcool/Gas.; 17-Gas./Álcool/GNV; 18-Gasolina/Elétrico</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="2"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="nMotor">
+																	<xs:annotation>
+																		<xs:documentation>Número do motor</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="21"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="CMT">
+																	<xs:annotation>
+																		<xs:documentation>CMT-Capacidade Máxima de Tração - em Toneladas 4 casas decimais</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="9"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="dist">
+																	<xs:annotation>
+																		<xs:documentation>Distância entre eixos</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="4"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="anoMod">
+																	<xs:annotation>
+																		<xs:documentation>Ano Modelo de Fabricação</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:pattern value="[0-9]{4}"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="anoFab">
+																	<xs:annotation>
+																		<xs:documentation>Ano de Fabricação</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:pattern value="[0-9]{4}"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="tpPint">
+																	<xs:annotation>
+																		<xs:documentation>Tipo de pintura</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:length value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="tpVeic">
+																	<xs:annotation>
+																		<xs:documentation>Tipo de veículo (utilizar tabela RENAVAM)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:pattern value="[0-9]{1,2}"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="espVeic">
+																	<xs:annotation>
+																		<xs:documentation>Espécie de veículo (utilizar tabela RENAVAM)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:pattern value="[0-9]{1}"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="VIN">
+																	<xs:annotation>
+																		<xs:documentation>Informa-se o veículo tem VIN (chassi) remarcado.
+R-Remarcado
+N-NormalVIN</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:length value="1"/>
+																			<xs:enumeration value="R"/>
+																			<xs:enumeration value="N"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="condVeic">
+																	<xs:annotation>
+																		<xs:documentation>Condição do veículo (1 - acabado; 2 - inacabado; 3 - semi-acabado)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="1"/>
+																			<xs:enumeration value="2"/>
+																			<xs:enumeration value="3"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="cMod">
+																	<xs:annotation>
+																		<xs:documentation>Código Marca Modelo (utilizar tabela RENAVAM)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:pattern value="[0-9]{1,6}"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="cCorDENATRAN">
+																	<xs:annotation>
+																		<xs:documentation>Código da Cor Segundo as regras de pré-cadastro do DENATRAN: 01-AMARELO;02-AZUL;03-BEGE;04-BRANCA;05-CINZA;06-DOURADA;07-GRENA 
+08-LARANJA;09-MARROM;10-PRATA;11-PRETA;12-ROSA;13-ROXA;14-VERDE;15-VERMELHA;16-FANTASIA</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="2"/>
+																			<xs:pattern value="[0-9]{1,2}"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="lota">
+																	<xs:annotation>
+																		<xs:documentation>Quantidade máxima de permitida de passageiros sentados, inclusive motorista.</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="3"/>
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:pattern value="[0-9]{1,3}"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="tpRest">
+																	<xs:annotation>
+																		<xs:documentation>Restrição
+0 - Não há;
+1 - Alienação Fiduciária;
+2 - Arrendamento Mercantil;
+3 - Reserva de Domínio;
+4 - Penhor de Veículos;
+9 - outras.</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="0"/>
+																			<xs:enumeration value="1"/>
+																			<xs:enumeration value="2"/>
+																			<xs:enumeration value="3"/>
+																			<xs:enumeration value="4"/>
+																			<xs:enumeration value="9"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="med">
+														<xs:annotation>
+															<xs:documentation>grupo do detalhamento de Medicamentos e de matérias-primas farmacêuticas</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="cProdANVISA">
+																	<xs:annotation>
+																		<xs:documentation>Utilizar o número do registro ANVISA  ou preencher com o literal “ISENTO”, no caso de medicamento isento de registro na ANVISA.</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:pattern value="[0-9]{11}|[0-9]{13}|ISENTO"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="xMotivoIsencao" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Obs.: Para medicamento isento de registro na ANVISA, informar o número da decisão que o isenta, como por exemplo o número da Resolução da Diretoria Colegiada da ANVISA (RDC).</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="255"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="vPMC" type="TDec_1302">
+																	<xs:annotation>
+																		<xs:documentation>Preço Máximo ao Consumidor.</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="arma" maxOccurs="500">
+														<xs:annotation>
+															<xs:documentation>Armamentos</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="tpArma">
+																	<xs:annotation>
+																		<xs:documentation>Indicador do tipo de arma de fogo (0 - Uso permitido; 1 - Uso restrito)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="0"/>
+																			<xs:enumeration value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="nSerie">
+																	<xs:annotation>
+																		<xs:documentation>Número de série da arma</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="15"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="nCano">
+																	<xs:annotation>
+																		<xs:documentation>Número de série do cano</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="15"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="descr">
+																	<xs:annotation>
+																		<xs:documentation>Descrição completa da arma, compreendendo: calibre, marca, capacidade, tipo de funcionamento, comprimento e demais elementos que permitam a sua perfeita identificação.</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="256"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="comb">
+														<xs:annotation>
+															<xs:documentation>Informar apenas para operações com combustíveis líquidos</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="cProdANP">
+																	<xs:annotation>
+																		<xs:documentation>Código de produto da ANP. codificação de produtos do SIMP (http://www.anp.gov.br)</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:pattern value="[0-9]{9}"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="descANP">
+																	<xs:annotation>
+																		<xs:documentation>Descrição do Produto conforme ANP. Utilizar a descrição de produtos do Sistema de Informações de Movimentação de Produtos - SIMP (http://www.anp.gov.br/simp/).</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="2"/>
+																			<xs:maxLength value="95"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="pGLP" type="TDec_0302a04Max100" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Percentual do GLP derivado do petróleo no produto GLP (cProdANP=210203001). Informar em número decimal o percentual do GLP derivado de petróleo no produto GLP. Valores 0 a 100.</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="pGNn" type="TDec_0302a04Max100" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Percentual de gás natural nacional - GLGNn para o produto GLP (cProdANP=210203001). Informar em número decimal o percentual do Gás Natural Nacional - GLGNn para o produto GLP. Valores de 0 a 100.</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="pGNi" type="TDec_0302a04Max100" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Percentual de gás natural importado GLGNi para o produto GLP (cProdANP=210203001). Informar em número deciaml o percentual do Gás Natural Importado - GLGNi para o produto GLP. Valores de 0 a 100.</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="vPart" type="TDec_1302" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor de partida (cProdANP=210203001). Deve ser informado neste campo o valor por quilograma sem ICMS.</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="CODIF" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Código de autorização / registro do CODIF. Informar apenas quando a UF utilizar o CODIF (Sistema de Controle do 			Diferimento do Imposto nas Operações com AEAC - Álcool Etílico Anidro Combustível).</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:pattern value="[0-9]{1,21}"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="qTemp" type="TDec_1204temperatura" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Quantidade de combustível
+faturada à temperatura ambiente.
+Informar quando a quantidade
+faturada informada no campo
+qCom (I10) tiver sido ajustada para
+uma temperatura diferente da
+ambiente.</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="UFCons" type="TUf">
+																	<xs:annotation>
+																		<xs:documentation>Sigla da UF de Consumo</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="CIDE" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>CIDE Combustíveis</xs:documentation>
+																	</xs:annotation>
+																	<xs:complexType>
+																		<xs:sequence>
+																			<xs:element name="qBCProd" type="TDec_1204v">
+																				<xs:annotation>
+																					<xs:documentation>BC do CIDE ( Quantidade comercializada)</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																			<xs:element name="vAliqProd" type="TDec_1104">
+																				<xs:annotation>
+																					<xs:documentation>Alíquota do CIDE  (em reais)</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																			<xs:element name="vCIDE" type="TDec_1302">
+																				<xs:annotation>
+																					<xs:documentation>Valor do CIDE</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																		</xs:sequence>
+																	</xs:complexType>
+																</xs:element>
+																<xs:element name="encerrante" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Informações do grupo de &quot;encerrante&quot;</xs:documentation>
+																	</xs:annotation>
+																	<xs:complexType>
+																		<xs:sequence>
+																			<xs:element name="nBico">
+																				<xs:annotation>
+																					<xs:documentation>Numero de identificação do Bico utilizado no abastecimento</xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:string">
+																						<xs:whiteSpace value="preserve"/>
+																						<xs:pattern value="[0-9]{1,3}"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																			<xs:element name="nBomba" minOccurs="0">
+																				<xs:annotation>
+																					<xs:documentation>Numero de identificação da bomba ao qual o bico está interligado</xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:string">
+																						<xs:whiteSpace value="preserve"/>
+																						<xs:pattern value="[0-9]{1,3}"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																			<xs:element name="nTanque">
+																				<xs:annotation>
+																					<xs:documentation>Numero de identificação do tanque ao qual o bico está interligado</xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:string">
+																						<xs:whiteSpace value="preserve"/>
+																						<xs:pattern value="[0-9]{1,3}"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																			<xs:element name="vEncIni" type="TDec_1203">
+																				<xs:annotation>
+																					<xs:documentation>Valor do Encerrante no ínicio do abastecimento</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																			<xs:element name="vEncFin" type="TDec_1203">
+																				<xs:annotation>
+																					<xs:documentation>Valor do Encerrante no final do abastecimento</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																		</xs:sequence>
+																	</xs:complexType>
+																</xs:element>
+																<xs:element name="pBio" type="TDec_03v00a04Max100Opc" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Percentual do índice de mistura do Biodiesel (B100) no Óleo Diesel B instituído pelo órgão regulamentador</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="origComb" minOccurs="0" maxOccurs="30">
+																	<xs:annotation>
+																		<xs:documentation>Grupo indicador da origem do combustível</xs:documentation>
+																	</xs:annotation>
+																	<xs:complexType>
+																		<xs:sequence>
+																			<xs:element name="indImport">
+																				<xs:annotation>
+																					<xs:documentation>Indicador de importação 0=Nacional; 1=Importado;</xs:documentation>
+																				</xs:annotation>
+																				<xs:simpleType>
+																					<xs:restriction base="xs:string">
+																						<xs:whiteSpace value="preserve"/>
+																						<xs:enumeration value="0"/>
+																						<xs:enumeration value="1"/>
+																					</xs:restriction>
+																				</xs:simpleType>
+																			</xs:element>
+																			<xs:element name="cUFOrig" type="TCodUfIBGE">
+																				<xs:annotation>
+																					<xs:documentation>UF de origem do produtor ou do importado</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																			<xs:element name="pOrig" type="TDec_03v00a04Max100Opc">
+																				<xs:annotation>
+																					<xs:documentation>Percentual originário para a UF</xs:documentation>
+																				</xs:annotation>
+																			</xs:element>
+																		</xs:sequence>
+																	</xs:complexType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="nRECOPI">
+														<xs:annotation>
+															<xs:documentation>Número do RECOPI</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:whiteSpace value="preserve"/>
+																<xs:maxLength value="20"/>
+																<xs:pattern value="[0-9]{20}"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:choice>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="imposto">
+										<xs:annotation>
+											<xs:documentation>Tributos incidentes nos produtos ou serviços da NF-e</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="vTotTrib" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor estimado total de impostos federais, estaduais e municipais</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:choice minOccurs="0">
+													<xs:sequence>
+														<xs:element name="ICMS">
+															<xs:annotation>
+																<xs:documentation>Dados do ICMS Normal e ST</xs:documentation>
+															</xs:annotation>
+															<xs:complexType>
+																<xs:choice>
+																	<xs:element name="ICMS00">
+																		<xs:annotation>
+																			<xs:documentation>Tributação pelo ICMS
+00 - Tributada integralmente</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributção pelo ICMS
+00 - Tributada integralmente</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="00"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="modBC">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS:
+0 - Margem Valor Agregado (%);
+1 - Pauta (valor);
+2 - Preço Tabelado Máximo (valor);
+3 - Valor da Operação.</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="vBC" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMS" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMS" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="pFCP" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCP" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS02">
+																		<xs:annotation>
+																			<xs:documentation>Tributação monofásica própria sobre combustíveis</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributção pelo ICMS
+02= Tributação monofásica própria sobre combustíveis;</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="02"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="qBCMono" type="TDec_1104v" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Quantidade tributada.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="adRemICMS" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota ad rem do imposto.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSMono" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS própri</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS10">
+																		<xs:annotation>
+																			<xs:documentation>Tributação pelo ICMS
+10 - Tributada e com cobrança do ICMS por substituição tributária</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>10 - Tributada e com cobrança do ICMS por substituição tributária</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="10"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="modBC">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS:
+0 - Margem Valor Agregado (%);
+1 - Pauta (valor);
+2 - Preço Tabelado Máximo (valor);
+3 - Valor da Operação.</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="vBC" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMS" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMS" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCP" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCP" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCP" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:element name="modBCST">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS ST:
+0 – Preço tabelado ou máximo  sugerido;
+1 - Lista Negativa (valor);
+2 - Lista Positiva (valor);
+3 - Lista Neutra (valor);
+4 - Margem Valor Agregado (%);
+5 - Pauta (valor)
+6-Valor da Operação;</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																							<xs:enumeration value="4"/>
+																							<xs:enumeration value="5"/>
+																							<xs:enumeration value="6"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="pMVAST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual da Margem de Valor Adicionado ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pRedBCST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual de redução da BC ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vBCST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMSST" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP retido por substituicao tributaria.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCPST" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vICMSSTDeson" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS-ST desonerado.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="motDesICMSST">
+																						<xs:annotation>
+																							<xs:documentation>Motivo da desoneração do ICMS-ST: 3-Uso na agropecuária; 9-Outros; 12-Fomento agropecuário.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="3"/>
+																								<xs:enumeration value="9"/>
+																								<xs:enumeration value="12"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS15">
+																		<xs:annotation>
+																			<xs:documentation>Tributação monofásica própria e com responsabilidade pela retenção sobre combustíveis</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributção pelo ICMS
+15= Tributação monofásica própria e com responsabilidade pela retenção sobre combustíveis;</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="15"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="qBCMono" type="TDec_1104v" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Quantidade tributada.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="adRemICMS" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota ad rem do imposto.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSMono" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS próprio</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="qBCMonoReten" type="TDec_1104v" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Quantidade tributada sujeita a retenção.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="adRemICMSReten" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota ad rem do imposto com retenção.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSMonoReten" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS com retenção</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="pRedAdRem" type="TDec_0302Max100">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de redução do valor da alíquota ad rem do ICMS.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="motRedAdRem">
+																						<xs:annotation>
+																							<xs:documentation>Motivo da redução do adrem
+																							1= Transporte coletivo de passageiros; 9=Outros; 
+																						</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="1"/>
+																								<xs:enumeration value="9"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS20">
+																		<xs:annotation>
+																			<xs:documentation>Tributção pelo ICMS
+20 - Com redução de base de cálculo</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributção pelo ICMS
+20 - Com redução de base de cálculo</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="20"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="modBC">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS:
+0 - Margem Valor Agregado (%);
+1 - Pauta (valor);
+2 - Preço Tabelado Máximo (valor);
+3 - Valor da Operação.</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="pRedBC" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Percentual de redução da BC</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vBC" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMS" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMS" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCP" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCP" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCP" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Grupo desoneração</xs:documentation>
+																					</xs:annotation>
+																					<xs:element name="vICMSDeson" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="motDesICMS">
+																						<xs:annotation>
+																							<xs:documentation>Motivo da desoneração do ICMS:3-Uso na agropecuária;9-Outros;12-Fomento agropecuário</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="3"/>
+																								<xs:enumeration value="9"/>
+																								<xs:enumeration value="12"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="indDeduzDeson" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Indica se o valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd):
+0=Valor do ICMS desonerado (vICMSDeson) não deduz do valor do item (vProd) / total da NF-e;
+1=Valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd) / total da NF-e.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS30">
+																		<xs:annotation>
+																			<xs:documentation>Tributação pelo ICMS
+30 - Isenta ou não tributada e com cobrança do ICMS por substituição tributária</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributção pelo ICMS
+30 - Isenta ou não tributada e com cobrança do ICMS por substituição tributária</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="30"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="modBCST">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS ST:
+0 – Preço tabelado ou máximo  sugerido;
+1 - Lista Negativa (valor);
+2 - Lista Positiva (valor);
+3 - Lista Neutra (valor);
+4 - Margem Valor Agregado (%);
+5 - Pauta (valor).
+6 - Valor da Operação</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																							<xs:enumeration value="4"/>
+																							<xs:enumeration value="5"/>
+																							<xs:enumeration value="6"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="pMVAST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual da Margem de Valor Adicionado ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pRedBCST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual de redução da BC ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vBCST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMSST" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCPST" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Grupo desoneração</xs:documentation>
+																					</xs:annotation>
+																					<xs:element name="vICMSDeson" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="motDesICMS">
+																						<xs:annotation>
+																							<xs:documentation>Motivo da desoneração do ICMS:6-Utilitários Motocicleta AÁrea Livre;7-SUFRAMA;9-Outros</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="6"/>
+																								<xs:enumeration value="7"/>
+																								<xs:enumeration value="9"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="indDeduzDeson" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Indica se o valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd):
+0=Valor do ICMS desonerado (vICMSDeson) não deduz do valor do item (vProd) / total da NF-e;
+1=Valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd) / total da NF-e.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS40">
+																		<xs:annotation>
+																			<xs:documentation>Tributação pelo ICMS
+40 - Isenta 
+41 - Não tributada 
+50 - Suspensão</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributação pelo ICMS 
+40 - Isenta 
+41 - Não tributada 
+50 - Suspensão 
+51 - Diferimento</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="40"/>
+																							<xs:enumeration value="41"/>
+																							<xs:enumeration value="50"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vICMSDeson" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>O valor do ICMS será informado apenas nas operações com veículos beneficiados com a desoneração condicional do ICMS.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="motDesICMS">
+																						<xs:annotation>
+																							<xs:documentation>Este campo será preenchido quando o campo anterior estiver preenchido.
+Informar o motivo da desoneração:
+1 – Táxi;
+3 – Produtor Agropecuário;
+4 – Frotista/Locadora;
+5 – Diplomático/Consular;
+6 – Utilitários e Motocicletas da Amazônia Ocidental e Áreas de Livre Comércio (Resolução 714/88 e 790/94 – CONTRAN e suas alterações);
+7 – SUFRAMA;
+8 - Venda a órgão Público;
+9 – Outros
+10- Deficiente Condutor
+11- Deficiente não condutor
+16 - Olimpíadas Rio 2016
+90 - Solicitado pelo Fisco</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="1"/>
+																								<xs:enumeration value="3"/>
+																								<xs:enumeration value="4"/>
+																								<xs:enumeration value="5"/>
+																								<xs:enumeration value="6"/>
+																								<xs:enumeration value="7"/>
+																								<xs:enumeration value="8"/>
+																								<xs:enumeration value="9"/>
+																								<xs:enumeration value="10"/>
+																								<xs:enumeration value="11"/>
+																								<xs:enumeration value="16"/>
+																								<xs:enumeration value="90"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="indDeduzDeson" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Indica se o valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd):
+0=Valor do ICMS desonerado (vICMSDeson) não deduz do valor do item (vProd) / total da NF-e;
+1=Valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd) / total da NF-e.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS51">
+																		<xs:annotation>
+																			<xs:documentation>Tributção pelo ICMS 51 - Diferimento. A exigência do preenchimento das informações do ICMS diferido fica à critério de cada UF.</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+																						1 - Estrangeira - Importação direta 
+																						2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributação pelo ICMS 51 - Tributação com Diferimento</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="51"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="modBC" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS:
+																						0 - Margem Valor Agregado (%);
+																						1 - Pauta (valor);
+																						2 - Preço Tabelado Máximo (valor);
+																						3 - Valor da Operação.</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="pRedBC" type="TDec_0302a04" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual de redução da BC</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="cBenefRBC" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Código de Benefício Fiscal na UF aplicado ao item quando houver RBC.</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:pattern value="[!-ÿ]{8}|[!-ÿ]{10}"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="vBC" type="TDec_1302" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMS" type="TDec_0302a04" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do imposto</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSOp" type="TDec_1302" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS da Operação</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pDif" type="TDec_0302a04Max100" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual do diferemento</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSDif" type="TDec_1302" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS da diferido</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMS" type="TDec_1302" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCP" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCP" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCP" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="pFCPDif" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual do diferimento do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPDif" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP) diferido.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPEfet" type="TDec_1302" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Valor efetivo do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS53">
+																		<xs:annotation>
+																			<xs:documentation>Tributação monofásica sobre combustíveis com recolhimento diferido</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributção pelo ICMS
+53= Tributação monofásica sobre combustíveis com recolhimento diferido;</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="53"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="qBCMono" type="TDec_1104v" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Quantidade tributada.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="adRemICMS" type="TDec_0302a04" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota ad rem do imposto.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSMonoOp" type="TDec_1302" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS da operação</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pDif" type="TDec_0302a04Max100" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual do diferemento</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSMonoDif" type="TDec_1302" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS diferido</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSMono" type="TDec_1302" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS próprio devido</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="qBCMonoDif" type="TDec_1104v" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Quantidade tributada diferida.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="adRemICMSDif" type="TDec_0302a04" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota ad rem do imposto diferido</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS60">
+																		<xs:annotation>
+																			<xs:documentation>Tributação pelo ICMS
+60 - ICMS cobrado anteriormente por substituição tributária</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributação pelo ICMS 
+60 - ICMS cobrado anteriormente por substituição tributária</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="60"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>NT2010/004</xs:documentation>
+																					</xs:annotation>
+																					<xs:element name="vBCSTRet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da BC do ICMS ST retido anteriormente</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pST" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Aliquota suportada pelo consumidor final.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMSSubstituto" type="TDec_1302" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS Próprio do Substituto cobrado em operação anterior</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMSSTRet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS ST retido anteriormente</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCPSTRet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP retido anteriormente por ST.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCPSTRet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de FCP retido anteriormente por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPSTRet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="pRedBCEfet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de redução da base de cálculo efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vBCEfet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da base de cálculo efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pICMSEfet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Alíquota do ICMS efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMSEfet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS efetivo.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS61">
+																		<xs:annotation>
+																			<xs:documentation>Tributação monofásica sobre combustíveis cobrada anteriormente;</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributção pelo ICMS
+61= Tributação monofásica sobre combustíveis cobrada anteriormente</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="61"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="qBCMonoRet" type="TDec_1104v" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Quantidade tributada retida anteriormente</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="adRemICMSRet" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota ad rem do imposto retido anteriormente</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSMonoRet" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS retido anteriormente</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS70">
+																		<xs:annotation>
+																			<xs:documentation>Tributação pelo ICMS 
+70 - Com redução de base de cálculo e cobrança do ICMS por substituição tributária</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributção pelo ICMS
+70 - Com redução de base de cálculo e cobrança do ICMS por substituição tributária</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="70"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="modBC">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS:
+0 - Margem Valor Agregado (%);
+1 - Pauta (valor);
+2 - Preço Tabelado Máximo (valor);
+3 - Valor da Operação.</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="pRedBC" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Percentual de redução da BC</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vBC" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMS" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMS" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCP" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCP" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCP" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:element name="modBCST">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS ST:
+0 – Preço tabelado ou máximo  sugerido;
+1 - Lista Negativa (valor);
+2 - Lista Positiva (valor);
+3 - Lista Neutra (valor);
+4 - Margem Valor Agregado (%);
+5 - Pauta (valor);
+6 - Valor da Operação.</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																							<xs:enumeration value="4"/>
+																							<xs:enumeration value="5"/>
+																							<xs:enumeration value="6"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="pMVAST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual da Margem de Valor Adicionado ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pRedBCST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual de redução da BC ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vBCST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMSST" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCPST" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Grupo desoneração</xs:documentation>
+																					</xs:annotation>
+																					<xs:element name="vICMSDeson" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="motDesICMS">
+																						<xs:annotation>
+																							<xs:documentation>Motivo da desoneração do ICMS:3-Uso na agropecuária;9-Outros;12-Fomento agropecuário</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="3"/>
+																								<xs:enumeration value="9"/>
+																								<xs:enumeration value="12"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="indDeduzDeson" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Indica se o valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd):
+0=Valor do ICMS desonerado (vICMSDeson) não deduz do valor do item (vProd) / total da NF-e;
+1=Valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd) / total da NF-e.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vICMSSTDeson" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS-ST desonerado.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="motDesICMSST">
+																						<xs:annotation>
+																							<xs:documentation>Motivo da desoneração do ICMS-ST: 3-Uso na agropecuária; 9-Outros; 12-Fomento agropecuário.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="3"/>
+																								<xs:enumeration value="9"/>
+																								<xs:enumeration value="12"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMS90">
+																		<xs:annotation>
+																			<xs:documentation>Tributação pelo ICMS
+90 - Outras</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributção pelo ICMS
+90 - Outras</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="90"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="modBC">
+																						<xs:annotation>
+																							<xs:documentation>Modalidade de determinação da BC do ICMS: 
+0 - Margem Valor Agregado (%);
+1 - Pauta (valor);
+2 - Preço Tabelado Máximo (valor);
+3 - Valor da Operação.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																								<xs:enumeration value="2"/>
+																								<xs:enumeration value="3"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="vBC" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da BC do ICMS</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pRedBC" type="TDec_0302a04Opc" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de redução da BC</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pICMS" type="TDec_0302a04">
+																						<xs:annotation>
+																							<xs:documentation>Alíquota do ICMS</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMS" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:sequence minOccurs="0">
+																						<xs:element name="vBCFCP" type="TDec_1302">
+																							<xs:annotation>
+																								<xs:documentation>Valor da Base de cálculo do FCP.</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="pFCP" type="TDec_0302a04Opc">
+																							<xs:annotation>
+																								<xs:documentation>Percentual de ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="vFCP" type="TDec_1302">
+																							<xs:annotation>
+																								<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP).</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																					</xs:sequence>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="modBCST">
+																						<xs:annotation>
+																							<xs:documentation>Modalidade de determinação da BC do ICMS ST:
+0 – Preço tabelado ou máximo  sugerido;
+1 - Lista Negativa (valor);
+2 - Lista Positiva (valor);
+3 - Lista Neutra (valor);
+4 - Margem Valor Agregado (%);
+5 - Pauta (valor);
+6 - Valor da Operação.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																								<xs:enumeration value="2"/>
+																								<xs:enumeration value="3"/>
+																								<xs:enumeration value="4"/>
+																								<xs:enumeration value="5"/>
+																								<xs:enumeration value="6"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="pMVAST" type="TDec_0302a04Opc" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Percentual da Margem de Valor Adicionado ICMS ST</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pRedBCST" type="TDec_0302a04Opc" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de redução da BC ICMS ST</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vBCST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da BC do ICMS ST</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pICMSST" type="TDec_0302a04">
+																						<xs:annotation>
+																							<xs:documentation>Alíquota do ICMS ST</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMSST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS ST</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:sequence minOccurs="0">
+																						<xs:element name="vBCFCPST" type="TDec_1302">
+																							<xs:annotation>
+																								<xs:documentation>Valor da Base de cálculo do FCP.</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="pFCPST" type="TDec_0302a04Opc">
+																							<xs:annotation>
+																								<xs:documentation>Percentual de FCP retido por substituição tributária.</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="vFCPST" type="TDec_1302">
+																							<xs:annotation>
+																								<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																					</xs:sequence>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Grupo desoneração</xs:documentation>
+																					</xs:annotation>
+																					<xs:element name="vICMSDeson" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="motDesICMS">
+																						<xs:annotation>
+																							<xs:documentation>Motivo da desoneração do ICMS:3-Uso na agropecuária;9-Outros;12-Fomento agropecuário</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="3"/>
+																								<xs:enumeration value="9"/>
+																								<xs:enumeration value="12"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="indDeduzDeson" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Indica se o valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd):
+0=Valor do ICMS desonerado (vICMSDeson) não deduz do valor do item (vProd) / total da NF-e;
+1=Valor do ICMS desonerado (vICMSDeson) deduz do valor do item (vProd) / total da NF-e.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vICMSSTDeson" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS-ST desonerado.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="motDesICMSST">
+																						<xs:annotation>
+																							<xs:documentation>Motivo da desoneração do ICMS-ST: 3-Uso na agropecuária; 9-Outros; 12-Fomento agropecuário.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="3"/>
+																								<xs:enumeration value="9"/>
+																								<xs:enumeration value="12"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMSPart">
+																		<xs:annotation>
+																			<xs:documentation>Partilha do ICMS entre a UF de origem e UF de destino ou a UF definida na legislação
+Operação interestadual para consumidor final com partilha do ICMS  devido na operação entre a UF de origem e a UF do destinatário ou ou a UF definida na legislação. (Ex. UF da concessionária de entrega do  veículos)</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributação pelo ICMS 
+10 - Tributada e com cobrança do ICMS por substituição tributária;
+90 – Outros.</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="10"/>
+																							<xs:enumeration value="90"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="modBC">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS: 
+0 - Margem Valor Agregado (%);
+1 - Pauta (valor);
+2 - Preço Tabelado Máximo (valor);
+3 - Valor da Operação.</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="vBC" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pRedBC" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual de redução da BC</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMS" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMS" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="modBCST">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS ST:
+0 – Preço tabelado ou máximo  sugerido;
+1 - Lista Negativa (valor);
+2 - Lista Positiva (valor);
+3 - Lista Neutra (valor);
+4 - Margem Valor Agregado (%);
+5 - Pauta (valor).
+6 - Valor da Operação</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																							<xs:enumeration value="4"/>
+																							<xs:enumeration value="5"/>
+																							<xs:enumeration value="6"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="pMVAST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual da Margem de Valor Adicionado ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pRedBCST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual de redução da BC ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vBCST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMSST" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS ST</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP retido por substituicao tributaria.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCPST" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:element name="pBCOp" type="TDec_0302a04Opc">
+																					<xs:annotation>
+																						<xs:documentation>Percentual para determinação do valor  da Base de Cálculo da operação própria.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="UFST" type="TUf">
+																					<xs:annotation>
+																						<xs:documentation>Sigla da UF para qual é devido o ICMS ST da operação.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMSST">
+																		<xs:annotation>
+																			<xs:documentation>Grupo de informação do ICMSST devido para a UF de destino, nas operações interestaduais de produtos que tiveram retenção antecipada de ICMS por ST na UF do remetente. Repasse via Substituto Tributário.</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CST">
+																					<xs:annotation>
+																						<xs:documentation>Tributção pelo ICMS
+41-Não Tributado.
+60-Cobrado anteriormente por substituição tributária.</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="41"/>
+																							<xs:enumeration value="60"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="vBCSTRet" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Informar o valor da BC do ICMS ST retido na UF remetente</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Aliquota suportada pelo consumidor final.</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSSubstituto" type="TDec_1302" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS Próprio do Substituto cobrado em operação anterior</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSSTRet" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation> Informar o valor do ICMS ST retido na UF remetente (iv2.0))</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCPSTRet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Informar o valor da Base de Cálculo do FCP retido anteriormente por ST.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCPSTRet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual relativo ao Fundo de Combate à Pobreza (FCP) retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPSTRet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP) retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:element name="vBCSTDest" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation> Informar o valor da BC do ICMS ST da UF destino</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSSTDest" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Informar o valor da BC do ICMS ST da UF destino (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="pRedBCEfet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de redução da base de cálculo efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vBCEfet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da base de cálculo efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pICMSEfet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Alíquota do ICMS efetivo.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMSEfet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS efetivo.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMSSN101">
+																		<xs:annotation>
+																			<xs:documentation>Tributação do ICMS pelo SIMPLES NACIONAL e CSOSN=101 (v.2.0)</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno 
+(v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CSOSN">
+																					<xs:annotation>
+																						<xs:documentation>101- Tributada pelo Simples Nacional com permissão de crédito. (v.2.0)</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="101"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="pCredSN" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota aplicável de cálculo do crédito (Simples Nacional). (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vCredICMSSN" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor crédito do ICMS que pode ser aproveitado nos termos do art. 23 da LC 123 (Simples Nacional) (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMSSN102">
+																		<xs:annotation>
+																			<xs:documentation>Tributação do ICMS pelo SIMPLES NACIONAL e CSOSN=102, 103, 300 ou 400 (v.2.0))</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno 
+(v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CSOSN">
+																					<xs:annotation>
+																						<xs:documentation>102- Tributada pelo Simples Nacional sem permissão de crédito. 
+103 – Isenção do ICMS  no Simples Nacional para faixa de receita bruta.
+300 – Imune.
+400 – Não tributda pelo Simples Nacional (v.2.0) (v.2.0)</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="102"/>
+																							<xs:enumeration value="103"/>
+																							<xs:enumeration value="300"/>
+																							<xs:enumeration value="400"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMSSN201">
+																		<xs:annotation>
+																			<xs:documentation>Tributação do ICMS pelo SIMPLES NACIONAL e CSOSN=201 (v.2.0)</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>Origem da mercadoria:
+0 – Nacional;
+1 – Estrangeira – Importação direta;
+2 – Estrangeira – Adquirida no mercado interno. (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CSOSN">
+																					<xs:annotation>
+																						<xs:documentation>201- Tributada pelo Simples Nacional com permissão de crédito e com cobrança do ICMS por Substituição Tributária (v.2.0)</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="201"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="modBCST">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS ST:
+0 – Preço tabelado ou máximo  sugerido;
+1 - Lista Negativa (valor);
+2 - Lista Positiva (valor);
+3 - Lista Neutra (valor);
+4 - Margem Valor Agregado (%);
+5 - Pauta (valor). (v2.0)
+6 - Valor da Operação</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																							<xs:enumeration value="4"/>
+																							<xs:enumeration value="5"/>
+																							<xs:enumeration value="6"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="pMVAST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual da Margem de Valor Adicionado ICMS ST (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pRedBCST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual de redução da BC ICMS ST  (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vBCST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS ST (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMSST" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS ST (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS ST (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCPST" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:element name="pCredSN" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota aplicável de cálculo do crédito (Simples Nacional). (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vCredICMSSN" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor crédito do ICMS que pode ser aproveitado nos termos do art. 23 da LC 123 (Simples Nacional) (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMSSN202">
+																		<xs:annotation>
+																			<xs:documentation>Tributação do ICMS pelo SIMPLES NACIONAL e CSOSN=202 ou 203 (v.2.0)</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>Origem da mercadoria:
+0 – Nacional;
+1 – Estrangeira – Importação direta;
+2 – Estrangeira – Adquirida no mercado interno. (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CSOSN">
+																					<xs:annotation>
+																						<xs:documentation>202- Tributada pelo Simples Nacional sem permissão de crédito e com cobrança do ICMS por Substituição Tributária;
+203-  Isenção do ICMS nos Simples Nacional para faixa de receita bruta e com cobrança do ICMS por Substituição Tributária (v.2.0)</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="202"/>
+																							<xs:enumeration value="203"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="modBCST">
+																					<xs:annotation>
+																						<xs:documentation>Modalidade de determinação da BC do ICMS ST:
+0 – Preço tabelado ou máximo  sugerido;
+1 - Lista Negativa (valor);
+2 - Lista Positiva (valor);
+3 - Lista Neutra (valor);
+4 - Margem Valor Agregado (%);
+5 - Pauta (valor). (v2.0)
+6 - Valor da Operação</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="0"/>
+																							<xs:enumeration value="1"/>
+																							<xs:enumeration value="2"/>
+																							<xs:enumeration value="3"/>
+																							<xs:enumeration value="4"/>
+																							<xs:enumeration value="5"/>
+																							<xs:enumeration value="6"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:element name="pMVAST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual da Margem de Valor Adicionado ICMS ST (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pRedBCST" type="TDec_0302a04Opc" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>Percentual de redução da BC ICMS ST  (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vBCST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do ICMS ST (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pICMSST" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do ICMS ST (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vICMSST" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor do ICMS ST (v2.0)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCPST" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMSSN500">
+																		<xs:annotation>
+																			<xs:documentation>Tributação do ICMS pelo SIMPLES NACIONAL,CRT=1 – Simples Nacional e CSOSN=500 (v.2.0)</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CSOSN">
+																					<xs:annotation>
+																						<xs:documentation>500 – ICMS cobrado anterirmente por substituição tributária (substituído) ou por antecipação
+(v.2.0)</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="500"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCSTRet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da BC do ICMS ST retido anteriormente (v2.0)</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pST" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Aliquota suportada pelo consumidor final.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMSSubstituto" type="TDec_1302" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS próprio do substituto</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMSSTRet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS ST retido anteriormente  (v2.0)</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="vBCFCPSTRet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da Base de cálculo do FCP retido anteriormente.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pFCPSTRet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de FCP retido anteriormente por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vFCPSTRet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="pRedBCEfet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de redução da base de cálculo efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vBCEfet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da base de cálculo efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pICMSEfet" type="TDec_0302a04Opc">
+																						<xs:annotation>
+																							<xs:documentation>Alíquota do ICMS efetiva.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMSEfet" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS efetivo.</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																	<xs:element name="ICMSSN900">
+																		<xs:annotation>
+																			<xs:documentation>Tributação do ICMS pelo SIMPLES NACIONAL, CRT=1 – Simples Nacional, CRT=4 - MEI e CSOSN=900 (v2.0)</xs:documentation>
+																		</xs:annotation>
+																		<xs:complexType>
+																			<xs:sequence>
+																				<xs:element name="orig" type="Torig" minOccurs="0">
+																					<xs:annotation>
+																						<xs:documentation>origem da mercadoria: 0 - Nacional 
+1 - Estrangeira - Importação direta 
+2 - Estrangeira - Adquirida no mercado interno</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="CSOSN">
+																					<xs:annotation>
+																						<xs:documentation>Tributação pelo ICMS 900 - Outros(v2.0)</xs:documentation>
+																					</xs:annotation>
+																					<xs:simpleType>
+																						<xs:restriction base="xs:string">
+																							<xs:whiteSpace value="preserve"/>
+																							<xs:enumeration value="900"/>
+																						</xs:restriction>
+																					</xs:simpleType>
+																				</xs:element>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="modBC">
+																						<xs:annotation>
+																							<xs:documentation>Modalidade de determinação da BC do ICMS: 
+0 - Margem Valor Agregado (%);
+1 - Pauta (valor);
+2 - Preço Tabelado Máximo (valor);
+3 - Valor da Operação.</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																								<xs:enumeration value="2"/>
+																								<xs:enumeration value="3"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="vBC" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da BC do ICMS</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pRedBC" type="TDec_0302a04Opc" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de redução da BC</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pICMS" type="TDec_0302a04">
+																						<xs:annotation>
+																							<xs:documentation>Alíquota do ICMS</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMS" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="modBCST">
+																						<xs:annotation>
+																							<xs:documentation>Modalidade de determinação da BC do ICMS ST:
+0 – Preço tabelado ou máximo  sugerido;
+1 - Lista Negativa (valor);
+2 - Lista Positiva (valor);
+3 - Lista Neutra (valor);
+4 - Margem Valor Agregado (%);
+5 - Pauta (valor).
+6 - Valor da Operação</xs:documentation>
+																						</xs:annotation>
+																						<xs:simpleType>
+																							<xs:restriction base="xs:string">
+																								<xs:whiteSpace value="preserve"/>
+																								<xs:enumeration value="0"/>
+																								<xs:enumeration value="1"/>
+																								<xs:enumeration value="2"/>
+																								<xs:enumeration value="3"/>
+																								<xs:enumeration value="4"/>
+																								<xs:enumeration value="5"/>
+																								<xs:enumeration value="6"/>
+																							</xs:restriction>
+																						</xs:simpleType>
+																					</xs:element>
+																					<xs:element name="pMVAST" type="TDec_0302a04Opc" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Percentual da Margem de Valor Adicionado ICMS ST</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pRedBCST" type="TDec_0302a04Opc" minOccurs="0">
+																						<xs:annotation>
+																							<xs:documentation>Percentual de redução da BC ICMS ST</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vBCST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor da BC do ICMS ST</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="pICMSST" type="TDec_0302a04">
+																						<xs:annotation>
+																							<xs:documentation>Alíquota do ICMS ST</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vICMSST" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor do ICMS ST</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:sequence minOccurs="0">
+																						<xs:element name="vBCFCPST" type="TDec_1302">
+																							<xs:annotation>
+																								<xs:documentation>Valor da Base de cálculo do FCP.</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="pFCPST" type="TDec_0302a04Opc">
+																							<xs:annotation>
+																								<xs:documentation>Percentual de FCP retido por substituição tributária.</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																						<xs:element name="vFCPST" type="TDec_1302">
+																							<xs:annotation>
+																								<xs:documentation>Valor do FCP retido por substituição tributária.</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																					</xs:sequence>
+																				</xs:sequence>
+																				<xs:sequence minOccurs="0">
+																					<xs:element name="pCredSN" type="TDec_0302a04">
+																						<xs:annotation>
+																							<xs:documentation>Alíquota aplicável de cálculo do crédito (Simples Nacional). (v2.0)</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																					<xs:element name="vCredICMSSN" type="TDec_1302">
+																						<xs:annotation>
+																							<xs:documentation>Valor crédito do ICMS que pode ser aproveitado nos termos do art. 23 da LC 123 (Simples Nacional) (v2.0)</xs:documentation>
+																						</xs:annotation>
+																					</xs:element>
+																				</xs:sequence>
+																			</xs:sequence>
+																		</xs:complexType>
+																	</xs:element>
+																</xs:choice>
+															</xs:complexType>
+														</xs:element>
+														<xs:element name="IPI" type="TIpi" minOccurs="0"/>
+														<xs:element name="II" minOccurs="0">
+															<xs:annotation>
+																<xs:documentation>Dados do Imposto de Importação</xs:documentation>
+															</xs:annotation>
+															<xs:complexType>
+																<xs:sequence>
+																	<xs:element name="vBC" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Base da BC do Imposto de Importação</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vDespAdu" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor das despesas aduaneiras</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vII" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor do Imposto de Importação</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vIOF" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor do Imposto sobre Operações Financeiras</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																</xs:sequence>
+															</xs:complexType>
+														</xs:element>
+													</xs:sequence>
+													<xs:sequence>
+														<xs:element name="IPI" type="TIpi" minOccurs="0"/>
+														<xs:element name="ISSQN">
+															<xs:annotation>
+																<xs:documentation>ISSQN</xs:documentation>
+															</xs:annotation>
+															<xs:complexType>
+																<xs:sequence>
+																	<xs:element name="vBC" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor da BC do ISSQN</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vAliq" type="TDec_0302a04">
+																		<xs:annotation>
+																			<xs:documentation>Alíquota do ISSQN</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vISSQN" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor da do ISSQN</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="cMunFG" type="TCodMunIBGE">
+																		<xs:annotation>
+																			<xs:documentation>Informar o município de ocorrência do fato gerador do ISSQN. Utilizar a Tabela do IBGE (Anexo VII - Tabela de UF, Município e País). “Atenção, não vincular com os campos B12, C10 ou E10” v2.0</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="cListServ" type="TCListServ">
+																		<xs:annotation>
+																			<xs:documentation>Informar o Item da lista de serviços da LC 116/03 em que se classifica o serviço.</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vDeducao" type="TDec_1302Opc" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Valor dedução para redução da base de cálculo</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vOutro" type="TDec_1302Opc" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Valor outras retenções</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vDescIncond" type="TDec_1302Opc" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Valor desconto incondicionado</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vDescCond" type="TDec_1302Opc" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Valor desconto condicionado</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vISSRet" type="TDec_1302Opc" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Valor Retenção ISS</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="indISS">
+																		<xs:annotation>
+																			<xs:documentation>Exibilidade do ISS:1-Exigível;2-Não incidente;3-Isenção;4-Exportação;5-Imunidade;6-Exig.Susp. Judicial;7-Exig.Susp. ADM</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="xs:string">
+																				<xs:whiteSpace value="preserve"/>
+																				<xs:enumeration value="1"/>
+																				<xs:enumeration value="2"/>
+																				<xs:enumeration value="3"/>
+																				<xs:enumeration value="4"/>
+																				<xs:enumeration value="5"/>
+																				<xs:enumeration value="6"/>
+																				<xs:enumeration value="7"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="cServico" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Código do serviço prestado dentro do município</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="TString">
+																				<xs:whiteSpace value="preserve"/>
+																				<xs:minLength value="1"/>
+																				<xs:maxLength value="20"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="cMun" type="TCodMunIBGE" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Código do Município de Incidência do Imposto</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="cPais" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Código de Pais</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="xs:string">
+																				<xs:whiteSpace value="preserve"/>
+																				<xs:pattern value="[0-9]{1,4}"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="nProcesso" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Número do Processo administrativo ou judicial de suspenção do processo</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="TString">
+																				<xs:whiteSpace value="preserve"/>
+																				<xs:minLength value="1"/>
+																				<xs:maxLength value="30"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="indIncentivo">
+																		<xs:annotation>
+																			<xs:documentation>Indicador de Incentivo Fiscal. 1=Sim; 2=Não</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="xs:string">
+																				<xs:whiteSpace value="preserve"/>
+																				<xs:enumeration value="1"/>
+																				<xs:enumeration value="2"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																</xs:sequence>
+															</xs:complexType>
+														</xs:element>
+													</xs:sequence>
+												</xs:choice>
+												<xs:element name="PIS" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Dados do PIS</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:choice>
+															<xs:element name="PISAliq">
+																<xs:annotation>
+																	<xs:documentation>Código de Situação Tributária do PIS.
+ 01 – Operação Tributável - Base de Cálculo = Valor da Operação Alíquota Normal (Cumulativo/Não Cumulativo);
+02 - Operação Tributável - Base de Calculo = Valor da Operação (Alíquota Diferenciada);</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="CST">
+																			<xs:annotation>
+																				<xs:documentation>Código de Situação Tributária do PIS.
+ 01 – Operação Tributável - Base de Cálculo = Valor da Operação Alíquota Normal (Cumulativo/Não Cumulativo);
+02 - Operação Tributável - Base de Calculo = Valor da Operação (Alíquota Diferenciada);</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:whiteSpace value="preserve"/>
+																					<xs:enumeration value="01"/>
+																					<xs:enumeration value="02"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																		<xs:element name="vBC" type="TDec_1302">
+																			<xs:annotation>
+																				<xs:documentation>Valor da BC do PIS</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="pPIS" type="TDec_0302a04">
+																			<xs:annotation>
+																				<xs:documentation>Alíquota do PIS (em percentual)</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="vPIS" type="TDec_1302">
+																			<xs:annotation>
+																				<xs:documentation>Valor do PIS</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="PISQtde">
+																<xs:annotation>
+																	<xs:documentation>Código de Situação Tributária do PIS.
+03 - Operação Tributável - Base de Calculo = Quantidade Vendida x Alíquota por Unidade de Produto;</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="CST">
+																			<xs:annotation>
+																				<xs:documentation>Código de Situação Tributária do PIS.
+03 - Operação Tributável - Base de Calculo = Quantidade Vendida x Alíquota por Unidade de Produto;</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:whiteSpace value="preserve"/>
+																					<xs:enumeration value="03"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																		<xs:element name="qBCProd" type="TDec_1204v">
+																			<xs:annotation>
+																				<xs:documentation>Quantidade Vendida  (NT2011/004)</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="vAliqProd" type="TDec_1104v">
+																			<xs:annotation>
+																				<xs:documentation>Alíquota do PIS (em reais) (NT2011/004)</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="vPIS" type="TDec_1302">
+																			<xs:annotation>
+																				<xs:documentation>Valor do PIS</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="PISNT">
+																<xs:annotation>
+																	<xs:documentation>Código de Situação Tributária do PIS.
+04 - Operação Tributável - Tributação Monofásica - (Alíquota Zero);
+06 - Operação Tributável - Alíquota Zero;
+07 - Operação Isenta da contribuição;
+08 - Operação Sem Incidência da contribuição;
+09 - Operação com suspensão da contribuição;</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="CST">
+																			<xs:annotation>
+																				<xs:documentation>Código de Situação Tributária do PIS.
+04 - Operação Tributável - Tributação Monofásica - (Alíquota Zero);
+05 - Operação Tributável (ST);
+06 - Operação Tributável - Alíquota Zero;
+07 - Operação Isenta da contribuição;
+08 - Operação Sem Incidência da contribuição;
+09 - Operação com suspensão da contribuição;</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:whiteSpace value="preserve"/>
+																					<xs:enumeration value="04"/>
+																					<xs:enumeration value="05"/>
+																					<xs:enumeration value="06"/>
+																					<xs:enumeration value="07"/>
+																					<xs:enumeration value="08"/>
+																					<xs:enumeration value="09"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="PISOutr">
+																<xs:annotation>
+																	<xs:documentation>Código de Situação Tributária do PIS.
+99 - Outras Operações.</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="CST">
+																			<xs:annotation>
+																				<xs:documentation>Código de Situação Tributária do PIS.
+99 - Outras Operações.</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:whiteSpace value="preserve"/>
+																					<xs:enumeration value="49"/>
+																					<xs:enumeration value="50"/>
+																					<xs:enumeration value="51"/>
+																					<xs:enumeration value="52"/>
+																					<xs:enumeration value="53"/>
+																					<xs:enumeration value="54"/>
+																					<xs:enumeration value="55"/>
+																					<xs:enumeration value="56"/>
+																					<xs:enumeration value="60"/>
+																					<xs:enumeration value="61"/>
+																					<xs:enumeration value="62"/>
+																					<xs:enumeration value="63"/>
+																					<xs:enumeration value="64"/>
+																					<xs:enumeration value="65"/>
+																					<xs:enumeration value="66"/>
+																					<xs:enumeration value="67"/>
+																					<xs:enumeration value="70"/>
+																					<xs:enumeration value="71"/>
+																					<xs:enumeration value="72"/>
+																					<xs:enumeration value="73"/>
+																					<xs:enumeration value="74"/>
+																					<xs:enumeration value="75"/>
+																					<xs:enumeration value="98"/>
+																					<xs:enumeration value="99"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																		<xs:choice>
+																			<xs:sequence>
+																				<xs:element name="vBC" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do PIS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pPIS" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do PIS (em percentual)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																			</xs:sequence>
+																			<xs:sequence>
+																				<xs:element name="qBCProd" type="TDec_1204v">
+																					<xs:annotation>
+																						<xs:documentation>Quantidade Vendida (NT2011/004)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vAliqProd" type="TDec_1104v">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do PIS (em reais) (NT2011/004)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																			</xs:sequence>
+																		</xs:choice>
+																		<xs:element name="vPIS" type="TDec_1302">
+																			<xs:annotation>
+																				<xs:documentation>Valor do PIS</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+														</xs:choice>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="PISST" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Dados do PIS Substituição Tributária</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:choice>
+																<xs:sequence>
+																	<xs:element name="vBC" type="TDec_1302Opc">
+																		<xs:annotation>
+																			<xs:documentation>Valor da BC do PIS ST</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="pPIS" type="TDec_0302a04">
+																		<xs:annotation>
+																			<xs:documentation>Alíquota do PIS ST (em percentual)</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																</xs:sequence>
+																<xs:sequence>
+																	<xs:element name="qBCProd" type="TDec_1204">
+																		<xs:annotation>
+																			<xs:documentation>Quantidade Vendida</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vAliqProd" type="TDec_1104">
+																		<xs:annotation>
+																			<xs:documentation>Alíquota do PIS ST (em reais)</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																</xs:sequence>
+															</xs:choice>
+															<xs:element name="vPIS" type="TDec_1302">
+																<xs:annotation>
+																	<xs:documentation>Valor do PIS ST</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="indSomaPISST" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Indica se o valor do PISST compõe o valor total da NF-e</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:enumeration value="0"/>
+																		<xs:enumeration value="1"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="COFINS" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Dados do COFINS</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:choice>
+															<xs:element name="COFINSAliq">
+																<xs:annotation>
+																	<xs:documentation>Código de Situação Tributária do COFINS.
+ 01 – Operação Tributável - Base de Cálculo = Valor da Operação Alíquota Normal (Cumulativo/Não Cumulativo);
+02 - Operação Tributável - Base de Calculo = Valor da Operação (Alíquota Diferenciada);</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="CST">
+																			<xs:annotation>
+																				<xs:documentation>Código de Situação Tributária do COFINS.
+ 01 – Operação Tributável - Base de Cálculo = Valor da Operação Alíquota Normal (Cumulativo/Não Cumulativo);
+02 - Operação Tributável - Base de Calculo = Valor da Operação (Alíquota Diferenciada);</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:whiteSpace value="preserve"/>
+																					<xs:enumeration value="01"/>
+																					<xs:enumeration value="02"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																		<xs:element name="vBC" type="TDec_1302">
+																			<xs:annotation>
+																				<xs:documentation>Valor da BC do COFINS</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="pCOFINS" type="TDec_0302a04">
+																			<xs:annotation>
+																				<xs:documentation>Alíquota do COFINS (em percentual)</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="vCOFINS" type="TDec_1302">
+																			<xs:annotation>
+																				<xs:documentation>Valor do COFINS</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="COFINSQtde">
+																<xs:annotation>
+																	<xs:documentation>Código de Situação Tributária do COFINS.
+03 - Operação Tributável - Base de Calculo = Quantidade Vendida x Alíquota por Unidade de Produto;</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="CST">
+																			<xs:annotation>
+																				<xs:documentation>Código de Situação Tributária do COFINS.
+03 - Operação Tributável - Base de Calculo = Quantidade Vendida x Alíquota por Unidade de Produto;</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:enumeration value="03"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																		<xs:element name="qBCProd" type="TDec_1204v">
+																			<xs:annotation>
+																				<xs:documentation>Quantidade Vendida (NT2011/004)</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="vAliqProd" type="TDec_1104v">
+																			<xs:annotation>
+																				<xs:documentation>Alíquota do COFINS (em reais) (NT2011/004)</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="vCOFINS" type="TDec_1302">
+																			<xs:annotation>
+																				<xs:documentation>Valor do COFINS</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="COFINSNT">
+																<xs:annotation>
+																	<xs:documentation>Código de Situação Tributária do COFINS:
+04 - Operação Tributável - Tributação Monofásica - (Alíquota Zero);
+06 - Operação Tributável - Alíquota Zero;
+07 - Operação Isenta da contribuição;
+08 - Operação Sem Incidência da contribuição;
+09 - Operação com suspensão da contribuição;</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="CST">
+																			<xs:annotation>
+																				<xs:documentation>Código de Situação Tributária do COFINS:
+04 - Operação Tributável - Tributação Monofásica - (Alíquota Zero);
+05 - Operação Tributável (ST);
+06 - Operação Tributável - Alíquota Zero;
+07 - Operação Isenta da contribuição;
+08 - Operação Sem Incidência da contribuição;
+09 - Operação com suspensão da contribuição;</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:whiteSpace value="preserve"/>
+																					<xs:enumeration value="04"/>
+																					<xs:enumeration value="05"/>
+																					<xs:enumeration value="06"/>
+																					<xs:enumeration value="07"/>
+																					<xs:enumeration value="08"/>
+																					<xs:enumeration value="09"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+															<xs:element name="COFINSOutr">
+																<xs:annotation>
+																	<xs:documentation>Código de Situação Tributária do COFINS:
+49 - Outras Operações de Saída
+50 - Operação com Direito a Crédito - Vinculada Exclusivamente a Receita Tributada no Mercado Interno
+51 - Operação com Direito a Crédito – Vinculada Exclusivamente a Receita Não Tributada no Mercado Interno
+52 - Operação com Direito a Crédito - Vinculada Exclusivamente a Receita de Exportação
+53 - Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno
+54 - Operação com Direito a Crédito - Vinculada a Receitas Tributadas no Mercado Interno e de Exportação
+55 - Operação com Direito a Crédito - Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação
+56 - Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno, e de Exportação
+60 - Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Tributada no Mercado Interno
+61 - Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno
+62 - Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita de Exportação
+63 - Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno
+64 - Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas no Mercado Interno e de Exportação
+65 - Crédito Presumido - Operação de Aquisição Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação
+66 - Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno, e de Exportação
+67 - Crédito Presumido - Outras Operações
+70 - Operação de Aquisição sem Direito a Crédito
+71 - Operação de Aquisição com Isenção
+72 - Operação de Aquisição com Suspensão
+73 - Operação de Aquisição a Alíquota Zero
+74 - Operação de Aquisição sem Incidência da Contribuição
+75 - Operação de Aquisição por Substituição Tributária
+98 - Outras Operações de Entrada
+99 - Outras Operações.</xs:documentation>
+																</xs:annotation>
+																<xs:complexType>
+																	<xs:sequence>
+																		<xs:element name="CST">
+																			<xs:annotation>
+																				<xs:documentation>Código de Situação Tributária do COFINS:
+49 - Outras Operações de Saída
+50 - Operação com Direito a Crédito - Vinculada Exclusivamente a Receita Tributada no Mercado Interno
+51 - Operação com Direito a Crédito – Vinculada Exclusivamente a Receita Não Tributada no Mercado Interno
+52 - Operação com Direito a Crédito - Vinculada Exclusivamente a Receita de Exportação
+53 - Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno
+54 - Operação com Direito a Crédito - Vinculada a Receitas Tributadas no Mercado Interno e de Exportação
+55 - Operação com Direito a Crédito - Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação
+56 - Operação com Direito a Crédito - Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno, e de Exportação
+60 - Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Tributada no Mercado Interno
+61 - Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita Não-Tributada no Mercado Interno
+62 - Crédito Presumido - Operação de Aquisição Vinculada Exclusivamente a Receita de Exportação
+63 - Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno
+64 - Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas no Mercado Interno e de Exportação
+65 - Crédito Presumido - Operação de Aquisição Vinculada a Receitas Não-Tributadas no Mercado Interno e de Exportação
+66 - Crédito Presumido - Operação de Aquisição Vinculada a Receitas Tributadas e Não-Tributadas no Mercado Interno, e de Exportação
+67 - Crédito Presumido - Outras Operações
+70 - Operação de Aquisição sem Direito a Crédito
+71 - Operação de Aquisição com Isenção
+72 - Operação de Aquisição com Suspensão
+73 - Operação de Aquisição a Alíquota Zero
+74 - Operação de Aquisição sem Incidência da Contribuição
+75 - Operação de Aquisição por Substituição Tributária
+98 - Outras Operações de Entrada
+99 - Outras Operações.</xs:documentation>
+																			</xs:annotation>
+																			<xs:simpleType>
+																				<xs:restriction base="xs:string">
+																					<xs:whiteSpace value="preserve"/>
+																					<xs:enumeration value="49"/>
+																					<xs:enumeration value="50"/>
+																					<xs:enumeration value="51"/>
+																					<xs:enumeration value="52"/>
+																					<xs:enumeration value="53"/>
+																					<xs:enumeration value="54"/>
+																					<xs:enumeration value="55"/>
+																					<xs:enumeration value="56"/>
+																					<xs:enumeration value="60"/>
+																					<xs:enumeration value="61"/>
+																					<xs:enumeration value="62"/>
+																					<xs:enumeration value="63"/>
+																					<xs:enumeration value="64"/>
+																					<xs:enumeration value="65"/>
+																					<xs:enumeration value="66"/>
+																					<xs:enumeration value="67"/>
+																					<xs:enumeration value="70"/>
+																					<xs:enumeration value="71"/>
+																					<xs:enumeration value="72"/>
+																					<xs:enumeration value="73"/>
+																					<xs:enumeration value="74"/>
+																					<xs:enumeration value="75"/>
+																					<xs:enumeration value="98"/>
+																					<xs:enumeration value="99"/>
+																				</xs:restriction>
+																			</xs:simpleType>
+																		</xs:element>
+																		<xs:choice>
+																			<xs:sequence>
+																				<xs:element name="vBC" type="TDec_1302">
+																					<xs:annotation>
+																						<xs:documentation>Valor da BC do COFINS</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="pCOFINS" type="TDec_0302a04">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do COFINS (em percentual)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																			</xs:sequence>
+																			<xs:sequence>
+																				<xs:element name="qBCProd" type="TDec_1204v">
+																					<xs:annotation>
+																						<xs:documentation>Quantidade Vendida (NT2011/004)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																				<xs:element name="vAliqProd" type="TDec_1104v">
+																					<xs:annotation>
+																						<xs:documentation>Alíquota do COFINS (em reais) (NT2011/004)</xs:documentation>
+																					</xs:annotation>
+																				</xs:element>
+																			</xs:sequence>
+																		</xs:choice>
+																		<xs:element name="vCOFINS" type="TDec_1302">
+																			<xs:annotation>
+																				<xs:documentation>Valor do COFINS</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																	</xs:sequence>
+																</xs:complexType>
+															</xs:element>
+														</xs:choice>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="COFINSST" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Dados do COFINS da
+Substituição Tributaria;</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:choice>
+																<xs:sequence>
+																	<xs:element name="vBC" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor da BC do COFINS ST</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="pCOFINS" type="TDec_0302a04">
+																		<xs:annotation>
+																			<xs:documentation>Alíquota do COFINS ST(em percentual)</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																</xs:sequence>
+																<xs:sequence>
+																	<xs:element name="qBCProd" type="TDec_1204">
+																		<xs:annotation>
+																			<xs:documentation>Quantidade Vendida</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vAliqProd" type="TDec_1104">
+																		<xs:annotation>
+																			<xs:documentation>Alíquota do COFINS ST(em reais)</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																</xs:sequence>
+															</xs:choice>
+															<xs:element name="vCOFINS" type="TDec_1302">
+																<xs:annotation>
+																	<xs:documentation>Valor do COFINS ST</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="indSomaCOFINSST" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Indica se o valor da COFINS ST compõe o valor total da NFe</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:enumeration value="0"/>
+																		<xs:enumeration value="1"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="ICMSUFDest" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Grupo a ser informado nas vendas interestarduais para consumidor final, não contribuinte de ICMS</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="vBCUFDest" type="TDec_1302">
+																<xs:annotation>
+																	<xs:documentation>Valor da Base de Cálculo do ICMS na UF do destinatário.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="vBCFCPUFDest" type="TDec_1302" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Valor da Base de Cálculo do FCP na UF do destinatário.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="pFCPUFDest" type="TDec_0302a04" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Percentual adicional inserido na alíquota interna da UF de destino, relativo ao Fundo de Combate à Pobreza (FCP) naquela UF.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="pICMSUFDest" type="TDec_0302a04">
+																<xs:annotation>
+																	<xs:documentation>Alíquota adotada nas operações internas na UF do destinatário para o produto / mercadoria.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="pICMSInter">
+																<xs:annotation>
+																	<xs:documentation>Alíquota interestadual das UF envolvidas: - 4% alíquota interestadual para produtos importados; - 7% para os Estados de origem do Sul e Sudeste (exceto ES), destinado para os Estados do Norte e Nordeste  ou ES; - 12% para os demais casos.</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:enumeration value="4.00"/>
+																		<xs:enumeration value="7.00"/>
+																		<xs:enumeration value="12.00"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="pICMSInterPart" type="TDec_0302a04">
+																<xs:annotation>
+																	<xs:documentation>Percentual de partilha para a UF do destinatário: - 40% em 2016; - 60% em 2017; - 80% em 2018; - 100% a partir de 2019.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="vFCPUFDest" type="TDec_1302" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Valor do ICMS relativo ao Fundo de Combate à Pobreza (FCP) da UF de destino.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="vICMSUFDest" type="TDec_1302">
+																<xs:annotation>
+																	<xs:documentation>Valor do ICMS de partilha para a UF do destinatário.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="vICMSUFRemet" type="TDec_1302">
+																<xs:annotation>
+																	<xs:documentation>Valor do ICMS de partilha para a UF do remetente. Nota: A partir de 2019, este valor será zero.</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="IS" type="TIS" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Grupo de informações do Imposto Seletivo</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="IBSCBS" type="TTribNFe" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Grupo de informações dos tributos IBS, CBS e Imposto Seletivo</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="impostoDevol" minOccurs="0">
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="pDevol" type="TDec_0302Max100">
+													<xs:annotation>
+														<xs:documentation>Percentual de mercadoria devolvida</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="IPI">
+													<xs:annotation>
+														<xs:documentation>Informação de IPI devolvido</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="vIPIDevol" type="TDec_1302">
+																<xs:annotation>
+																	<xs:documentation>Valor do IPI devolvido</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="infAdProd" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações adicionais do produto (norma referenciada, informações complementares, etc)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="500"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="obsItem" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Grupo de observações de uso livre (para o item da NF-e) </xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="obsCont" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Grupo de observações de uso livre (para o item da NF-e) </xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="xTexto">
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="60"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+														<xs:attribute name="xCampo" use="required">
+															<xs:simpleType>
+																<xs:restriction base="TString">
+																	<xs:minLength value="1"/>
+																	<xs:maxLength value="20"/>
+																</xs:restriction>
+															</xs:simpleType>
+														</xs:attribute>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="obsFisco" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Grupo de observações de uso livre (para o item da NF-e) </xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="xTexto">
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="60"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+														<xs:attribute name="xCampo" use="required">
+															<xs:simpleType>
+																<xs:restriction base="TString">
+																	<xs:minLength value="1"/>
+																	<xs:maxLength value="20"/>
+																</xs:restriction>
+															</xs:simpleType>
+														</xs:attribute>
+													</xs:complexType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="vItem" type="TDec_1302" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor total do Item, correspondente à sua participação no total da nota. A soma dos itens deverá corresponder ao total da nota.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="DFeReferenciado" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Referenciamento de item de outros DFe</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="chaveAcesso" type="TChNFe">
+													<xs:annotation>
+														<xs:documentation>Chave de Acesso do DFe referenciado</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="nItem" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Número do item do documento referenciado. Corresponde ao atributo nItem do elemento det do documento original.</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="[1-9]{1}[0-9]{0,1}|[1-8]{1}[0-9]{2}|[9]{1}[0-8]{1}[0-9]{1}|[9]{1}[9]{1}[0]{1}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+								<xs:attribute name="nItem" use="required">
+									<xs:annotation>
+										<xs:documentation>Número do item do NF</xs:documentation>
+									</xs:annotation>
+									<xs:simpleType>
+										<xs:restriction base="xs:string">
+											<xs:whiteSpace value="preserve"/>
+											<xs:pattern value="[1-9]{1}[0-9]{0,1}|[1-8]{1}[0-9]{2}|[9]{1}[0-8]{1}[0-9]{1}|[9]{1}[9]{1}[0]{1}"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="total">
+							<xs:annotation>
+								<xs:documentation>Dados dos totais da NF-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="ICMSTot">
+										<xs:annotation>
+											<xs:documentation>Totais referentes ao ICMS</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="vBC" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>BC do ICMS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMS" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do ICMS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSDeson" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do ICMS desonerado</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vFCPUFDest" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor total do ICMS relativo ao Fundo de Combate à Pobreza (FCP) para a UF de destino.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSUFDest" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor total do ICMS de partilha para a UF do destinatário</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSUFRemet" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor total do ICMS de partilha para a UF do remetente</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vFCP" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do FCP (Fundo de Combate à Pobreza).</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vBCST" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>BC do ICMS ST</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vST" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do ICMS ST</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vFCPST" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do FCP (Fundo de Combate à Pobreza) retido por substituição tributária.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vFCPSTRet" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do FCP (Fundo de Combate à Pobreza) retido anteriormente por substituição tributária.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="qBCMono" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor total da quantidade tributada do ICMS monofásico próprio</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSMono" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor total do ICMS monofásico próprio</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="qBCMonoReten" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor total da quantidade tributada do ICMS monofásico sujeito a retenção</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSMonoReten" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor total do ICMS monofásico sujeito a retenção</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="qBCMonoRet" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor total da quantidade tributada do ICMS monofásico retido anteriormente</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSMonoRet" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS monofásico retido anteriormente</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vProd" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total dos produtos e serviços</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vFrete" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do Frete</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vSeg" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do Seguro</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vDesc" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do Desconto</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vII" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do II</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vIPI" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do IPI</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vIPIDevol" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total do IPI devolvido. Deve ser informado quando preenchido o Grupo Tributos Devolvidos na emissão de nota finNFe=4 (devolução) nas operações com não contribuintes do IPI. Corresponde ao total da soma dos campos id: UA04.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vPIS" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do PIS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vCOFINS" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do COFINS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vOutro" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Outras Despesas acessórias</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vNF" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Total da NF-e</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vTotTrib" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor estimado total de impostos federais, estaduais e municipais</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="ISSQNtot" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Totais referentes ao ISSQN</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="vServ" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor Total dos Serviços sob não-incidência ou não tributados pelo ICMS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vBC" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Base de Cálculo do ISS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vISS" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor Total do ISS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vPIS" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor do PIS sobre serviços</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vCOFINS" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor do COFINS sobre serviços</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="dCompet" type="TData">
+													<xs:annotation>
+														<xs:documentation>Data da prestação do serviço  (AAAA-MM-DD)</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vDeducao" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor dedução para redução da base de cálculo</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vOutro" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor outras retenções</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vDescIncond" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor desconto incondicionado</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vDescCond" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor desconto condicionado</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vISSRet" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor Total Retenção ISS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="cRegTrib" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Código do regime especial de tributação</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:enumeration value="1"/>
+															<xs:enumeration value="2"/>
+															<xs:enumeration value="3"/>
+															<xs:enumeration value="4"/>
+															<xs:enumeration value="5"/>
+															<xs:enumeration value="6"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="retTrib" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Retenção de Tributos Federais</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="vRetPIS" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor Retido de PIS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vRetCOFINS" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor Retido de COFINS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vRetCSLL" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor Retido de CSLL</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vBCIRRF" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Base de Cálculo do IRRF</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vIRRF" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor Retido de IRRF</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vBCRetPrev" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Base de Cálculo da Retenção da Previdêncica Social</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vRetPrev" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor da Retenção da Previdêncica Social</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="ISTot" type="TISTot" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valores totais da NF com Imposto Seletivo</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="IBSCBSTot" type="TIBSCBSMonoTot" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valores totais da NF com IBS / CBS</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vNFTot" type="TDec_1302Opc" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor Total da NF considerando os impostos por fora IBS, CBS e IS</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="transp">
+							<xs:annotation>
+								<xs:documentation>Dados dos transportes da NF-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="modFrete">
+										<xs:annotation>
+											<xs:documentation>Modalidade do frete
+0- Contratação do Frete por conta do Remetente (CIF);
+1- Contratação do Frete por conta do destinatário/remetente (FOB);
+2- Contratação do Frete por conta de terceiros;
+3- Transporte próprio por conta do remetente;
+4- Transporte próprio por conta do destinatário;
+9- Sem Ocorrência de transporte.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="3"/>
+												<xs:enumeration value="4"/>
+												<xs:enumeration value="9"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="transporta" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Dados do transportador</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:choice minOccurs="0">
+													<xs:element name="CNPJ" type="TCnpj">
+														<xs:annotation>
+															<xs:documentation>CNPJ do transportador</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="CPF" type="TCpf">
+														<xs:annotation>
+															<xs:documentation>CPF do transportador</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:choice>
+												<xs:element name="xNome" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Razão Social ou nome do transportador</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="60"/>
+															<xs:minLength value="2"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="IE" type="TIeDest" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Inscrição Estadual (v2.0)</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="xEnder" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Endereço completo</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="xMun" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Nome do munícipio</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="60"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="UF" type="TUf" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Sigla da UF</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="retTransp" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Dados da retenção  ICMS do Transporte</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="vServ" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do Serviço</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vBCRet" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>BC da Retenção do ICMS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pICMSRet" type="TDec_0302a04">
+													<xs:annotation>
+														<xs:documentation>Alíquota da Retenção</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSRet" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS Retido</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="CFOP">
+													<xs:annotation>
+														<xs:documentation>Código Fiscal de Operações e Prestações</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="[1,2,3,5,6,7]{1}[0-9]{3}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="cMunFG" type="TCodMunIBGE">
+													<xs:annotation>
+														<xs:documentation>Código do Município de Ocorrência do Fato Gerador (utilizar a tabela do IBGE)</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:choice>
+										<xs:sequence minOccurs="0">
+											<xs:element name="veicTransp" type="TVeiculo" minOccurs="0">
+												<xs:annotation>
+													<xs:documentation>Dados do veículo</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+											<xs:element name="reboque" type="TVeiculo" minOccurs="0" maxOccurs="5">
+												<xs:annotation>
+													<xs:documentation>Dados do reboque/Dolly (v2.0)</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+										</xs:sequence>
+										<xs:element name="vagao" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Identificação do vagão (v2.0)</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="1"/>
+													<xs:maxLength value="20"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="balsa" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Identificação da balsa (v2.0)</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="1"/>
+													<xs:maxLength value="20"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="vol" minOccurs="0" maxOccurs="5000">
+										<xs:annotation>
+											<xs:documentation>Dados dos volumes</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="qVol" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Quantidade de volumes transportados</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="[0-9]{1,15}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="esp" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Espécie dos volumes transportados</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="marca" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Marca dos volumes transportados</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="nVol" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Numeração dos volumes transportados</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="pesoL" type="TDec_1203" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Peso líquido (em kg)</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pesoB" type="TDec_1203" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Peso bruto (em kg)</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="lacres" minOccurs="0" maxOccurs="5000">
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="nLacre">
+																<xs:annotation>
+																	<xs:documentation>Número dos Lacres</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="60"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="cobr" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Dados da cobrança da NF-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="fat" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Dados da fatura</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="nFat" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Número da fatura</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="vOrig" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor original da fatura</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vDesc" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor do desconto da fatura</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vLiq" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor líquido da fatura</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="dup" minOccurs="0" maxOccurs="120">
+										<xs:annotation>
+											<xs:documentation>Dados das duplicatas NT 2011/004</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="nDup" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Número da duplicata</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="60"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="dVenc" type="TData" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Data de vencimento da duplicata (AAAA-MM-DD)</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vDup" type="TDec_1302Opc">
+													<xs:annotation>
+														<xs:documentation>Valor da duplicata</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="pag">
+							<xs:annotation>
+								<xs:documentation>Dados de Pagamento. Obrigatório apenas para (NFC-e) NT 2012/004</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="detPag" maxOccurs="100">
+										<xs:annotation>
+											<xs:documentation>Grupo de detalhamento da forma de pagamento.</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="indPag" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Indicador da Forma de Pagamento:0-Pagamento à Vista;1-Pagamento à Prazo;</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:enumeration value="0"/>
+															<xs:enumeration value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="tPag">
+													<xs:annotation>
+														<xs:documentation>Forma de Pagamento:</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="[0-9]{2}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="xPag" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Descrição do Meio de Pagamento</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="2"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="vPag" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do Pagamento. Esta tag poderá ser omitida quando a tag tPag=90 (Sem Pagamento), caso contrário deverá ser preenchida.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="dPag" type="TData" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Data do Pagamento</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:sequence minOccurs="0">
+													<xs:element name="CNPJPag" type="TCnpj">
+														<xs:annotation>
+															<xs:documentation>CNPJ transacional do pagamento - Preencher informando o CNPJ do estabelecimento onde o pagamento foi processado/transacionado/recebido quando a emissão do documento fiscal ocorrer em estabelecimento distinto</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="UFPag" type="TUfEmi">
+														<xs:annotation>
+															<xs:documentation>UF do CNPJ do estabelecimento onde o pagamento foi processado/transacionado/recebido.</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+												<xs:element name="card" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Grupo de Cartões, PIX, Boletos e outros Pagamentos Eletrônicos</xs:documentation>
+													</xs:annotation>
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="tpIntegra">
+																<xs:annotation>
+																	<xs:documentation>Tipo de Integração do processo de pagamento com o sistema de automação da empresa:
+1 - Pagamento integrado com o sistema de automação da empresa (Ex.: equipamento TEF, Comércio Eletrônico, POS Integrado);
+2 - Pagamento não integrado com o sistema de automação da empresa (Ex.: equipamento POS Simples).</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:enumeration value="1"/>
+																		<xs:enumeration value="2"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="CNPJ" type="TCnpj" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>CNPJ da instituição de pagamento</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="tBand" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Bandeira da operadora de cartão</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="xs:string">
+																		<xs:whiteSpace value="preserve"/>
+																		<xs:pattern value="[0-9]{2}"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="cAut" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Número de autorização da operação com cartões, PIX, boletos e outros pagamentos eletrônicos</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="128"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+															<xs:element name="CNPJReceb" type="TCnpj" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>CNPJ do beneficiário do pagamento</xs:documentation>
+																</xs:annotation>
+															</xs:element>
+															<xs:element name="idTermPag" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Identificador do terminal de pagamento</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="40"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="vTroco" type="TDec_1302" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor do Troco.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infIntermed" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de Informações do Intermediador da Transação</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="CNPJ" type="TCnpj">
+										<xs:annotation>
+											<xs:documentation>CNPJ do Intermediador da Transação (agenciador, plataforma de delivery, marketplace e similar) de serviços e de negócios.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="idCadIntTran">
+										<xs:annotation>
+											<xs:documentation>Identificador cadastrado no intermediador</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infAdic" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações adicionais da NF-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="infAdFisco" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações adicionais de interesse do Fisco (v2.0)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="2000"/>
+												<xs:minLength value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="infCpl" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações complementares de interesse do Contribuinte</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="5000"/>
+												<xs:minLength value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="obsCont" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Campo de uso livre do contribuinte
+informar o nome do campo no atributo xCampo
+e o conteúdo do campo no xTexto</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xTexto">
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="xCampo" use="required">
+												<xs:simpleType>
+													<xs:restriction base="TString">
+														<xs:minLength value="1"/>
+														<xs:maxLength value="20"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="obsFisco" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Campo de uso exclusivo do Fisco
+informar o nome do campo no atributo xCampo
+e o conteúdo do campo no xTexto</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xTexto">
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="xCampo" use="required">
+												<xs:simpleType>
+													<xs:restriction base="TString">
+														<xs:minLength value="1"/>
+														<xs:maxLength value="20"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="procRef" minOccurs="0" maxOccurs="100">
+										<xs:annotation>
+											<xs:documentation>Grupo de informações do  processo referenciado</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="nProc">
+													<xs:annotation>
+														<xs:documentation>Indentificador do processo ou ato
+concessório</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="indProc">
+													<xs:annotation>
+														<xs:documentation>Origem do processo, informar com:
+0 - SEFAZ;
+1 - Justiça Federal;
+2 - Justiça Estadual;
+3 - Secex/RFB;
+4 - CONFAZ;
+9 - Outros.</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:enumeration value="0"/>
+															<xs:enumeration value="1"/>
+															<xs:enumeration value="2"/>
+															<xs:enumeration value="3"/>
+															<xs:enumeration value="4"/>
+															<xs:enumeration value="9"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="tpAto" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Tipo do ato concessório
+														Para origem do Processo na SEFAZ (indProc=0), informar o
+tipo de ato concessório:
+08 - Termo de Acordo;
+10 - Regime Especial;
+12 - Autorização específica;
+14 - Ajuste SINIEF;
+15 - Convênio ICMS.</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:enumeration value="08"/>
+															<xs:enumeration value="10"/>
+															<xs:enumeration value="12"/>
+															<xs:enumeration value="14"/>
+															<xs:enumeration value="15"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="exporta" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações de exportação</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="UFSaidaPais" type="TUfEmi">
+										<xs:annotation>
+											<xs:documentation>Sigla da UF de Embarque ou de transposição de fronteira</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="xLocExporta">
+										<xs:annotation>
+											<xs:documentation>Local de Embarque ou de transposição de fronteira</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xLocDespacho" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Descrição do local de despacho</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="compra" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações de compras  (Nota de Empenho, Pedido e Contrato)</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="xNEmp" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informação da Nota de Empenho de compras públicas (NT2011/004)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="22"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xPed" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informação do pedido</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xCont" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informação do contrato</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="cana" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações de registro aquisições de cana</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="safra">
+										<xs:annotation>
+											<xs:documentation>Identificação da safra</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="4"/>
+												<xs:maxLength value="9"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="ref">
+										<xs:annotation>
+											<xs:documentation>Mês e Ano de Referência, formato: MM/AAAA</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="(0[1-9]|1[0-2])([/][2][0-9][0-9][0-9])"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="forDia" maxOccurs="31">
+										<xs:annotation>
+											<xs:documentation>Fornecimentos diários</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="qtde" type="TDec_1110v">
+													<xs:annotation>
+														<xs:documentation>Quantidade em quilogramas - peso líquido</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="dia" use="required">
+												<xs:annotation>
+													<xs:documentation>Número do dia</xs:documentation>
+												</xs:annotation>
+												<xs:simpleType>
+													<xs:restriction base="xs:string">
+														<xs:whiteSpace value="preserve"/>
+														<xs:pattern value="[1-9]|[1][0-9]|[2][0-9]|[3][0-1]"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+										<xs:unique name="pk_Dia">
+											<xs:selector xpath="./*"/>
+											<xs:field xpath="@dia"/>
+										</xs:unique>
+									</xs:element>
+									<xs:element name="qTotMes" type="TDec_1110v">
+										<xs:annotation>
+											<xs:documentation>Total do mês</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="qTotAnt" type="TDec_1110v">
+										<xs:annotation>
+											<xs:documentation>Total Anterior</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="qTotGer" type="TDec_1110v">
+										<xs:annotation>
+											<xs:documentation>Total Geral</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="deduc" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Deduções - Taxas e Contribuições</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xDed">
+													<xs:annotation>
+														<xs:documentation>Descrição da Dedução</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="vDed" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>valor da dedução</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="vFor" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor  dos fornecimentos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vTotDed" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor Total das Deduções</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vLiqFor" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor Líquido dos fornecimentos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infRespTec" type="TInfRespTec" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do Responsável Técnico pela emissão do DF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="infSolicNFF" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo para informações da solicitação da NFF</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="xSolic">
+										<xs:annotation>
+											<xs:documentation>Solicitação do pedido de emissão da NFF</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="5000"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="agropecuario" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Produtos Agropecurários Animais, Vegetais e Florestais</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:choice>
+									<xs:element name="defensivo" maxOccurs="20">
+										<xs:annotation>
+											<xs:documentation>Defensivo Agrícola / Agrotóxico</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="nReceituario">
+													<xs:annotation>
+														<xs:documentation>Número do Receituário ou Receita do Defensivo / Agrotóxico</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="30"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="CPFRespTec" type="TCpf">
+													<xs:annotation>
+														<xs:documentation>CPF do Responsável Técnico pelo receituário</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="guiaTransito">
+										<xs:annotation>
+											<xs:documentation>Guias De Trânsito de produtos agropecurários animais, vegetais e de origem florestal.</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="tpGuia">
+													<xs:annotation>
+														<xs:documentation>Tipo da Guia: 1 - GTA; 2 - TTA; 3 - DTA; 4 - ATV; 5 - PTV; 6 - GTV; 7 - Guia Florestal (DOF, SisFlora - PA e MT, SIAM - MG)</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:enumeration value="1"/>
+															<xs:enumeration value="2"/>
+															<xs:enumeration value="3"/>
+															<xs:enumeration value="4"/>
+															<xs:enumeration value="5"/>
+															<xs:enumeration value="6"/>
+															<xs:enumeration value="7"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="UFGuia" type="TUfEmi"/>
+												<xs:element name="serieGuia" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Série da Guia</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="9"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="nGuia">
+													<xs:annotation>
+														<xs:documentation>Número da Guia</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:pattern value="[0-9]{1,9}"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:choice>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="versao" type="TVerNFe" use="required">
+						<xs:annotation>
+							<xs:documentation>Versão do leiaute (v4.00)</xs:documentation>
+						</xs:annotation>
+					</xs:attribute>
+					<xs:attribute name="Id" use="required">
+						<xs:annotation>
+							<xs:documentation>PL_005d - 11/08/09 - validação do Id</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:ID">
+								<xs:pattern value="NFe[0-9]{44}"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+				<xs:unique name="pk_nItem">
+					<xs:selector xpath="./*"/>
+					<xs:field xpath="@nItem"/>
+				</xs:unique>
+			</xs:element>
+			<xs:element name="infNFeSupl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informações suplementares Nota Fiscal</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="qrCode">
+							<xs:annotation>
+								<xs:documentation>Texto com o QR-Code impresso no DANFE NFC-e</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:minLength value="60"/>
+									<xs:maxLength value="1000"/>
+									<!--QRCODE V1-->
+									<xs:pattern value="((HTTPS?|https?)://.*\?chNFe=[0-9]{44}&amp;nVersao=100&amp;tpAmb=[1-2](&amp;cDest=([A-Za-z0-9.:+-/)(]{0}|[A-Za-z0-9.:+-/)(]{5,20})?)?&amp;dhEmi=[A-Fa-f0-9]{50}&amp;vNF=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;vICMS=(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)&amp;digVal=[A-Fa-f0-9]{56}&amp;cIdToken=[0-9]{6}&amp;cHashQRCode=[A-Fa-f0-9]{40})"/>
+									<!--QRCODE V2 ONLINE-->
+									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{34}(1|3|4)[0-9]{9})\|[2]\|[1-2]\|(0|[1-9]{1}([0-9]{1,5})?)\|[A-Fa-f0-9]{40})"/>
+									<!--QRCODE V2 OFFLINE-->
+									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{34}9[0-9]{9})\|[2]\|[1-2]\|([0]{1}[1-9]{1}|[1-2]{1}[0-9]{1}|[3]{1}[0-1]{1})\|(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)\|[A-Fa-f0-9]{56}\|(0|[1-9]{1}([0-9]{1,5})?)\|[A-Fa-f0-9]{40})"/>
+									<!--QRCODE V3 ONLINE-->
+									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{34}(1|3|4)[0-9]{9})\|[3]\|[1-2])"/>
+									<!--QRCODE V3 OFFLINE-->
+									<xs:pattern value="((HTTPS?|https?)://.*\?p=([0-9]{34}(9)[0-9]{9})\|[3]\|[1-2]\|([0]{1}[1-9]{1}|[1-2]{1}[0-9]{1}|[3]{1}[0-1]{1})\|(0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?)\|((1|2|3)?)\|(([0-9]{3,14})?)\|([a-zA-Z0-9+/]+[=]{0,2}))"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="urlChave">
+							<xs:annotation>
+								<xs:documentation>Informar a URL da &quot;Consulta por chave de acesso da NFC-e&quot;. A mesma URL que deve estar informada no DANFE NFC-e para consulta por chave de acesso.</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TString">
+									<xs:minLength value="21"/>
+									<xs:maxLength value="85"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TProtNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Protocolo de status resultado do processamento da NF-e</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infProt">
+				<xs:annotation>
+					<xs:documentation>Dados do protocolo de status</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="verAplic" type="TVerAplic">
+							<xs:annotation>
+								<xs:documentation>Versão do Aplicativo que processou a NF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="chNFe" type="TChNFe">
+							<xs:annotation>
+								<xs:documentation>Chaves de acesso da NF-e, compostas por: UF do emitente, AAMM da emissão da NFe, CNPJ do emitente, modelo, série e número da NF-e e código numérico+DV.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="dhRecbto" type="TDateTimeUTC">
+							<xs:annotation>
+								<xs:documentation>Data e hora de processamento, no formato AAAA-MM-DDTHH:MM:SSTZD. Deve ser preenchida com data e hora da gravação no Banco em caso de Confirmação. Em caso de Rejeição, com data e hora do recebimento do Lote de NF-e enviado.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nProt" type="TProt" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número do Protocolo de Status da NF-e. 1 posição (1 – Secretaria de Fazenda Estadual 2 – Receita Federal); 2 - códiga da UF - 2 posições ano; 10 seqüencial no ano.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="digVal" type="ds:DigestValueType" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Digest Value da NF-e processada. Utilizado para conferir a integridade da NF-e original.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cStat" type="TStat">
+							<xs:annotation>
+								<xs:documentation>Código do status da mensagem enviada.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="xMotivo" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Descrição literal do status do serviço solicitado.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:sequence minOccurs="0">
+							<xs:element name="cMsg">
+								<xs:annotation>
+									<xs:documentation>Código da Mensagem.</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:pattern value="[0-9]{1,4}"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="xMsg">
+								<xs:annotation>
+									<xs:documentation>Mensagem da SEFAZ para o emissor.</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="200"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:sequence>
+					<xs:attribute name="Id" type="xs:ID" use="optional"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TEnviNFe">
+		<xs:annotation>
+			<xs:documentation> Tipo Pedido de Concessão de Autorização da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="idLote" type="TIdLote"/>
+			<xs:element name="indSinc">
+				<xs:annotation>
+					<xs:documentation>Indicador de processamento síncrono. 0=NÃO; 1=SIM=Síncrono</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:enumeration value="0"/>
+						<xs:enumeration value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="NFe" type="TNFe" maxOccurs="50"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetEnviNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Retorno do Pedido de Autorização da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="verAplic" type="TVerAplic">
+				<xs:annotation>
+					<xs:documentation>Versão do Aplicativo que recebeu o Lote.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cStat" type="TStat">
+				<xs:annotation>
+					<xs:documentation>Código do status da mensagem enviada.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMotivo" type="TMotivo">
+				<xs:annotation>
+					<xs:documentation>Descrição literal do status do serviço solicitado.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>código da UF de atendimento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="dhRecbto" type="TDateTimeUTC">
+				<xs:annotation>
+					<xs:documentation>Data e hora do recebimento, no formato AAAA-MM-DDTHH:MM:SSTZD</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice>
+				<xs:element name="infRec" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Dados do Recibo do Lote</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="nRec" type="TRec">
+								<xs:annotation>
+									<xs:documentation>Número do Recibo</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="tMed" type="TMed">
+								<xs:annotation>
+									<xs:documentation>Tempo médio de resposta do serviço (em segundos) dos últimos 5 minutos</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="protNFe" type="TProtNFe" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Protocolo de status resultado do processamento sincrono da NFC-e</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TConsReciNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Pedido de Consulta do Recido do Lote de Notas Fiscais Eletrônicas</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="nRec" type="TRec">
+				<xs:annotation>
+					<xs:documentation>Número do Recibo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetConsReciNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Retorno do Pedido de  Consulta do Recido do Lote de Notas Fiscais Eletrônicas</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="verAplic" type="TVerAplic">
+				<xs:annotation>
+					<xs:documentation>Versão do Aplicativo que processou a NF-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="nRec" type="TRec">
+				<xs:annotation>
+					<xs:documentation>Número do Recibo Consultado</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cStat" type="TStat">
+				<xs:annotation>
+					<xs:documentation>Código do status da mensagem enviada.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMotivo" type="TMotivo">
+				<xs:annotation>
+					<xs:documentation>Descrição literal do status do serviço solicitado.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>código da UF de atendimento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="dhRecbto" type="TDateTimeUTC">
+				<xs:annotation>
+					<xs:documentation>Data e hora de processamento, no formato AAAA-MM-DDTHH:MM:SSTZD. Em caso de Rejeição, com data e hora do recebimento do Lote de NF-e enviado.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:sequence minOccurs="0">
+				<xs:element name="cMsg">
+					<xs:annotation>
+						<xs:documentation>Código da Mensagem (v2.0) 
+alterado para tamanho variavel 1-4. (NT2011/004)</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:pattern value="[0-9]{1,4}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="xMsg">
+					<xs:annotation>
+						<xs:documentation>Mensagem da SEFAZ para o emissor. (v2.0)</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TString">
+							<xs:minLength value="1"/>
+							<xs:maxLength value="200"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+			<xs:element name="protNFe" type="TProtNFe" minOccurs="0" maxOccurs="50">
+				<xs:annotation>
+					<xs:documentation>Protocolo de status resultado do processamento da NF-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TNfeProc">
+		<xs:annotation>
+			<xs:documentation> Tipo da NF-e processada</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="NFe" type="TNFe"/>
+			<xs:element name="protNFe" type="TProtNFe"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerNFe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TEndereco">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Endereço  // 24/10/08 - tamanho mínimo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="xLgr">
+				<xs:annotation>
+					<xs:documentation>Logradouro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="nro">
+				<xs:annotation>
+					<xs:documentation>Número</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xCpl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Complemento</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xBairro">
+				<xs:annotation>
+					<xs:documentation>Bairro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cMun" type="TCodMunIBGE">
+				<xs:annotation>
+					<xs:documentation>Código do município (utilizar a tabela do IBGE), informar 9999999 para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMun">
+				<xs:annotation>
+					<xs:documentation>Nome do município, informar EXTERIOR para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUf">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF, informar EX para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CEP" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>CEP</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{8}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cPais" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Código de Pais</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{1,4}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xPais" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Nome do país</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="fone" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Telefone, preencher com Código DDD + número do telefone , nas operações com exterior é permtido informar o código do país + código da localidade + número do telefone</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{6,14}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TEnderEmi">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Endereço do Emitente  // 24/10/08 - desmembrado / tamanho mínimo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="xLgr">
+				<xs:annotation>
+					<xs:documentation>Logradouro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="nro">
+				<xs:annotation>
+					<xs:documentation>Número</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xCpl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Complemento</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xBairro">
+				<xs:annotation>
+					<xs:documentation>Bairro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cMun" type="TCodMunIBGE">
+				<xs:annotation>
+					<xs:documentation>Código do município</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMun">
+				<xs:annotation>
+					<xs:documentation>Nome do município</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUfEmi">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CEP">
+				<xs:annotation>
+					<xs:documentation>CEP - NT 2011/004</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{8}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cPais" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Código do país</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:enumeration value="1058"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xPais" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Nome do país</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:enumeration value="Brasil"/>
+						<xs:enumeration value="BRASIL"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="fone" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Preencher com Código DDD + número do telefone (v.2.0)</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{6,14}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TLocal">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Local de Retirada ou Entrega // 24/10/08 - tamanho mínimo // v2.0</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="CNPJ" type="TCnpjOpc">
+					<xs:annotation>
+						<xs:documentation>CNPJ</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="CPF" type="TCpf">
+					<xs:annotation>
+						<xs:documentation>CPF (v2.0)</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+			<xs:element name="xNome" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Razão Social ou Nome do Expedidor/Recebedor</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xLgr">
+				<xs:annotation>
+					<xs:documentation>Logradouro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="nro">
+				<xs:annotation>
+					<xs:documentation>Número</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xCpl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Complemento</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xBairro">
+				<xs:annotation>
+					<xs:documentation>Bairro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cMun" type="TCodMunIBGE">
+				<xs:annotation>
+					<xs:documentation>Código do município (utilizar a tabela do IBGE)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMun">
+				<xs:annotation>
+					<xs:documentation>Nome do município</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUf">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CEP" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>CEP</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{8}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cPais" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Código de Pais</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{1,4}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xPais" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Nome do país</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="fone" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Telefone, preencher com Código DDD + número do telefone , nas operações com exterior é permtido informar o código do país + código da localidade + número do telefone</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{6,14}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="email" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informar o e-mail do expedidor/Recebedor. O campo pode ser utilizado para informar o e-mail de recepção da NF-e indicada pelo expedidor</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:whiteSpace value="preserve"/>
+						<xs:minLength value="1"/>
+						<xs:maxLength value="60"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="IE" type="TIe" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Inscrição Estadual (v2.0)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TInfRespTec">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações do responsável técnico pelo sistema de emissão de DF-e</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CNPJ" type="TCnpjOpc">
+				<xs:annotation>
+					<xs:documentation>CNPJ</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xContato">
+				<xs:annotation>
+					<xs:documentation>Informar o nome da pessoa a ser contatada na empresa desenvolvedora do sistema utilizado na emissão do documento fiscal eletrônico.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="email">
+				<xs:annotation>
+					<xs:documentation>Informar o e-mail da pessoa a ser contatada na empresa desenvolvedora do sistema.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:whiteSpace value="preserve"/>
+						<xs:minLength value="6"/>
+						<xs:maxLength value="60"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="fone">
+				<xs:annotation>
+					<xs:documentation>Informar o telefone da pessoa a ser contatada na empresa desenvolvedora do sistema. Preencher com o Código DDD + número do telefone.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{6,14}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:sequence minOccurs="0">
+				<xs:element name="idCSRT">
+					<xs:annotation>
+						<xs:documentation>Identificador do CSRT utilizado para montar o hash do CSRT</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:pattern value="[0-9]{2}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="hashCSRT">
+					<xs:annotation>
+						<xs:documentation>O hashCSRT é o resultado da função hash (SHA-1 – Base64) do CSRT fornecido pelo fisco mais a Chave de Acesso da NFe.</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:base64Binary">
+							<xs:length value="20"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TVeiculo">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Veículo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="placa">
+				<xs:annotation>
+					<xs:documentation>Placa do veículo (NT2011/004)</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[A-Z]{2,3}[0-9]{4}|[A-Z]{3,4}[0-9]{3}|[A-Z0-9]{7}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUf" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="RNTC" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Registro Nacional de Transportador de Carga (ANTT)</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:minLength value="1"/>
+						<xs:maxLength value="20"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="Torig">
+		<xs:annotation>
+			<xs:documentation>Tipo Origem da mercadoria CST ICMS  origem da mercadoria: 0-Nacional exceto as indicadas nos códigos 3, 4, 5 e 8;1-Estrangeira - Importação direta; 2-Estrangeira - Adquirida no mercado interno; 3-Nacional, conteudo superior 40% e inferior ou igual a 70%; 4-Nacional, processos produtivos básicos; 5-Nacional, conteudo inferior 40%; 6-Estrangeira - Importação direta, com similar nacional, lista CAMEX; 7-Estrangeira - mercado interno, sem simular,lista CAMEX;8-Nacional, Conteúdo de Importação superior a 70%.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="0"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+			<xs:enumeration value="3"/>
+			<xs:enumeration value="4"/>
+			<xs:enumeration value="5"/>
+			<xs:enumeration value="6"/>
+			<xs:enumeration value="7"/>
+			<xs:enumeration value="8"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TFinNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Finalidade da NF-e (1=Normal; 2=Complementar; 3=Ajuste; 4=Devolução/Retorno)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+			<xs:enumeration value="3"/>
+			<xs:enumeration value="4"/>
+			<xs:enumeration value="5"/>
+			<xs:enumeration value="6"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TTpNFDebito">
+		<xs:annotation>
+			<xs:documentation>Tipo de Nota de Débito: 
+			01=Transferência de créditos para Cooperativas; 
+			02=Anulação de Crédito por Saídas Imunes/Isentas; 
+			03=Débitos de notas fiscais não processadas na apuração; 
+			04=Multa e juros; 
+			05=Transferência de crédito na sucessão; 
+			06=Pagamento antecipado; 
+			07=Perda em estoque; 
+			08=Desenquadramento do SN;</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="01"/>
+			<xs:enumeration value="02"/>
+			<xs:enumeration value="03"/>
+			<xs:enumeration value="04"/>
+			<xs:enumeration value="05"/>
+			<xs:enumeration value="06"/>
+			<xs:enumeration value="07"/>
+			<xs:enumeration value="08"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TTpNFCredito">
+		<xs:annotation>
+			<xs:documentation>Tipo de Nota de Crédito: 
+			01=Multa e juros; 
+			02=Apropriação de crédito presumido de IBS sobre o saldo devedor na ZFM (art. 450, § 1º, LC 214/25);
+			03=Retorno por recusa na entrega ou por não localização do destinatário na tentativa de entrega;
+			04=Redução de valores;
+			05=Transferência de crédito na sucessão;
+			</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="01"/>
+			<xs:enumeration value="02"/>
+			<xs:enumeration value="03"/>
+			<xs:enumeration value="04"/>
+			<xs:enumeration value="05"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TProcEmi">
+		<xs:annotation>
+			<xs:documentation>Tipo processo de emissão da NF-e</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="0"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+			<xs:enumeration value="3"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCListServ">
+		<xs:annotation>
+			<xs:documentation>Tipo Código da Lista de Serviços LC 116/2003</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{2}.[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TIdLote">
+		<xs:annotation>
+			<xs:documentation> Tipo Identificação de Lote</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{1,15}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TVerNFe">
+		<xs:annotation>
+			<xs:documentation> Tipo Versão da NF-e - 4.00</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="4\.00"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TGuid">
+		<xs:annotation>
+			<xs:documentation>Identificador único (Globally Unique Identifier)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="TIpi">
+		<xs:annotation>
+			<xs:documentation>Tipo: Dados do IPI</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CNPJProd" type="TCnpj" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>CNPJ do produtor da mercadoria, quando diferente do emitente. Somente para os casos de exportação direta ou indireta.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cSelo" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Código do selo de controle do IPI</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:minLength value="1"/>
+						<xs:maxLength value="60"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="qSelo" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Quantidade de selo de controle do IPI</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{1,12}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cEnq">
+				<xs:annotation>
+					<xs:documentation>Código de Enquadramento Legal do IPI (tabela a ser criada pela RFB)</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:minLength value="1"/>
+						<xs:maxLength value="3"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:choice>
+				<xs:element name="IPITrib">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="CST">
+								<xs:annotation>
+									<xs:documentation>Código da Situação Tributária do IPI:
+00-Entrada com recuperação de crédito
+49 - Outras entradas
+50-Saída tributada
+99-Outras saídas</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:enumeration value="00"/>
+										<xs:enumeration value="49"/>
+										<xs:enumeration value="50"/>
+										<xs:enumeration value="99"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:choice>
+								<xs:sequence>
+									<xs:element name="vBC" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor da BC do IPI</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="pIPI" type="TDec_0302a04">
+										<xs:annotation>
+											<xs:documentation>Alíquota do IPI</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+								<xs:sequence>
+									<xs:element name="qUnid" type="TDec_1204v">
+										<xs:annotation>
+											<xs:documentation>Quantidade total na unidade padrão para tributação</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vUnid" type="TDec_1104">
+										<xs:annotation>
+											<xs:documentation>Valor por Unidade Tributável. Informar o valor do imposto Pauta por unidade de medida.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:choice>
+							<xs:element name="vIPI" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do IPI</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="IPINT">
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="CST">
+								<xs:annotation>
+									<xs:documentation>Código da Situação Tributária do IPI:
+01-Entrada tributada com alíquota zero
+02-Entrada isenta
+03-Entrada não-tributada
+04-Entrada imune
+05-Entrada com suspensão
+51-Saída tributada com alíquota zero
+52-Saída isenta
+53-Saída não-tributada
+54-Saída imune
+55-Saída com suspensão</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:enumeration value="01"/>
+										<xs:enumeration value="02"/>
+										<xs:enumeration value="03"/>
+										<xs:enumeration value="04"/>
+										<xs:enumeration value="05"/>
+										<xs:enumeration value="51"/>
+										<xs:enumeration value="52"/>
+										<xs:enumeration value="53"/>
+										<xs:enumeration value="54"/>
+										<xs:enumeration value="55"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/nfe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/nfe_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas-softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteNFe_v4.00.xsd"/>
+	<xs:element name="NFe" type="TNFe">
+		<xs:annotation>
+			<xs:documentation>Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/procInutNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/procInutNFe_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteInutNFe_v4.00.xsd"/>
+	<xs:element name="ProcInutNFe" type="TProcInutNFe">
+		<xs:annotation>
+			<xs:documentation>Pedido de inutilização de númeração de  NF-e processado</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/procNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/procNFe_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/nfe" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteNFe_v4.00.xsd"/>
+	<xs:element name="nfeProc" type="TNfeProc">
+		<xs:annotation>
+			<xs:documentation>NF-e processada</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/retConsReciNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/retConsReciNFe_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteNFe_v4.00.xsd"/>
+	<xs:element name="retConsReciNFe" type="TRetConsReciNFe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do retorno do Pedido de  Consulta do Recido do Lote de Notas Fiscais Eletrônicas</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/retConsSitNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/retConsSitNFe_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteConsSitNFe_v4.00.xsd"/>
+	<xs:element name="retConsSitNFe" type="TRetConsSitNFe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do retorno da consulta da situação atual da NF-e</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/retConsStatServ_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/retConsStatServ_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteConsStatServ_v4.00.xsd"/>
+	<xs:element name="retConsStatServ" type="TRetConsStatServ">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do Resultado da Consulta do Status do Serviço</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/retEnviNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/retEnviNFe_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteNFe_v4.00.xsd"/>
+	<xs:element name="retEnviNFe" type="TRetEnviNFe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do retorno do Pedido de Concessão de Autorização da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/retInutNFe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/retInutNFe_v4.00.xsd
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/nfe" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="leiauteInutNFe_v4.00.xsd"/>
+	<xs:element name="retInutNFe" type="TRetInutNFe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do retorno do Pedido de Inutilização de Numeração da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/tiposBasico_v4.00.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/tiposBasico_v4.00.xsd
@@ -1,0 +1,598 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- PL_008  - 30/07/2013- NT 2013/005 -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:nfe="http://www.portalfiscal.inf.br/nfe" targetNamespace="http://www.portalfiscal.inf.br/nfe" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:simpleType name="TCodUfIBGE">
+		<xs:annotation>
+			<xs:documentation>Tipo Código da UF da tabela do IBGE</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="11"/>
+			<xs:enumeration value="12"/>
+			<xs:enumeration value="13"/>
+			<xs:enumeration value="14"/>
+			<xs:enumeration value="15"/>
+			<xs:enumeration value="16"/>
+			<xs:enumeration value="17"/>
+			<xs:enumeration value="21"/>
+			<xs:enumeration value="22"/>
+			<xs:enumeration value="23"/>
+			<xs:enumeration value="24"/>
+			<xs:enumeration value="25"/>
+			<xs:enumeration value="26"/>
+			<xs:enumeration value="27"/>
+			<xs:enumeration value="28"/>
+			<xs:enumeration value="29"/>
+			<xs:enumeration value="31"/>
+			<xs:enumeration value="32"/>
+			<xs:enumeration value="33"/>
+			<xs:enumeration value="35"/>
+			<xs:enumeration value="41"/>
+			<xs:enumeration value="42"/>
+			<xs:enumeration value="43"/>
+			<xs:enumeration value="50"/>
+			<xs:enumeration value="51"/>
+			<xs:enumeration value="52"/>
+			<xs:enumeration value="53"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCodMunIBGE">
+		<xs:annotation>
+			<xs:documentation>Tipo Código do Município da tabela do IBGE</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{7}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TChNFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Chave da Nota Fiscal Eletrônica</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="44"/>
+			<xs:pattern value="[0-9]{44}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TProt">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do Protocolo de Status</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="17"/>
+			<xs:pattern value="[0-9]{15}|[0-9]{17}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TRec">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do Recibo do envio de lote de NF-e</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="15"/>
+			<xs:pattern value="[0-9]{15}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TStat">
+		<xs:annotation>
+			<xs:documentation>Tipo Código da Mensagem enviada</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="4"/>
+			<xs:pattern value="[0-9]{3,4}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCnpj">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do CNPJ</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="14"/>
+			<xs:pattern value="[0-9]{14}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCnpjVar">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do CNPJ tmanho varíavel (3-14)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="14"/>
+			<xs:pattern value="[0-9]{3,14}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCnpjOpc">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do CNPJ Opcional</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="14"/>
+			<xs:pattern value="[0-9]{0}|[0-9]{14}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCpf">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do CPF</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="11"/>
+			<xs:pattern value="[0-9]{11}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCpfVar">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do CPF de tamanho variável (3-11)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="11"/>
+			<xs:pattern value="[0-9]{3,11}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0104v">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com até 1 dígitos inteiros, podendo ter de 1 até 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{1,4}|[1-9]{1}(\.[0-9]{1,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0204v">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com até 2 dígitos inteiros, podendo ter de 1 até 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{1,4}|[1-9]{1}[0-9]{0,1}(\.[0-9]{1,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0302a04">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com até 3 dígitos inteiros, podendo ter de 2 até 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{2,4}|[1-9]{1}[0-9]{0,2}(\.[0-9]{2,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0302a04Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com até 3 dígitos inteiros e 2 até 4 decimais. Utilizados em TAGs opcionais, não aceita valor zero.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[0-9]{2,4}|[1-9]{1}[0-9]{0,2}(\.[0-9]{2,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0302Max100">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 3 inteiros (no máximo 100), com 2 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0(\.[0-9]{2})?|100(\.00)?|[1-9]{1}[0-9]{0,1}(\.[0-9]{2})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0304Max100">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 3 inteiros (no máximo 100), com 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0(\.[0-9]{4})?|100(\.00)?|[1-9]{1}[0-9]{0,1}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_03v00a04Max100Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 3 inteiros (no máximo 100), com 4 decimais, não aceita valor zero</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0(\.[1-9][0-9]{0,3})|0(\.[0][1-9][0-9]{0,2})|0(\.[0][0][1-9][0-9]{0,1})|0(\.[0][0][0][1-9])|100(\.[0]{1,4})?|[1-9]{1}[0-9]{0,1}(\.[0-9]{1,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0302a04Max100">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 3 inteiros (no máximo 100), com até 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0(\.[0-9]{2,4})?|[1-9]{1}[0-9]{0,1}(\.[0-9]{2,4})?|100(\.0{2,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0803v">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 8 inteiros, podendo ter de 1 até 3 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{3}|[1-9]{1}[0-9]{0,7}(\.[0-9]{1,3})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1104">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 11 inteiros, podendo ter 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{4}|[1-9]{1}[0-9]{0,10}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1104v">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 11 inteiros, podendo ter de 1 até 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{1,4}|[1-9]{1}[0-9]{0,10}|[1-9]{1}[0-9]{0,10}(\.[0-9]{1,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1104Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 11 inteiros, podendo ter 4 decimais (utilizado em tags opcionais)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[1-9]{1}[0-9]{3}|0\.[0-9]{3}[1-9]{1}|0\.[0-9]{2}[1-9]{1}[0-9]{1}|0\.[0-9]{1}[1-9]{1}[0-9]{2}|[1-9]{1}[0-9]{0,10}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1110v">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 11 inteiros, podendo ter de 1 até 10 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{1,10}|[1-9]{1}[0-9]{0,10}|[1-9]{1}[0-9]{0,10}(\.[0-9]{1,10})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1203">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 12 inteiros, podendo ter  3 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{3}|[1-9]{1}[0-9]{0,11}(\.[0-9]{3})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1204">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 12 inteiros e 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{1,4}|[1-9]{1}[0-9]{0,11}|[1-9]{1}[0-9]{0,11}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1204v">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 12 inteiros de 1 até 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{1,4}|[1-9]{1}[0-9]{0,11}|[1-9]{1}[0-9]{0,11}(\.[0-9]{1,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1204Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 12 inteiros com 1 até 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[0-9]{1,4}|[1-9]{1}[0-9]{0,11}|[1-9]{1}[0-9]{0,11}(\.[0-9]{1,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1204temperatura">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 12 inteiros, 1 a 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[1-9]{1}[0-9]{3}|0\.[0-9]{3}[1-9]{1}|0\.[0-9]{2}[1-9]{1}[0-9]{1}|0\.[0-9]{1}[1-9]{1}[0-9]{2}|[1-9]{1}[0-9]{0,11}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1302">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 13 de corpo e 2 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1302Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 13 de corpo e 2 decimais, utilizado em tags opcionais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[0-9]{1}[1-9]{1}|0\.[1-9]{1}[0-9]{1}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TIeDest">
+		<xs:annotation>
+			<xs:documentation>Tipo Inscrição Estadual do Destinatário // alterado para aceitar vazio ou ISENTO - maio/2010 v2.0</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="14"/>
+			<xs:pattern value="ISENTO|[0-9]{2,14}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TIeDestNaoIsento">
+		<xs:annotation>
+			<xs:documentation>Tipo Inscrição Estadual do Destinatário // alterado para aceitar vazio ou ISENTO - maio/2010 v2.0</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="14"/>
+			<xs:pattern value="[0-9]{2,14}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TIeST">
+		<xs:annotation>
+			<xs:documentation>Tipo Inscrição Estadual do ST // acrescentado EM 24/10/08</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="14"/>
+			<xs:pattern value="[0-9]{2,14}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TIe">
+		<xs:annotation>
+			<xs:documentation>Tipo Inscrição Estadual do Emitente // alterado EM 24/10/08 para aceitar ISENTO</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="14"/>
+			<xs:pattern value="[0-9]{2,14}|ISENTO"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TMod">
+		<xs:annotation>
+			<xs:documentation>Tipo Modelo Documento Fiscal</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="55"/>
+			<xs:enumeration value="65"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TNF">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do Documento Fiscal</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[1-9]{1}[0-9]{0,8}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TSerie">
+		<xs:annotation>
+			<xs:documentation>Tipo Série do Documento Fiscal </xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|[1-9]{1}[0-9]{0,2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TUf">
+		<xs:annotation>
+			<xs:documentation>Tipo Sigla da UF</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="AC"/>
+			<xs:enumeration value="AL"/>
+			<xs:enumeration value="AM"/>
+			<xs:enumeration value="AP"/>
+			<xs:enumeration value="BA"/>
+			<xs:enumeration value="CE"/>
+			<xs:enumeration value="DF"/>
+			<xs:enumeration value="ES"/>
+			<xs:enumeration value="GO"/>
+			<xs:enumeration value="MA"/>
+			<xs:enumeration value="MG"/>
+			<xs:enumeration value="MS"/>
+			<xs:enumeration value="MT"/>
+			<xs:enumeration value="PA"/>
+			<xs:enumeration value="PB"/>
+			<xs:enumeration value="PE"/>
+			<xs:enumeration value="PI"/>
+			<xs:enumeration value="PR"/>
+			<xs:enumeration value="RJ"/>
+			<xs:enumeration value="RN"/>
+			<xs:enumeration value="RO"/>
+			<xs:enumeration value="RR"/>
+			<xs:enumeration value="RS"/>
+			<xs:enumeration value="SC"/>
+			<xs:enumeration value="SE"/>
+			<xs:enumeration value="SP"/>
+			<xs:enumeration value="TO"/>
+			<xs:enumeration value="EX"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TUfEmi">
+		<xs:annotation>
+			<xs:documentation>Tipo Sigla da UF de emissor // acrescentado em 24/10/08 </xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="AC"/>
+			<xs:enumeration value="AL"/>
+			<xs:enumeration value="AM"/>
+			<xs:enumeration value="AP"/>
+			<xs:enumeration value="BA"/>
+			<xs:enumeration value="CE"/>
+			<xs:enumeration value="DF"/>
+			<xs:enumeration value="ES"/>
+			<xs:enumeration value="GO"/>
+			<xs:enumeration value="MA"/>
+			<xs:enumeration value="MG"/>
+			<xs:enumeration value="MS"/>
+			<xs:enumeration value="MT"/>
+			<xs:enumeration value="PA"/>
+			<xs:enumeration value="PB"/>
+			<xs:enumeration value="PE"/>
+			<xs:enumeration value="PI"/>
+			<xs:enumeration value="PR"/>
+			<xs:enumeration value="RJ"/>
+			<xs:enumeration value="RN"/>
+			<xs:enumeration value="RO"/>
+			<xs:enumeration value="RR"/>
+			<xs:enumeration value="RS"/>
+			<xs:enumeration value="SC"/>
+			<xs:enumeration value="SE"/>
+			<xs:enumeration value="SP"/>
+			<xs:enumeration value="TO"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TAmb">
+		<xs:annotation>
+			<xs:documentation>Tipo Ambiente</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TVerAplic">
+		<xs:annotation>
+			<xs:documentation>Tipo Versão do Aplicativo</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="nfe:TString">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="20"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TMotivo">
+		<xs:annotation>
+			<xs:documentation>Tipo Motivo</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="nfe:TString">
+			<xs:maxLength value="255"/>
+			<xs:minLength value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TJust">
+		<xs:annotation>
+			<xs:documentation>Tipo Justificativa</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="nfe:TString">
+			<xs:minLength value="15"/>
+			<xs:maxLength value="255"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TServ">
+		<xs:annotation>
+			<xs:documentation>Tipo Serviço solicitado</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="nfe:TString"/>
+	</xs:simpleType>
+	<xs:simpleType name="Tano">
+		<xs:annotation>
+			<xs:documentation> Tipo ano</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TMed">
+		<xs:annotation>
+			<xs:documentation> Tipo temp médio em segundos</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{1,4}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TString">
+		<xs:annotation>
+			<xs:documentation> Tipo string genérico</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TData">
+		<xs:annotation>
+			<xs:documentation> Tipo data AAAA-MM-DD</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="(((20(([02468][048])|([13579][26]))-02-29))|(20[0-9][0-9])-((((0[1-9])|(1[0-2]))-((0[1-9])|(1\d)|(2[0-8])))|((((0[13578])|(1[02]))-31)|(((0[1,3-9])|(1[0-2]))-(29|30)))))"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TTime">
+		<xs:annotation>
+			<xs:documentation> Tipo hora HH:MM:SS // tipo acrescentado na v2.0</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="(([0-1][0-9])|([2][0-3])):([0-5][0-9]):([0-5][0-9])"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDateTimeUTC">
+		<xs:annotation>
+			<xs:documentation>Data e Hora, formato UTC (AAAA-MM-DDThh:mm:ssTZD, onde TZD = +hh:mm ou -hh:mm)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="(((20(([02468][048])|([13579][26]))-02-29))|(20[0-9][0-9])-((((0[1-9])|(1[0-2]))-((0[1-9])|(1\d)|(2[0-8])))|((((0[13578])|(1[02]))-31)|(((0[1,3-9])|(1[0-2]))-(29|30)))))T(20|21|22|23|[0-1]\d):[0-5]\d:[0-5]\d([\-,\+](0[0-9]|10|11):00|([\+](12):00))"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TPlaca">
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[A-Z]{2,3}[0-9]{4}|[A-Z]{3,4}[0-9]{3}|[A-Z0-9]{7}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCOrgaoIBGE">
+		<xs:annotation>
+			<xs:documentation>Tipo Código de orgão (UF da tabela do IBGE + 90 RFB)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="11"/>
+			<xs:enumeration value="12"/>
+			<xs:enumeration value="13"/>
+			<xs:enumeration value="14"/>
+			<xs:enumeration value="15"/>
+			<xs:enumeration value="16"/>
+			<xs:enumeration value="17"/>
+			<xs:enumeration value="21"/>
+			<xs:enumeration value="22"/>
+			<xs:enumeration value="23"/>
+			<xs:enumeration value="24"/>
+			<xs:enumeration value="25"/>
+			<xs:enumeration value="26"/>
+			<xs:enumeration value="27"/>
+			<xs:enumeration value="28"/>
+			<xs:enumeration value="29"/>
+			<xs:enumeration value="31"/>
+			<xs:enumeration value="32"/>
+			<xs:enumeration value="33"/>
+			<xs:enumeration value="35"/>
+			<xs:enumeration value="41"/>
+			<xs:enumeration value="42"/>
+			<xs:enumeration value="43"/>
+			<xs:enumeration value="50"/>
+			<xs:enumeration value="51"/>
+			<xs:enumeration value="52"/>
+			<xs:enumeration value="53"/>
+			<xs:enumeration value="90"/>
+			<xs:enumeration value="91"/>
+			<xs:enumeration value="92"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/xmldsig-core-schema_v1.01.xsd
+++ b/src/main/resources/schemas/PL_010b_NT2025_002_v1.30/xmldsig-core-schema_v1.01.xsd
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- ***************************************************-->
+<!-- ***   Schema específico para assinaturas XML    ***-->
+<!-- *** a partir de certificados do padrão (X509)   ***-->
+<!-- *** ICP-Brasil - Projeto Nota Fiscal Eletrônica ***-->
+<!-- ***************************************************-->
+<!-- Schema for XML Signatures-->
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.w3.org/2000/09/xmldsig#" elementFormDefault="qualified" attributeFormDefault="unqualified" version="0.1">
+	<element name="Signature" type="ds:SignatureType"/>
+	<complexType name="SignatureType">
+		<sequence>
+			<element name="SignedInfo" type="ds:SignedInfoType"/>
+			<element name="SignatureValue" type="ds:SignatureValueType"/>
+			<element name="KeyInfo" type="ds:KeyInfoType"/>
+		</sequence>
+		<attribute name="Id" type="ID" use="optional"/>
+	</complexType>
+	<complexType name="SignatureValueType">
+		<simpleContent>
+			<extension base="base64Binary">
+				<attribute name="Id" type="ID" use="optional"/>
+			</extension>
+		</simpleContent>
+	</complexType>
+	<complexType name="SignedInfoType">
+		<sequence>
+			<element name="CanonicalizationMethod">
+				<complexType>
+					<attribute name="Algorithm" type="anyURI" use="required" fixed="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+				</complexType>
+			</element>
+			<element name="SignatureMethod">
+				<complexType>
+					<attribute name="Algorithm" type="anyURI" use="required" fixed="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+				</complexType>
+			</element>
+			<element name="Reference" type="ds:ReferenceType"/>
+		</sequence>
+		<attribute name="Id" type="ID" use="optional"/>
+	</complexType>
+	<complexType name="ReferenceType">
+		<sequence>
+			<element name="Transforms" type="ds:TransformsType">
+				<!-- Garante a unicidade do atributo -->
+				<unique name="unique_Transf_Alg">
+					<selector xpath="./*"/>
+					<field xpath="@Algorithm"/>
+				</unique>
+			</element>
+			<element name="DigestMethod">
+				<complexType>
+					<attribute name="Algorithm" type="anyURI" use="required" fixed="http://www.w3.org/2000/09/xmldsig#sha1"/>
+				</complexType>
+			</element>
+			<element name="DigestValue" type="ds:DigestValueType"/>
+		</sequence>
+		<attribute name="Id" type="ID" use="optional"/>
+		<attribute name="URI" use="required">
+			<simpleType>
+				<restriction base="anyURI">
+					<minLength value="2"/>
+				</restriction>
+			</simpleType>
+		</attribute>
+		<attribute name="Type" type="anyURI" use="optional"/>
+	</complexType>
+	<complexType name="TransformsType">
+		<sequence>
+			<element name="Transform" type="ds:TransformType" minOccurs="2" maxOccurs="2"/>
+		</sequence>
+	</complexType>
+	<complexType name="TransformType">
+		<sequence minOccurs="0" maxOccurs="unbounded">
+			<element name="XPath" type="string"/>
+		</sequence>
+		<attribute name="Algorithm" type="ds:TTransformURI" use="required"/>
+	</complexType>
+	<complexType name="KeyInfoType">
+		<sequence>
+			<element name="X509Data" type="ds:X509DataType"/>
+		</sequence>
+		<attribute name="Id" type="ID" use="optional"/>
+	</complexType>
+	<complexType name="X509DataType">
+		<sequence>
+			<element name="X509Certificate" type="base64Binary"/>
+		</sequence>
+	</complexType>
+	<simpleType name="DigestValueType">
+		<restriction base="base64Binary"/>
+	</simpleType>
+	<simpleType name="TTransformURI">
+		<restriction base="anyURI">
+			<enumeration value="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+			<enumeration value="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+		</restriction>
+	</simpleType>
+</schema>


### PR DESCRIPTION
Realizada a atualização dos schemas, verificado que algumas classes como o enum NFDebito já possuía todos os enums correspondentes a última N.T, porém os schemas não continham ainda essa atualização, causando erros ao validar o XML com o XSD.