### PR TITLE
Modificação do atributo grupoCreditoPresumido para ser uma lista de gCred

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemProduto.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemProduto.java
@@ -48,8 +48,8 @@ public class NFNotaInfoItemProduto extends DFBase {
     @Element(name = "cBenef", required = false)
     private String codigoBeneficioFiscalUF;
 
-    @Element(name = "gCred", required = false)
-    private NFNotaInfoItemProdutoGrupoCreditoPresumido grupoCreditoPresumido;
+    @ElementList(entry = "gCred", inline = true, required = false)
+    private List<NFNotaInfoItemProdutoGrupoCreditoPresumido> grupoCreditoPresumido;
 
     @Element(name = "EXTIPI", required = false)
     private String extipi;
@@ -352,7 +352,7 @@ public class NFNotaInfoItemProduto extends DFBase {
     }
 
     public void setGrupoCreditoPresumido(
-        final NFNotaInfoItemProdutoGrupoCreditoPresumido grupoCreditoPresumido) {
+        final List<NFNotaInfoItemProdutoGrupoCreditoPresumido> grupoCreditoPresumido) {
         this.grupoCreditoPresumido = grupoCreditoPresumido;
     }
 
@@ -524,7 +524,7 @@ public class NFNotaInfoItemProduto extends DFBase {
         return this.rastros;
     }
 
-    public NFNotaInfoItemProdutoGrupoCreditoPresumido getGrupoCreditoPresumido() {
+    public List<NFNotaInfoItemProdutoGrupoCreditoPresumido> getGrupoCreditoPresumido() {
         return grupoCreditoPresumido;
     }
 

--- a/src/test/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemProdutoTest.java
+++ b/src/test/java/com/fincatto/documentofiscal/nfe400/classes/nota/NFNotaInfoItemProdutoTest.java
@@ -1585,10 +1585,7 @@ public class NFNotaInfoItemProdutoTest {
 
     @Test
     public void deveGerarXMLDeAcordoComOPadraoEstabelecidoGrupoCreditoPresumido() {
-        final NFNotaInfoItemProdutoGrupoCreditoPresumido grupoCreditoPresumido = new NFNotaInfoItemProdutoGrupoCreditoPresumido();
-        grupoCreditoPresumido.setCodigoBeneficioFiscalCreditoPresumido("DF020111");
-        grupoCreditoPresumido.setPercentualCreditoPresumido(new BigDecimal("65.12"));
-        grupoCreditoPresumido.setValorCreditoPresumido(new BigDecimal("12.73"));
+    	final List<NFNotaInfoItemProdutoGrupoCreditoPresumido> grupoCreditoPresumido = Collections.singletonList(FabricaDeObjetosFake.getNFNotaInfoItemProdutoGrupoCreditoPresumido());
 
         final NFNotaInfoItemProduto nfNotaInfoItemProdutoGrupoCreditoPresumido = FabricaDeObjetosFake.getNFNotaInfoItemProduto();
         nfNotaInfoItemProdutoGrupoCreditoPresumido.setGrupoCreditoPresumido(grupoCreditoPresumido);


### PR DESCRIPTION
Este pull request altera a estrutura do atributo grupoCreditoPresumido na classe NFNotaInfoItemProduto, substituindo o tipo único NFNotaInfoItemProdutoGrupoCreditoPresumido por uma lista (List<NFNotaInfoItemProdutoGrupoCreditoPresumido>).

**Alterações realizadas**

- Alterado o atributo grupoCreditoPresumido para utilizar @ElementList com inline = true, permitindo múltiplas ocorrências da tag gCred no XML.
- Ajustados os métodos getter e setter para trabalhar com List<NFNotaInfoItemProdutoGrupoCreditoPresumido>.
- Atualizados os testes unitários para refletir o novo comportamento, passando a utilizar lista de objetos em vez de instância única.
- Mantida compatibilidade com o padrão de serialização XML esperado para múltiplos grupos gCred.

**Objetivo**

Permitir o suporte a múltiplos grupos de crédito presumido (gCred) por item de produto na NF-e, atendendo aos cenários em que mais de um crédito presumido precisa ser informado no mesmo item, conforme estrutura suportada pelo schema XML.

**Impacto**

- Breaking change: Código que utilizava getGrupoCreditoPresumido() ou setGrupoCreditoPresumido() com objeto único deverá ser ajustado para utilizar lista.
- Não há impacto na estrutura geral da NF-e além da possibilidade de múltiplas ocorrências do grupo gCred.