### PR TITLE
Correção da estrutura de CTeNotaInfoInformacoesRelativasImpostosIBSCBS

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeNotaInfoInformacoesRelativasImpostosIBSCBS.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeNotaInfoInformacoesRelativasImpostosIBSCBS.java
@@ -124,10 +124,10 @@ public class CTeNotaInfoInformacoesRelativasImpostosIBSCBS extends DFBase {
         return vIBS;
     }
 
-    public void setvIBS(String vIBS) {
-        this.vIBS = vIBS;
+    public void setvIBS(BigDecimal vIBS) {
+        this.vIBS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(vIBS, "Valor do IBS");
     }
-
+    
     public GCBS getGCBS() {
       return gCBS;
     }


### PR DESCRIPTION
Corrigindo a estrutura da Classe TCIBS - faltava o field vIBS.

Adiciondo static nas inner class para possibilitar a desserialização do xml do CT-e.