### PR TITLE
refactor: Atualização enum de acordo com a tabela cClassTrib

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/NFNotaInfoImpostoTributacaoIBSCBSClassTrib.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/NFNotaInfoImpostoTributacaoIBSCBSClassTrib.java
@@ -343,8 +343,17 @@ public enum NFNotaInfoImpostoTributacaoIBSCBSClassTrib {
 	
 	CST_410021("410021", CST_410, "Contribui\u00e7\u00e3o de que trata o art. 149-A da Constitui\u00e7\u00e3o Federal",
 				"Art. 12 § 2º", SEM_ALIQUOTA, NA, NA, NA_SN, NA, NA, NA, NA, NA, NA, null, null, of(2025, 6, 11)),
-	
-	CST_410999("410999", CST_410, "Opera\u00e7\u00f5es n\u00e3o onerosas sem previs\u00e3o de tributa\u00e7\u00e3o, n\u00e3o especificadas anteriormente",
+
+    CST_410026("410026", CST_410, "Doa\u00e7\u00e3o com anula\u00e7\u00e3o de cr\u00e9dito",
+            "Art. 6º", SEM_ALIQUOTA, NA, NA, NA_SN, ZERO, NA, NA, NA, NA, NA, null, null, of(2025, 5, 19)),
+
+    CST_410029("410029", CST_410, "Opera\u00e7\u00f5es acobertadas somente pelo ICMS",
+            "Art. 4º", SEM_ALIQUOTA, NA, NA, NA_SN, ZERO, NA, NA, NA, NA, NA, null, null, of(2025, 5, 19)),
+
+    CST_410030("410030", CST_410, "Estorno de cr\u00e9dito por perecimento, deterioriza\u00e7\u00e3o, roubo, furto ou extravio",
+            "Art. 47, § 6º", SEM_ALIQUOTA, NA, NA, NA_SN, ZERO, NA, NA, NA, NA, NA, null, null, of(2025, 5, 19)),
+
+    CST_410999("410999", CST_410, "Opera\u00e7\u00f5es n\u00e3o onerosas sem previs\u00e3o de tributa\u00e7\u00e3o, n\u00e3o especificadas anteriormente",
 				"Art. 4º, § 1º", SEM_ALIQUOTA, NA, NA, NA_SN, ZERO, NA, NA, NA, NA, NA, null, null, of(2025, 6, 11)),
 	
 	// CST_510

--- a/src/test/java/com/fincatto/documentofiscal/nfe400/classes/NFNotaInfoImpostoTributacaoIBSCBSClassTribTest.java
+++ b/src/test/java/com/fincatto/documentofiscal/nfe400/classes/NFNotaInfoImpostoTributacaoIBSCBSClassTribTest.java
@@ -104,6 +104,9 @@ public class NFNotaInfoImpostoTributacaoIBSCBSClassTribTest {
 		Assert.assertEquals("410019", NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410019.getCodigo());
 		Assert.assertEquals("410020", NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410020.getCodigo());
 		Assert.assertEquals("410021", NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410021.getCodigo());
+        Assert.assertEquals("410026", NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410026.getCodigo());
+        Assert.assertEquals("410029", NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410029.getCodigo());
+        Assert.assertEquals("410030", NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410030.getCodigo());
 		Assert.assertEquals("410999", NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410999.getCodigo());
 		Assert.assertEquals("510001", NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_510001.getCodigo());
 		Assert.assertEquals("510002", NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_510002.getCodigo());
@@ -244,6 +247,9 @@ public class NFNotaInfoImpostoTributacaoIBSCBSClassTribTest {
     	Assert.assertEquals("Exclusão da gorjeta na base de cálculo no fornecimento de alimentação", NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410019.getDescricao());
     	Assert.assertEquals("Exclusão do valor de intermediação na base de cálculo no fornecimento de alimentação", NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410020.getDescricao());
     	Assert.assertEquals("Contribuição de que trata o art. 149-A da Constituição Federal", NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410021.getDescricao());
+        Assert.assertEquals("Doação com anulação de crédito", NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410026.getDescricao());
+        Assert.assertEquals("Operações acobertadas somente pelo ICMS", NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410029.getDescricao());
+        Assert.assertEquals("Estorno de crédito por perecimento, deteriorização, roubo, furto ou extravio", NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410030.getDescricao());
     	Assert.assertEquals("Operações não onerosas sem previsão de tributação, não especificadas anteriormente", NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410999.getDescricao());
     	Assert.assertEquals("Operações, sujeitas a diferimento, com energia elétrica, relativas à geração, comercialização, distribuição e transmissão", NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_510001.getDescricao());
     	Assert.assertEquals("Operações, sujeitas a diferimento, com insumos agropecuários e aquícolas destinados a produtor rural contribuinte (Anexo IX)", NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_510002.getDescricao());
@@ -388,7 +394,10 @@ public class NFNotaInfoImpostoTributacaoIBSCBSClassTribTest {
 		Assert.assertEquals(NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410019, NFNotaInfoImpostoTributacaoIBSCBSClassTrib.valueOfCodigo("410019"));
 		Assert.assertEquals(NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410020, NFNotaInfoImpostoTributacaoIBSCBSClassTrib.valueOfCodigo("410020"));
 		Assert.assertEquals(NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410021, NFNotaInfoImpostoTributacaoIBSCBSClassTrib.valueOfCodigo("410021"));
-		Assert.assertEquals(NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410999, NFNotaInfoImpostoTributacaoIBSCBSClassTrib.valueOfCodigo("410999"));
+        Assert.assertEquals(NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410026, NFNotaInfoImpostoTributacaoIBSCBSClassTrib.valueOfCodigo("410026"));
+        Assert.assertEquals(NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410029, NFNotaInfoImpostoTributacaoIBSCBSClassTrib.valueOfCodigo("410029"));
+        Assert.assertEquals(NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410030, NFNotaInfoImpostoTributacaoIBSCBSClassTrib.valueOfCodigo("410030"));
+        Assert.assertEquals(NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_410999, NFNotaInfoImpostoTributacaoIBSCBSClassTrib.valueOfCodigo("410999"));
 		Assert.assertEquals(NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_510001, NFNotaInfoImpostoTributacaoIBSCBSClassTrib.valueOfCodigo("510001"));
 		Assert.assertEquals(NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_510002, NFNotaInfoImpostoTributacaoIBSCBSClassTrib.valueOfCodigo("510002"));
         Assert.assertEquals(NFNotaInfoImpostoTributacaoIBSCBSClassTrib.CST_515001, NFNotaInfoImpostoTributacaoIBSCBSClassTrib.valueOfCodigo("515001"));


### PR DESCRIPTION
Realizado ajustes de acordo com a última tabela vigente, sendo eles:

- Adição dos códigos 410026, 410029, 410030, 515001, 811001, 811002, 811003
- Marcado 210001, 210002, 210003, 510002 como Deprecated
- Adequação dos testes
