### PR TITLE
Ajustes validadores CNPJ

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/validadores/DFStringValidador.java
+++ b/src/main/java/com/fincatto/documentofiscal/validadores/DFStringValidador.java
@@ -202,7 +202,7 @@ public abstract class DFStringValidador {
 
     public static void cnpj(final String cnpj) {
         if (cnpj != null) {
-            final Matcher matcher = Pattern.compile("^[0-9]{14}$").matcher(cnpj);
+            final Matcher matcher = Pattern.compile("^\\w{12}\\d{2}$").matcher(cnpj);
             if (!matcher.find()) {
                 throw new IllegalStateException(String.format("Formato CNPJ Invalido (%s)", cnpj));
             }
@@ -211,7 +211,7 @@ public abstract class DFStringValidador {
 
     public static String cnpj(final String cnpj, final String info) {
         if (cnpj != null) {
-            final Matcher matcher = Pattern.compile("^[0-9]{14}$").matcher(cnpj);
+            final Matcher matcher = Pattern.compile("^\\w{12}\\d{2}$").matcher(cnpj);
             if (!matcher.find()) {
                 throw new IllegalStateException(String.format("Formato CNPJ Invalido (%s) em %s", cnpj, info));
             }

--- a/src/test/java/com/fincatto/documentofiscal/utils/DFUtilsTest.java
+++ b/src/test/java/com/fincatto/documentofiscal/utils/DFUtilsTest.java
@@ -46,6 +46,7 @@ public class DFUtilsTest {
     @Test
     public void deveValidarCnpjAlfanumerico() {
         Assert.assertTrue(DFUtils.isCnpjValido("12ABC34501DE35"));
+        Assert.assertTrue(DFUtils.isCnpjValido("12abc34501de35"));
     }
 
     @Test

--- a/src/test/java/com/fincatto/documentofiscal/validadores/DFStringValidadorTest.java
+++ b/src/test/java/com/fincatto/documentofiscal/validadores/DFStringValidadorTest.java
@@ -195,7 +195,9 @@ public class DFStringValidadorTest {
 
     @Test
     public void deveValidarCNPJ() {
+        DFStringValidador.cnpj("ZLVERP05000160");
         DFStringValidador.cnpj("01234567000100");
+        DFStringValidador.cnpj("ABCDEFGHIJKL80", "");
         DFStringValidador.cnpj("01234567000100", "");
     }
 
@@ -240,6 +242,12 @@ public class DFStringValidadorTest {
     @Test(expected = IllegalStateException.class)
     public void naoDeveValidarCNPJCasoNaoPossua14CaracteresInfo() {
         DFStringValidador.cnpj("1234567890123", "");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void naoDeveValidarCNPJCasoNaoEstejaNoPadrao() {
+        DFStringValidador.cnpj("ZLVERP0500016a");
+        DFStringValidador.cnpj("aLVERP0500016a", "");
     }
 
     @Test


### PR DESCRIPTION
Ajusta validador de string para CNPJ alfanumérico;
Adiciona casos aos testes de formato CNPJ para validar alfanumérico;
Adiciona caso ao teste de validação de CNPJ para 'ignorecase' dos caracteres