### PR TITLE
fix: atualiza schema CTe para RTC 1.14 corrigindo ordenação dos campos vIBS/gCBS

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/validadores/DFXMLValidador.java
+++ b/src/main/java/com/fincatto/documentofiscal/validadores/DFXMLValidador.java
@@ -142,7 +142,7 @@ public final class DFXMLValidador {
     }
 
     private static boolean validaCTe400(final String xml, final String xsd) throws IOException, SAXException, URISyntaxException {
-        final URL xsdPath = DFXMLValidador.class.getClassLoader().getResource(String.format("schemas/PL_CTe_400_NT2025.001_RTC_1.05/%s", xsd));
+        final URL xsdPath = DFXMLValidador.class.getClassLoader().getResource(String.format("schemas/PL_CTe_400_NT2025.001 RTC_1.14/%s", xsd));
         final SchemaFactory schemaFactory = SchemaFactory.newInstance("http://www.w3.org/2001/XMLSchema");
         final Schema schema = schemaFactory.newSchema(new StreamSource(xsdPath.toURI().toString()));
         schema.newValidator().validate(new StreamSource(new StringReader(xml)));

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/DFeTiposBasicos_v1.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/DFeTiposBasicos_v1.00.xsd
@@ -1,0 +1,1428 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2025 rel. 2 (x64) (https://www.altova.com) by PROCERGS (Procergs - Centro de Tecnologia da Informação e Comunicação do Estado do Rio Grande do Sul S.A.) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+	<xs:simpleType name="TChDFeRTC">
+		<xs:annotation>
+			<xs:documentation>Tipo Chave de Documento Fiscal Eletrônico</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="44"/>
+			<xs:pattern value="[0-9]{6}[A-Z0-9]{12}[0-9]{26}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TStringRTC">
+		<xs:annotation>
+			<xs:documentation> Tipo string genérico</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCST">
+		<xs:annotation>
+			<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="\d{3}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TcClassTrib">
+		<xs:annotation>
+			<xs:documentation>Código de Classificação Tributária do IBS e da CBS</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="\d{6}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TcCredPres">
+		<xs:annotation>
+			<xs:documentation>Código de Classificação do Crédito Presumido do IBS e da CBS, conforme tabela cCredPres</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="\d{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec1104RTC">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 11 de corpo e 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{4}|[1-9]{1}[0-9]{0,10}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1104OpRTC">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 11 inteiros, podendo ter 4 decimais (utilizado em tags opcionais)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[1-9]{1}[0-9]{3}|0\.[0-9]{3}[1-9]{1}|0\.[0-9]{2}[1-9]{1}[0-9]{1}|0\.[0-9]{1}[1-9]{1}[0-9]{2}|[1-9]{1}[0-9]{0,10}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCnpjBaseRTC">
+		<xs:annotation>
+			<xs:documentation>Tipo CNPJ Base</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[A-Z0-9]{8}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCnpjRTC">
+		<xs:annotation>
+			<xs:documentation>Tipo CNPJ</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[A-Z0-9]{12}[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec1302RTC">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 13 de corpo e 2 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0302_04RTC">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com até 3 dígitos inteiros, podendo ter de 2 até 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{2,4}|[1-9]{1}[0-9]{0,2}(\.[0-9]{2,4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TOperCompraGov">
+		<xs:annotation>
+			<xs:documentation>Tipo da Operação com Ente Governamental</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+			<xs:enumeration value="3"/>
+			<xs:enumeration value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TEnteGov">
+		<xs:annotation>
+			<xs:documentation>Tipo de Ente Governamental</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+			<xs:enumeration value="3"/>
+			<xs:enumeration value="4"/>
+			<xs:enumeration value="5"/>
+			<xs:enumeration value="6"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TTpCredPresIBSZFM">
+		<xs:annotation>
+			<xs:documentation>Tipo de classificação do Crédito Presumido IBS ZFM</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="0"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+			<xs:enumeration value="3"/>
+			<xs:enumeration value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TIndDoacao">
+		<xs:annotation>
+			<xs:documentation>Tipo Indicador de Doação</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="1"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="TTribNFCom">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NFCom</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Indica se a operação é de doação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+			<xs:element name="gEstornoCred" type="TEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informado conforme indicador no cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribNF3e">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NF3e</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Indica se a operação é de doação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+			<xs:element name="gEstornoCred" type="TEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informado conforme indicador no cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribNFAg">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NFAg</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0"/>
+			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+			<xs:element name="gEstornoCred" type="TEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informado conforme indicador no cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribCTe">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação do CTe</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0"/>
+			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+			<xs:element name="gEstornoCred" type="TEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informado conforme indicador no cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribBPe">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação do BPe</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0"/>
+			<xs:element name="gIBSCBS" type="TCIBS" minOccurs="0"/>
+			<xs:element name="gEstornoCred" type="TEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informado conforme indicador no cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribNFCe">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NFCe</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Indica se a operação é de doação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice minOccurs="0">
+				<xs:element name="gIBSCBS" type="TCIBS"/>
+				<xs:element name="gIBSCBSMono" type="TMonofasia"/>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribNFe">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NFe</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Indica se a operação é de doação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice minOccurs="0">
+				<xs:element name="gIBSCBS" type="TCIBS"/>
+				<xs:element name="gIBSCBSMono" type="TMonofasia">
+					<xs:annotation>
+						<xs:documentation>Informar essa opção da Choice para Monofasia (CST 620)</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="gTransfCred" type="TTransfCred">
+					<xs:annotation>
+						<xs:documentation>Informar essa opção da Choice para o CST 800</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="gAjusteCompet" type="TAjusteCompet">
+					<xs:annotation>
+						<xs:documentation>Informar essa opção da Choice para o CST 811</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+			<xs:element name="gEstornoCred" type="TEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informado conforme indicador no cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice minOccurs="0">
+				<xs:element name="gCredPresOper" type="TCredPresOper">
+					<xs:annotation>
+						<xs:documentation>Crédito Presumido da Operação. Informado conforme indicador no cClassTrib.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="gCredPresIBSZFM" type="TCredPresIBSZFM">
+					<xs:annotation>
+						<xs:documentation>Classificação de acordo com o art. 450, § 1º, da LC 214/25 para o cálculo do crédito presumido na ZFM. Informado conforme indicador no cClassTrib.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribNFGas">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações da Tributação da NFGas</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CST" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do IBS/CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTrib" type="TcClassTrib"/>
+			<xs:element name="indDoacao" type="TIndDoacao" minOccurs="0"/>
+			<xs:choice minOccurs="0">
+				<xs:element name="gIBSCBS" type="TCIBS"/>
+				<xs:element name="gIBSCBSMono" type="TMonofasia">
+					<xs:annotation>
+						<xs:documentation>Informar essa opção da Choice para Monofasia</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+			<xs:element name="gEstornoCred" type="TEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informado conforme indicador no cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TIS">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações do Imposto Seletivo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CSTIS" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código Situação Tributária do Imposto Seletivo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTribIS" type="TcClassTrib"/>
+			<xs:sequence minOccurs="0">
+				<xs:element name="vBCIS" type="TDec1302RTC">
+					<xs:annotation>
+						<xs:documentation>Valor do BC</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="pIS" type="TDec_0302_04RTC">
+					<xs:annotation>
+						<xs:documentation>Alíquota do Imposto Seletivo (percentual)</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="pISEspec" type="TDec_0302_04RTC" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Alíquota do Imposto Seletivo (por valor)</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:sequence minOccurs="0">
+					<xs:element name="uTrib">
+						<xs:annotation>
+							<xs:documentation>Unidade de medida apropriada especificada em Lei Ordinaria para fins de apuração do Imposto Seletivo</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="TStringRTC">
+								<xs:minLength value="1"/>
+								<xs:maxLength value="6"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:element>
+					<xs:element name="qTrib" type="TDec_1104OpRTC">
+						<xs:annotation>
+							<xs:documentation>Quantidade com abse no campo uTrib informado</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+				</xs:sequence>
+				<xs:element name="vIS" type="TDec1302RTC">
+					<xs:annotation>
+						<xs:documentation>Valor do Imposto Seletivo calculado</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TISTot">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações de totais do Imposto Seletivo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vIS" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor Total do Imposto Seletivo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TIBSCBSTot">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações de totais da CBS/IBS</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vBCIBSCBS" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Total Base de Calculo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gIBS">
+				<xs:annotation>
+					<xs:documentation>Totalização do IBS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="gIBSUF">
+							<xs:annotation>
+								<xs:documentation>Totalização do IBS de competência da UF</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vDif" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Total do Diferimento</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vDevTrib" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Total de devoluções de tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vIBSUF" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Valor total do IBS Estadual</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="gIBSMun">
+							<xs:annotation>
+								<xs:documentation>Totalização do IBS de competência Municipal</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vDif" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Total do Diferimento</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vDevTrib" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Total de devoluções de tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vIBSMun" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Valor total do IBS Municipal</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="vIBS" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total do IBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gCBS">
+				<xs:annotation>
+					<xs:documentation>Totalização da CBS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="vDif" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Total do Diferimento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vDevTrib" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Total de devoluções de tributos</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBS" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total da CBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Totalização do estorno de crédito</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="vIBSEstCred" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total do IBS estornado</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSEstCred" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total da CBS estornada</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TIBSCBSMonoTot">
+		<xs:annotation>
+			<xs:documentation>Grupo de informações de totais da CBS/IBS com monofasia</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vBCIBSCBS" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Total Base de Calculo</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gIBS" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Totalização do IBS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="gIBSUF">
+							<xs:annotation>
+								<xs:documentation>Totalização do IBS de competência da UF</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vDif" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Total do Diferimento</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vDevTrib" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Total de devoluções de tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vIBSUF" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Valor total do IBS Estadual</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="gIBSMun">
+							<xs:annotation>
+								<xs:documentation>Totalização do IBS de competência Municipal</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vDif" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Total do Diferimento</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vDevTrib" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Total de devoluções de tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vIBSMun" type="TDec1302RTC">
+										<xs:annotation>
+											<xs:documentation>Valor total do IBS Municipal</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="vIBS" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total do IBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPres" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPresCondSus" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido Condição Suspensiva</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gCBS" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Totalização da CBS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="vDif" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Total do Diferimento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vDevTrib" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Total de devoluções de tributos</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBS" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total da CBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPres" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCredPresCondSus" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Total do Crédito Presumido Condição Suspensiva</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gMono" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Totais da Monofasia</xs:documentation>
+					<xs:documentation>Só deverá ser utilizado para DFe modelos 55 e 65</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="vIBSMono" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total do IBS monofásico</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSMono" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total da CBS monofásica</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vIBSMonoReten" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total do IBS monofásico sujeito a retenção</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSMonoReten" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total da CBS monofásica sujeita a retenção</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vIBSMonoRet" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor do IBS monofásico retido anteriormente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSMonoRet" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor da CBS monofásica retida anteriormente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gEstornoCred" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Totalização do estorno de crédito</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="vIBSEstCred" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total do IBS estornado</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSEstCred" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor total da CBS estornada</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TMonofasia">
+		<xs:annotation>
+			<xs:documentation>Tipo Monofasia</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:annotation>
+				<xs:documentation>Monofasia</xs:documentation>
+			</xs:annotation>
+			<xs:element name="gMonoPadrao" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de informações da Tributação Monofásica padrão</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="qBCMono" type="TDec1104RTC">
+							<xs:annotation>
+								<xs:documentation>Quantidade tributada na monofasia</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="adRemIBS" type="TDec_0302_04RTC">
+							<xs:annotation>
+								<xs:documentation>Alíquota ad rem do IBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="adRemCBS" type="TDec_0302_04RTC">
+							<xs:annotation>
+								<xs:documentation>Alíquota ad rem da CBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vIBSMono" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor do IBS monofásico</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSMono" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor da CBS monofásica</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gMonoReten" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de informações da Tributação Monofásica sujeita a retenção</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="qBCMonoReten" type="TDec1104RTC">
+							<xs:annotation>
+								<xs:documentation>Quantidade tributada sujeita a retenção.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="adRemIBSReten" type="TDec_0302_04RTC">
+							<xs:annotation>
+								<xs:documentation>Alíquota ad rem do IBS sujeito a retenção</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vIBSMonoReten" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor do IBS monofásico sujeito a retenção</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="adRemCBSReten" type="TDec_0302_04RTC">
+							<xs:annotation>
+								<xs:documentation>Alíquota ad rem da CBS sujeita a retenção</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSMonoReten" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor da CBS monofásica sujeita a retenção</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gMonoRet" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de informações da Tributação Monofásica retida anteriormente</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="qBCMonoRet" type="TDec1104RTC">
+							<xs:annotation>
+								<xs:documentation>Quantidade tributada retida anteriormente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="adRemIBSRet" type="TDec_0302_04RTC">
+							<xs:annotation>
+								<xs:documentation>Alíquota ad rem do IBS retido anteriormente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vIBSMonoRet" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor do IBS retido anteriormente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="adRemCBSRet" type="TDec_0302_04RTC">
+							<xs:annotation>
+								<xs:documentation>Alíquota ad rem da CBS retida anteriormente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSMonoRet" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor da CBS retida anteriormente</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gMonoDif" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de informações do diferimento da Tributação Monofásica</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="pDifIBS" type="TDec_0302_04RTC">
+							<xs:annotation>
+								<xs:documentation>Percentual do diferimento do imposto monofásico</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vIBSMonoDif" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor do IBS monofásico diferido</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="pDifCBS" type="TDec_0302_04RTC">
+							<xs:annotation>
+								<xs:documentation>Percentual do diferimento do imposto monofásico</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBSMonoDif" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor da CBS monofásica diferida</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="vTotIBSMonoItem" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Total de IBS monofásico do item</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vTotCBSMonoItem" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Total da CBS monofásica do item</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCIBS">
+		<xs:annotation>
+			<xs:documentation>Tipo CBS IBS Completo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:annotation>
+				<xs:documentation>IBS / CBS</xs:documentation>
+			</xs:annotation>
+			<xs:element name="vBC" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor do BC</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:sequence>
+				<xs:element name="gIBSUF">
+					<xs:annotation>
+						<xs:documentation>Grupo de informações do IBS na UF</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="pIBSUF" type="TDec_0302_04RTC">
+								<xs:annotation>
+									<xs:documentation>Aliquota do IBS de competência das UF (em percentual)</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="gDif" type="TDif" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Grupo de campos do Diferimento</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="gDevTrib" type="TDevTrib" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Grupo de Informações da devolução de tributos</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="gRed" type="TRed" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Grupo de campos da redução de aliquota</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="vIBSUF" type="TDec1302RTC">
+								<xs:annotation>
+									<xs:documentation>Valor do IBS de competência das UF</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="gIBSMun">
+					<xs:annotation>
+						<xs:documentation>Grupo de Informações do IBS no Município</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="pIBSMun" type="TDec_0302_04RTC">
+								<xs:annotation>
+									<xs:documentation>Aliquota do IBS Municipal (em percentual)</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="gDif" type="TDif" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Grupo de campos do Diferimento</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="gDevTrib" type="TDevTrib" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Grupo de Informações da devolução de tributos</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="gRed" type="TRed" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Grupo de campos da redução de aliquota</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="vIBSMun" type="TDec1302RTC">
+								<xs:annotation>
+									<xs:documentation>Valor do IBS Municipal</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="vIBS" type="TDec1302RTC">
+					<xs:annotation>
+						<xs:documentation>Valor do IBS</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+			<xs:element name="gCBS">
+				<xs:annotation>
+					<xs:documentation>Grupo de Tributação da CBS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="pCBS" type="TDec_0302_04RTC">
+							<xs:annotation>
+								<xs:documentation>Aliquota da CBS (em percentual)</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gDif" type="TDif" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de campos do Diferimento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gDevTrib" type="TDevTrib" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de Informações da devolução de tributos</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="gRed" type="TRed" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de campos da redução de aliquota</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCBS" type="TDec1302RTC">
+							<xs:annotation>
+								<xs:documentation>Valor da CBS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="gTribRegular" type="TTribRegular" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de informações da Tributação Regular. Informar como seria a tributação caso não cumprida a condição resolutória/suspensiva. Exemplo 1: Art. 442, §4. Operações com ZFM e ALC. Exemplo 2: Operações com suspensão do tributo.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gTribCompraGov" type="TTribCompraGov" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de informações da composição do valor do IBS e da CBS em compras governamental</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TRed">
+		<xs:annotation>
+			<xs:documentation>Tipo Redução Base de Cálculo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="pRedAliq" type="TDec_0302_04RTC">
+				<xs:annotation>
+					<xs:documentation>Percentual de redução de aliquota do cClassTrib</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqEfet" type="TDec_0302_04RTC">
+				<xs:annotation>
+					<xs:documentation>Aliquota Efetiva que será aplicada a Base de Calculo (em percentual)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCredPres">
+		<xs:annotation>
+			<xs:documentation>Tipo Crédito Presumido</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="pCredPres" type="TDec_0302_04RTC">
+				<xs:annotation>
+					<xs:documentation>Percentual do Crédito Presumido</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:choice>
+				<xs:element name="vCredPres" type="TDec1302RTC">
+					<xs:annotation>
+						<xs:documentation>Valor do Crédito Presumido</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vCredPresCondSus" type="TDec1302RTC">
+					<xs:annotation>
+						<xs:documentation>Valor do Crédito Presumido Condição Suspensiva, preencher apenas para cCredPres que possui indicação de Condição Suspensiva</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TDif">
+		<xs:annotation>
+			<xs:documentation>Tipo Diferimento</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="pDif" type="TDec_0302_04RTC">
+				<xs:annotation>
+					<xs:documentation>Percentual do diferimento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vDif" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor do diferimento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TDevTrib">
+		<xs:annotation>
+			<xs:documentation>Tipo Devolução Tributo</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vDevTrib" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor do tributo devolvido. No fornecimento de energia elétrica, água, esgoto e
+gás natural e em outras hipóteses definidas no regulamento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribRegular">
+		<xs:annotation>
+			<xs:documentation>Tipo Tributação Regular</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CSTReg" type="TCST">
+				<xs:annotation>
+					<xs:documentation>Código da Situação Tributária do IBS e CBS</xs:documentation>
+					<xs:documentation>Informar qual seria o CST caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cClassTribReg" type="TcClassTrib">
+				<xs:annotation>
+					<xs:documentation>Informar qual seria o cClassTrib caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqEfetRegIBSUF" type="TDec_0302_04RTC">
+				<xs:annotation>
+					<xs:documentation>Alíquota do IBS da UF</xs:documentation>
+					<xs:documentation>Informar como seria a Alíquota caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vTribRegIBSUF" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor do IBS da UF</xs:documentation>
+					<xs:documentation>Informar como seria o valor do Tributo caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqEfetRegIBSMun" type="TDec_0302_04RTC">
+				<xs:annotation>
+					<xs:documentation>Alíquota do IBS do Município</xs:documentation>
+					<xs:documentation>Informar como seria a Alíquota caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vTribRegIBSMun" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor do IBS do Município</xs:documentation>
+					<xs:documentation>Informar como seria o valor do Tributo caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqEfetRegCBS" type="TDec_0302_04RTC">
+				<xs:annotation>
+					<xs:documentation>Alíquota da CBS</xs:documentation>
+					<xs:documentation>Informar como seria a Alíquota caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vTribRegCBS" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor da CBS</xs:documentation>
+					<xs:documentation>Informar como seria o valor do Tributo caso não cumprida a condição resolutória/suspensiva</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTribCompraGov">
+		<xs:annotation>
+			<xs:documentation>Tipo Tributação Compra Governamental</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="pAliqIBSUF" type="TDec_0302_04RTC"/>
+			<xs:element name="vTribIBSUF" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor que seria devido a UF, sem aplicação do Art. 473. da LC 214/2025</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqIBSMun" type="TDec_0302_04RTC"/>
+			<xs:element name="vTribIBSMun" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor que seria devido ao município, sem aplicação do Art. 473. da LC 214/2025</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pAliqCBS" type="TDec_0302_04RTC"/>
+			<xs:element name="vTribCBS" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor que seria devido a CBS, sem aplicação do Art. 473. da LC 214/2025</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCompraGovReduzido">
+		<xs:annotation>
+			<xs:documentation>Tipo Compras Governamentais</xs:documentation>
+			<xs:documentation>Cada DFe que utilizar deverá utilizar esses tipo no grupo ide</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpEnteGov" type="TEnteGov">
+				<xs:annotation>
+					<xs:documentation>Para administração pública direta e suas autarquias e fundações:
+1=União
+2=Estados
+3=Distrito Federal
+4=Municípios
+5=Consórcio Público
+6=Comitê Gestor do IBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pRedutor" type="TDec_0302_04RTC">
+				<xs:annotation>
+					<xs:documentation>Percentual de redução de aliquota em compra governamental</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="tpOperGov" type="TOperCompraGov">
+				<xs:annotation>
+					<xs:documentation>Tipo da operação com ente governamental:
+1 – Fornecimento com pagamento posterior;
+
+2 - Recebimento do pagamento com fornecimento já realizado;
+
+3 – Fornecimento com pagamento já realizado;
+
+4 – Recebimento do pagamento com fornecimento posterior;</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="refDFeAnt" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Chave de acesso do documento fiscal anterior.
+
+Deverá ser informado para tpOperGov 2 e 3 e vedado para os tipos 1 e 4.
+
+No caso do toOperGov 2 aceitará apenas uma chave referenciada, no tipo 3 poderá aceitar múltiplas chaves
+
+Obs: a chave de acesso deverá ser de um emitente com o mesmo CNPJ base</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCompraGov">
+		<xs:annotation>
+			<xs:documentation>Tipo Compras Governamentais</xs:documentation>
+			<xs:documentation>Cada DFe que utilizar deverá utilizar esses tipo no grupo ide</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpEnteGov" type="TEnteGov">
+				<xs:annotation>
+					<xs:documentation>Para administração pública direta e suas autarquias e fundações:
+1=União
+2=Estados
+3=Distrito Federal
+4=Municípios
+5=Consórcio Público
+6=Comitê Gestor do IBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="pRedutor" type="TDec_0302_04RTC">
+				<xs:annotation>
+					<xs:documentation>Percentual de redução de aliquota em compra governamental</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="tpOperGov" type="TOperCompraGov">
+				<xs:annotation>
+					<xs:documentation>Tipo da operação com ente governamental:
+1 – Fornecimento com pagamento posterior;
+
+2 - Recebimento do pagamento com fornecimento já realizado;
+
+3 – Fornecimento com pagamento já realizado;
+
+4 – Recebimento do pagamento com fornecimento posterior;</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TPagRef">
+		<xs:annotation>
+			<xs:documentation>Tipo Pagamento que ocorre em DFe emitdo anteriormente</xs:documentation>
+			<xs:documentation>Informado para abater as parcelas de antecipação de pagamento, conforme art. 10 §4</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="refDFe" maxOccurs="99">
+				<xs:annotation>
+					<xs:documentation>Chave de acesso do documento fiscal de antecipação de pagamento
+
+Obs: esse DFe deverá ter o indAntecipacaoPgto marcado no grupo ide</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTransfCred">
+		<xs:annotation>
+			<xs:documentation>Tipo Transferência de Crédito</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vIBS" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor do IBS a ser transferido</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vCBS" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor da CBS a ser transferida</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TEstornoCred">
+		<xs:annotation>
+			<xs:documentation>Tipo Estorno de Crédito</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vIBSEstCred" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor do IBS a ser estornado</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vCBSEstCred" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor da CBS a ser estornada</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="TCompetApur">
+		<xs:annotation>
+			<xs:documentation>Ano e mês referência do período de apuração (AAAA-MM)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:gYearMonth">
+			<xs:minInclusive value="2025-01"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="TAjusteCompet">
+		<xs:annotation>
+			<xs:documentation>Tipo Ajuste de Competência</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="competApur" type="TCompetApur">
+				<xs:annotation>
+					<xs:documentation>Ano e mês referência do período de apuração (AAAA-MM)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vIBS" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor do IBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vCBS" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor da CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCredPresOper">
+		<xs:annotation>
+			<xs:documentation>Tipo Crédito Presumido da Operação</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="vBCCredPres" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor da Base de Cálculo do Crédito Presumido da Operação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cCredPres" type="TcCredPres">
+				<xs:annotation>
+					<xs:documentation>Código de Classificação do Crédito Presumido do IBS e da CBS</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gIBSCredPres" type="TCredPres" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de Informações do Crédito Presumido referente ao IBS, quando aproveitado pelo emitente do documento. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="gCBSCredPres" type="TCredPres" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Grupo de Informações do Crédito Presumido referente a CBS, quando aproveitado pelo emitente do documento. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCredPresIBSZFM">
+		<xs:annotation>
+			<xs:documentation>Tipo Informações do crédito presumido de IBS para fornecimentos a partir da ZFM</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="competApur" type="TCompetApur">
+				<xs:annotation>
+					<xs:documentation>Ano e mês referência do período de apuração (AAAA-MM)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="tpCredPresIBSZFM" type="TTpCredPresIBSZFM">
+				<xs:annotation>
+					<xs:documentation>Classificação de acordo com o art. 450, § 1º, da LC 214/25 para o cálculo do crédito presumido na ZFM</xs:documentation>
+					<xs:documentation>0 - Sem crédito presumido;
+1 - Bens de consumo final (55%);
+2 - Bens de capital (75%);
+3 - Bens intermediários (90,25%);
+4 - Bens de informática e outros definidos em legislação (100%).
+OBS: Percentuais definidos no art. 450, § 1º, da LC 214/25 para o cálculo do crédito presumido
+</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="vCredPresIBSZFM" type="TDec1302RTC">
+				<xs:annotation>
+					<xs:documentation>Valor do crédito presumido calculado sobre o saldo devedor apurado</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TPagamentoRTC">
+		<xs:annotation>
+			<xs:documentation>Tipo dados do pagamento para o sistema de arrecadação</xs:documentation>
+			<xs:documentation>Cada DFe que utilizar deverá utilizar esses tipo no grupo ide</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpMeioPgto" type="TMeioPgto">
+				<xs:annotation>
+					<xs:documentation>(Meio de pagamento utilizado (ver IT DFe 2026.001)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CNPJReceb" type="TCnpjRTC">
+				<xs:annotation>
+					<xs:documentation>CNPJ do recebedor do pagamento</xs:documentation>
+					<xs:documentation>Informar zeros não significativos</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="CNPJBasePSP" type="TCnpjBaseRTC">
+				<xs:annotation>
+					<xs:documentation>CNPJ base da instituição financeira</xs:documentation>
+					<xs:documentation>Informar zeros não significativos</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="nPag" use="required">
+			<xs:annotation>
+				<xs:documentation>Número sequencial do pagamento</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:whiteSpace value="preserve"/>
+					<xs:pattern value="[1-9]{1}[0-9]{0,1}|[1-8]{1}[0-9]{2}|[9]{1}[0-8]{1}[0-9]{1}|[9]{1}[9]{1}[0]{1}"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="idTransacao" use="required">
+			<xs:annotation>
+				<xs:documentation>ID específico da transação financeira conforme o meio de pagamento</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="TStringRTC">
+					<xs:minLength value="2"/>
+					<xs:maxLength value="35"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:simpleType name="TMeioPgto">
+		<xs:annotation>
+			<xs:documentation>Tipo de meio de Pagamento do arranjo financeiro</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/GTVe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/GTVe_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="GTVe" type="TGTVe">
+		<xs:annotation>
+			<xs:documentation>Guia de Trasnsporte Eletrônica</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/consSitCTeTiposBasico_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/consSitCTeTiposBasico_v4.00.xsd
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposGeralCTe_v4.00.xsd"/>
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v1.01.xsd"/>
+	<xs:complexType name="TConsSitCTe">
+		<xs:annotation>
+			<xs:documentation>Tipo Pedido de Consulta da Situação Atual do Conhecimento de Transporte eletrônico</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xServ" type="TServ" fixed="CONSULTAR">
+				<xs:annotation>
+					<xs:documentation>Serviço Solicitado</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="chCTe" type="TChDFe">
+				<xs:annotation>
+					<xs:documentation>Chaves de acesso da CT-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" use="required">
+			<xs:simpleType>
+				<xs:restriction base="TVerConsSitCTe"/>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="TRetConsSitCTe">
+		<xs:annotation>
+			<xs:documentation>Tipo Retorno de Pedido de Consulta da Situação Atual do Conhecimento de Transporte eletrônico</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="verAplic" type="TVerAplic">
+				<xs:annotation>
+					<xs:documentation>Versão do Aplicativo que processou o CT-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cStat" type="TStat">
+				<xs:annotation>
+					<xs:documentation>Código do status da mensagem enviada.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMotivo" type="TMotivo">
+				<xs:annotation>
+					<xs:documentation>Descrição literal do status do serviço solicitado.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>código da UF de atendimento</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="protCTe" minOccurs="0">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:any processContents="skip">
+							<xs:annotation>
+								<xs:documentation>Retornar protCTe da versão correspondente do CT-e autorizado</xs:documentation>
+							</xs:annotation>
+						</xs:any>
+					</xs:sequence>
+					<xs:attribute name="versao" use="required">
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:whiteSpace value="preserve"/>
+								<xs:enumeration value="1.03"/>
+								<xs:enumeration value="1.04"/>
+								<xs:enumeration value="2.00"/>
+								<xs:enumeration value="3.00"/>
+								<xs:enumeration value="4.00"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="procEventoCTe" minOccurs="0" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:any>
+							<xs:annotation>
+								<xs:documentation>Retornar procEventoCTe da versão correspondente do evento CT-e autorizado</xs:documentation>
+							</xs:annotation>
+						</xs:any>
+					</xs:sequence>
+					<xs:attribute name="versao" use="required">
+						<xs:simpleType>
+							<xs:restriction base="xs:string">
+								<xs:whiteSpace value="preserve"/>
+								<xs:enumeration value="1.04"/>
+								<xs:enumeration value="2.00"/>
+								<xs:enumeration value="3.00"/>
+								<xs:enumeration value="4.00"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerConsSitCTe" use="required"/>
+	</xs:complexType>
+	<xs:simpleType name="TVerConsSitCTe">
+		<xs:annotation>
+			<xs:documentation> Tipo Versão do Consulta situação de CT-e - 4.00</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="4\.00"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/consSitCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/consSitCTe_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="consSitCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="consSitCTe" type="TConsSitCTe">
+		<xs:annotation>
+			<xs:documentation>Schema de validação XML dp Pedido de Consulta da Situação Atual do CT-e.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/consStatServCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/consStatServCTe_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="consStatServTiposBasico_v4.00.xsd"/>
+	<xs:element name="consStatServCTe" type="TConsStatServ">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do Pedido de Consulta do Status do Serviço CT-e</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/consStatServTiposBasico_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/consStatServTiposBasico_v4.00.xsd
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposGeralCTe_v4.00.xsd"/>
+	<xs:complexType name="TConsStatServ">
+		<xs:annotation>
+			<xs:documentation>Tipo Pedido de Consulta do Status do Serviço CTe</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>Código da UF a ser verificado o status</xs:documentation>
+					<xs:documentation>Utilizar a Tabela do IBGE.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xServ" type="TServ" fixed="STATUS">
+				<xs:annotation>
+					<xs:documentation>Serviço Solicitado</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" use="required">
+			<xs:simpleType>
+				<xs:restriction base="TVerConsStat"/>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="TRetConsStatServ">
+		<xs:annotation>
+			<xs:documentation>Tipo Resultado da Consulta do Status do Serviço CTe</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="verAplic">
+				<xs:annotation>
+					<xs:documentation>Versão do Aplicativo que processou o CT-e</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TVerAplic">
+						<xs:whiteSpace value="collapse"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cStat" type="TStat">
+				<xs:annotation>
+					<xs:documentation>Código do status da mensagem enviada.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMotivo" type="TMotivo">
+				<xs:annotation>
+					<xs:documentation>Descrição literal do status do serviço solicitado.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>Código da UF responsável pelo serviço</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="dhRecbto" type="TDateTimeUTC">
+				<xs:annotation>
+					<xs:documentation>AAAA-MM-DDTHH:MM:SS TZD</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="tMed" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Tempo médio de resposta do serviço (em segundos) dos últimos 5 minutos</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:integer">
+						<xs:pattern value="[0-9]{1,4}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="dhRetorno" type="TDateTimeUTC" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>AAAA-MM-DDTHH:MM:SSDeve ser preenchida com data e hora previstas para o retorno dos serviços prestados.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xObs" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Campo observação utilizado para incluir informações ao contribuinte</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:minLength value="1"/>
+						<xs:maxLength value="255"/>
+						<xs:whiteSpace value="collapse"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerConsStat" use="required"/>
+	</xs:complexType>
+	<xs:simpleType name="TVerConsStat">
+		<xs:annotation>
+			<xs:documentation> Tipo Versão do Consulta do Status do Serviço CTe</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="4\.00"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cteModalAereo_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cteModalAereo_v4.00.xsd
@@ -1,0 +1,240 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposGeralCTe_v4.00.xsd"/>
+	<xs:element name="aereo">
+		<xs:annotation>
+			<xs:documentation>Informações do modal Aéreo</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="nMinu" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Número da Minuta</xs:documentation>
+						<xs:documentation>Documento que precede o CT-e, assinado pelo expedidor, espécie de pedido de serviço</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:pattern value="[0-9]{9}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nOCA" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Número Operacional do Conhecimento Aéreo</xs:documentation>
+						<xs:documentation>Representa o número de controle comumente utilizado pelo conhecimento aéreo composto por uma sequência numérica de onze dígitos. Os três primeiros dígitos representam um código que os operadores de transporte aéreo associados à IATA possuem. Em seguida um número de série de sete dígitos determinados pelo operador de transporte aéreo. Para finalizar, um dígito verificador, que é um sistema de módulo sete imponderado o qual divide o número de série do conhecimento aéreo por sete e usa o resto como dígito de verificação. </xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:pattern value="[0-9]{11}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="dPrevAereo" type="TData">
+					<xs:annotation>
+						<xs:documentation>Data prevista da entrega</xs:documentation>
+						<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="natCarga">
+					<xs:annotation>
+						<xs:documentation>Natureza da carga</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="xDime" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Dimensão</xs:documentation>
+									<xs:documentation>Formato:1234X1234X1234 (cm). Esse campo deve sempre que possível ser preenchido. Entretanto, quando for impossível o preenchimento das dimensões, fica obrigatório o preenchimento da cubagem em metro cúbico do leiaute do CT-e da estrutura genérica (infQ).
+</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="5"/>
+										<xs:maxLength value="14"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="cInfManu" minOccurs="0" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>Informações de manuseio</xs:documentation>
+									<xs:documentation>01 - certificado do expedidor para embarque de animal vivo;
+
+02 - artigo perigoso conforme Declaração do Expedidor anexa;
+
+03 - somente em aeronave cargueira; 
+
+04 - artigo perigoso - declaração do expedidor não requerida; 
+
+05 - artigo perigoso em quantidade isenta;
+
+06 - gelo seco para refrigeração (especificar no campo observações a quantidade); 
+
+07 - não restrito (especificar a Disposição Especial no campo observações);
+
+08 - artigo perigoso em carga consolidada (especificar a quantidade no campo observações)
+;
+09 - autorização da autoridade governamental anexa (especificar no campo observações); 
+
+10 – baterias de íons de lítio em conformidade com a Seção II da PI965 – CAO
+; 
+11 - baterias de íons de lítio em conformidade com a Seção II da PI966
+; 
+12 - baterias de íons de lítio em conformidade com a Seção II da PI967
+; 
+13 – baterias de metal lítio em conformidade com a Seção II da PI968 — CAO; 
+
+14 - baterias de metal lítio em conformidade com a Seção II da PI969; 
+
+15 - baterias de metal lítio em conformidade com a Seção II da PI970
+; 
+99 - outro (especificar no campo observações)
+.</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:enumeration value="01"/>
+										<xs:enumeration value="02"/>
+										<xs:enumeration value="03"/>
+										<xs:enumeration value="04"/>
+										<xs:enumeration value="05"/>
+										<xs:enumeration value="06"/>
+										<xs:enumeration value="07"/>
+										<xs:enumeration value="08"/>
+										<xs:enumeration value="09"/>
+										<xs:enumeration value="10"/>
+										<xs:enumeration value="11"/>
+										<xs:enumeration value="12"/>
+										<xs:enumeration value="13"/>
+										<xs:enumeration value="14"/>
+										<xs:enumeration value="15"/>
+										<xs:enumeration value="99"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="tarifa">
+					<xs:annotation>
+						<xs:documentation>Informações de tarifa</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="CL">
+								<xs:annotation>
+									<xs:documentation>Classe</xs:documentation>
+									<xs:documentation>Preencher com:
+									M - Tarifa Mínima;
+									G - Tarifa Geral;
+									E - Tarifa Específica</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:length value="1"/>
+										<xs:whiteSpace value="preserve"/>
+										<xs:pattern value="M"/>
+										<xs:pattern value="G"/>
+										<xs:pattern value="E"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="cTar" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Código da Tarifa</xs:documentation>
+									<xs:documentation>Deverão ser incluídos os códigos de três dígitos, correspondentes à tarifa.</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="4"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="vTar" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor da Tarifa</xs:documentation>
+									<xs:documentation>Valor da tarifa por kg quando for o caso.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="peri" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Preenchido quando for  transporte de produtos classificados pela ONU como perigosos.</xs:documentation>
+						<xs:documentation>O preenchimento desses campos não desobriga a empresa aérea de emitir os demais documentos que constam na legislação vigente.</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="nONU">
+								<xs:annotation>
+									<xs:documentation>Número ONU/UN</xs:documentation>
+									<xs:documentation>Ver a legislação de transporte de produtos perigosos aplicadas ao modal  </xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:pattern value="[0-9]{4}|ND"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="qTotEmb">
+								<xs:annotation>
+									<xs:documentation>Quantidade total de volumes contendo artigos perigosos</xs:documentation>
+									<xs:documentation>Preencher com o número de volumes (unidades) de artigos perigosos, ou seja, cada embalagem devidamente marcada e etiquetada (por ex.: número de caixas, de tambores, de bombonas, dentre outros). Não deve ser preenchido com o número de ULD, pallets ou containers.</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="20"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="infTotAP">
+								<xs:annotation>
+									<xs:documentation>Grupo de informações das quantidades totais de artigos perigosos</xs:documentation>
+									<xs:documentation>Preencher conforme a legislação de transporte de produtos perigosos aplicada ao modal</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="qTotProd" type="TDec_1104">
+											<xs:annotation>
+												<xs:documentation>Quantidade total de artigos perigosos</xs:documentation>
+												<xs:documentation>15 posições, sendo 11 inteiras e 4 decimais. 
+Deve indicar a quantidade total do artigo perigoso, tendo como base a unidade referenciada na Tabela 3-1 do Doc 9284, por exemplo: litros; quilogramas; quilograma bruto etc. O preenchimento não deve, entretanto, incluir a unidade de medida. No caso de transporte de material radioativo, deve-se indicar o somatório dos Índices de Transporte (TI). Não indicar a quantidade do artigo perigoso por embalagem.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="uniAP">
+											<xs:annotation>
+												<xs:documentation>Unidade de medida</xs:documentation>
+												<xs:documentation>1 – KG; 
+2 – KG G (quilograma bruto);
+3 – LITROS;
+4 – TI (índice de transporte para radioativos); 5- Unidades (apenas para artigos perigosos medidos em unidades que não se enquadram nos itens acima. Exemplo: baterias, celulares, equipamentos, veículos, dentre outros)</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="1"/>
+													<xs:maxLength value="1"/>
+													<xs:enumeration value="1"/>
+													<xs:enumeration value="2"/>
+													<xs:enumeration value="3"/>
+													<xs:enumeration value="4"/>
+													<xs:enumeration value="5"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cteModalAquaviario_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cteModalAquaviario_v4.00.xsd
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="aquav">
+		<xs:annotation>
+			<xs:documentation>Informações do modal Aquaviário</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="vPrest" type="TDec_1302">
+					<xs:annotation>
+						<xs:documentation>Valor da Prestação Base de Cálculo do AFRMM</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vAFRMM" type="TDec_1302">
+					<xs:annotation>
+						<xs:documentation>AFRMM (Adicional de Frete para Renovação da Marinha Mercante)</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="xNavio">
+					<xs:annotation>
+						<xs:documentation>Identificação do Navio </xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TString">
+							<xs:maxLength value="60"/>
+							<xs:minLength value="1"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="balsa" minOccurs="0" maxOccurs="3">
+					<xs:annotation>
+						<xs:documentation>Grupo de informações das balsas</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="xBalsa">
+								<xs:annotation>
+									<xs:documentation>Identificador da Balsa</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="60"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="nViag" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Número da Viagem</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:pattern value="[1-9]{1}[0-9]{0,9}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="direc">
+					<xs:annotation>
+						<xs:documentation>Direção</xs:documentation>
+						<xs:documentation>Preencher com: N-Norte, L-Leste, S-Sul, O-Oeste  </xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="N"/>
+							<xs:enumeration value="S"/>
+							<xs:enumeration value="L"/>
+							<xs:enumeration value="O"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="irin">
+					<xs:annotation>
+						<xs:documentation>Irin do navio sempre deverá ser informado</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:maxLength value="10"/>
+							<xs:minLength value="1"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="detCont" minOccurs="0" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Grupo de informações de detalhamento dos conteiners 
+(Somente para Redespacho Intermediário e Serviço Vinculado a Multimodal)</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="nCont" type="TContainer">
+								<xs:annotation>
+									<xs:documentation>Identificação do Container</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="lacre" minOccurs="0" maxOccurs="3">
+								<xs:annotation>
+									<xs:documentation>Grupo de informações dos lacres dos cointainers da qtde da carga </xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="nLacre">
+											<xs:annotation>
+												<xs:documentation>Lacre</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="1"/>
+													<xs:maxLength value="20"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="infDoc" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Informações dos documentos dos conteiners</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:choice>
+										<xs:element name="infNF" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>Informações das NF</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="serie">
+														<xs:annotation>
+															<xs:documentation>Série</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="3"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="nDoc">
+														<xs:annotation>
+															<xs:documentation>Número </xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="20"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="unidRat" type="TDec_0302_0303" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Unidade de medida rateada (Peso,Volume)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infNFe" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>Informações das NFe</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="chave" type="TChDFe">
+														<xs:annotation>
+															<xs:documentation>Chave de acesso da NF-e</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="unidRat" type="TDec_0302_0303" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Unidade de medida rateada (Peso,Volume)</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+									</xs:choice>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="tpNav" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Tipo de Navegação</xs:documentation>
+						<xs:documentation>Preencher com: 
+						0 - Interior;
+						1 - Cabotagem</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="0"/>
+							<xs:enumeration value="1"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cteModalDutoviario_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cteModalDutoviario_v4.00.xsd
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposGeralCTe_v4.00.xsd"/>
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="duto">
+		<xs:annotation>
+			<xs:documentation>Informações do modal Dutoviário</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="vTar" type="TDec_0906Opc" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Valor da tarifa</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="dIni" type="TData">
+					<xs:annotation>
+						<xs:documentation>Data de Início da prestação do serviço</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="dFim" type="TData">
+					<xs:annotation>
+						<xs:documentation>Data de Fim da prestação do serviço</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="classDuto" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Classificação do Dutoviário</xs:documentation>
+						<xs:documentation>Informar: 1 - Gasoduto 2 - Mineroduto 3 - Oleoduto</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="1"/>
+							<xs:enumeration value="2"/>
+							<xs:enumeration value="3"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="tpContratacao" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Tipo de contratação do serviço de transporte (apenas para gasoduto)</xs:documentation>
+						<xs:documentation>Informar:
+0 - Ponta a ponto
+1 - Capacidade de Entrada 
+2 - Capacidade de Saida</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="0"/>
+							<xs:enumeration value="1"/>
+							<xs:enumeration value="2"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="codPontoEntrada" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Código do Ponto de Entrada</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TString">
+							<xs:minLength value="2"/>
+							<xs:maxLength value="20"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="codPontoSaida" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Código do Ponto de Saída</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TString">
+							<xs:minLength value="2"/>
+							<xs:maxLength value="20"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nContrato" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Número do Contrato de Capacidade</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TString">
+							<xs:minLength value="2"/>
+							<xs:maxLength value="20"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cteModalFerroviario_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cteModalFerroviario_v4.00.xsd
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposGeralCTe_v4.00.xsd"/>
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:complexType name="TEnderFer">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Endereço</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="xLgr">
+				<xs:annotation>
+					<xs:documentation>Logradouro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="255"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="nro" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Número</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xCpl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Complemento</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xBairro" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Bairro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cMun" type="TCodMunIBGE">
+				<xs:annotation>
+					<xs:documentation>Código do município</xs:documentation>
+					<xs:documentation> Utilizar a tabela do IBGE
+					Informar 9999999 para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMun">
+				<xs:annotation>
+					<xs:documentation>Nome do município</xs:documentation>
+					<xs:documentation>Informar EXTERIOR para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="CEP">
+				<xs:annotation>
+					<xs:documentation>CEP</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{8}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUf">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF</xs:documentation>
+					<xs:documentation>Informar EX para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:element name="ferrov">
+		<xs:annotation>
+			<xs:documentation>Informações do modal Ferroviário</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="tpTraf">
+					<xs:annotation>
+						<xs:documentation>Tipo de Tráfego</xs:documentation>
+						<xs:documentation>Preencher com:
+						0-Próprio;
+						1-Mútuo;
+						2-Rodoferroviário;
+						3-Rodoviário.</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="0"/>
+							<xs:enumeration value="1"/>
+							<xs:enumeration value="2"/>
+							<xs:enumeration value="3"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="trafMut" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Detalhamento de informações para o tráfego mútuo</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="respFat">
+								<xs:annotation>
+									<xs:documentation>Responsável pelo Faturamento</xs:documentation>
+									<xs:documentation>Preencher com: 
+									1-Ferrovia de origem; 
+									2-Ferrovia de destino</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:enumeration value="1"/>
+										<xs:enumeration value="2"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="ferrEmi">
+								<xs:annotation>
+									<xs:documentation>Ferrovia Emitente do CTe</xs:documentation>
+									<xs:documentation>Preencher com: 
+									1-Ferrovia de origem; 
+									2-Ferrovia de destino</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:enumeration value="1"/>
+										<xs:enumeration value="2"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="vFrete" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do Frete do Tráfego Mútuo</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="chCTeFerroOrigem" type="TChDFe" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Chave de acesso do CT-e emitido pelo ferrovia de origem</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="ferroEnv" minOccurs="0" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>Informações das Ferrovias Envolvidas</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="CNPJ" type="TCnpj">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+												<xs:documentation>Informar o CNPJ da Ferrovia Envolvida. Caso a Ferrovia envolvida não seja inscrita no CNPJ o campo deverá preenchido com zeros.
+Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="cInt" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Código interno da Ferrovia envolvida</xs:documentation>
+												<xs:documentation>Uso da transportadora</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="1"/>
+													<xs:maxLength value="10"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="IE" type="TIe" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Inscrição Estadual</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="xNome">
+											<xs:annotation>
+												<xs:documentation>Razão Social ou Nome</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:maxLength value="60"/>
+													<xs:minLength value="2"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="enderFerro" type="TEnderFer">
+											<xs:annotation>
+												<xs:documentation>Dados do endereço da ferrovia envolvida</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="fluxo">
+					<xs:annotation>
+						<xs:documentation>Fluxo Ferroviário</xs:documentation>
+						<xs:documentation>Trata-se de um número identificador do contrato firmado com o cliente </xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TString">
+							<xs:minLength value="1"/>
+							<xs:maxLength value="10"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cteModalRodoviarioOS_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cteModalRodoviarioOS_v4.00.xsd
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposGeralCTe_v4.00.xsd"/>
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:simpleType name="TTermoAutFreta">
+		<xs:annotation>
+			<xs:documentation>Tipo Termo  de Autorização de Fretamento – TAF</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="12"/>
+			<xs:pattern value="[0-9]{12}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TNroRegEstadual">
+		<xs:annotation>
+			<xs:documentation>Tipo Número de Registro Estadual</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="25"/>
+			<xs:pattern value="[0-9]{25}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:element name="rodoOS">
+		<xs:annotation>
+			<xs:documentation>Informações do modal Rodoviário</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:choice>
+					<xs:element name="TAF" type="TTermoAutFreta">
+						<xs:annotation>
+							<xs:documentation>Termo de Autorização de Fretamento – TAF</xs:documentation>
+							<xs:documentation>Registro obrigatório do emitente do CT-e OS junto à ANTT, de acordo com a Resolução ANTT nº 4.777/2015</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="NroRegEstadual" type="TNroRegEstadual">
+						<xs:annotation>
+							<xs:documentation>Número do Registro Estadual </xs:documentation>
+							<xs:documentation>Registro obrigatório do emitente do CT-e OS junto à Agência Reguladora  Estadual.					</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+				</xs:choice>
+				<xs:element name="veic" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Dados do Veículo</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="placa">
+								<xs:annotation>
+									<xs:documentation>Placa do veículo </xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TPlaca"/>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="RENAVAM" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>RENAVAM do veículo </xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="9"/>
+										<xs:maxLength value="11"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="prop" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Proprietário ou possuidor do Veículo.
+Só preenchido quando o veículo não pertencer à empresa emitente do CT-e OS</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:choice>
+											<xs:element name="CPF" type="TCpf">
+												<xs:annotation>
+													<xs:documentation>Número do CPF</xs:documentation>
+													<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+											<xs:element name="CNPJ" type="TCnpjOpc">
+												<xs:annotation>
+													<xs:documentation>Número do CNPJ</xs:documentation>
+													<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+										</xs:choice>
+										<xs:choice>
+											<xs:element name="TAF" type="TTermoAutFreta">
+												<xs:annotation>
+													<xs:documentation>Termo de Autorização de Fretamento – TAF</xs:documentation>
+													<xs:documentation>De acordo com a Resolução ANTT nº 4.777/2015						</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+											<xs:element name="NroRegEstadual" type="TNroRegEstadual">
+												<xs:annotation>
+													<xs:documentation>Número do Registro Estadual </xs:documentation>
+													<xs:documentation>Registro obrigatório do emitente do CT-e OS junto à Agência Reguladora  Estadual						</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+										</xs:choice>
+										<xs:element name="xNome">
+											<xs:annotation>
+												<xs:documentation>Razão Social ou Nome do proprietário</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:maxLength value="60"/>
+													<xs:minLength value="2"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:sequence minOccurs="0">
+											<xs:element name="IE">
+												<xs:annotation>
+													<xs:documentation>Inscrição Estadual</xs:documentation>
+												</xs:annotation>
+												<xs:simpleType>
+													<xs:restriction base="TIeDest"/>
+												</xs:simpleType>
+											</xs:element>
+											<xs:element name="UF" type="TUf">
+												<xs:annotation>
+													<xs:documentation>UF</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+										</xs:sequence>
+										<xs:element name="tpProp">
+											<xs:annotation>
+												<xs:documentation>Tipo Proprietário ou possuidor</xs:documentation>
+												<xs:documentation>Preencher com:
+												0-TAC – Agregado;
+												1-TAC Independente; ou 
+												2 – Outros.</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:whiteSpace value="preserve"/>
+													<xs:enumeration value="0"/>
+													<xs:enumeration value="1"/>
+													<xs:enumeration value="2"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="UF" type="TUf" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>UF em que veículo está licenciado</xs:documentation>
+									<xs:documentation>Sigla da UF de licenciamento do veículo.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="infFretamento" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Dados do fretamento (apenas para Transporte de Pessoas)</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="tpFretamento">
+								<xs:annotation>
+									<xs:documentation>Tipo Fretamento</xs:documentation>
+									<xs:documentation>Preencher com:
+ 1 - Eventual 2 - Continuo								</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:enumeration value="1"/>
+										<xs:enumeration value="2"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="dhViagem" type="TDateTimeUTC" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Data e hora da viagem (Apenas para fretamento eventual)</xs:documentation>
+									<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cteModalRodoviario_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cteModalRodoviario_v4.00.xsd
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposGeralCTe_v4.00.xsd"/>
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="rodo">
+		<xs:annotation>
+			<xs:documentation>Informações do modal Rodoviário</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="RNTRC">
+					<xs:annotation>
+						<xs:documentation>Registro Nacional de Transportadores Rodoviários de Carga</xs:documentation>
+						<xs:documentation>Registro obrigatório do emitente do CT-e junto à ANTT para exercer a atividade de transportador rodoviário de cargas por conta de terceiros e mediante remuneração.
+						</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TRNTRC"/>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="occ" minOccurs="0" maxOccurs="10">
+					<xs:annotation>
+						<xs:documentation>Ordens de Coleta associados</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="serie" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Série da OCC</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="3"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="nOcc">
+								<xs:annotation>
+									<xs:documentation>Número da Ordem de coleta</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:pattern value="[1-9]{1}[0-9]{0,5}"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="dEmi" type="TData">
+								<xs:annotation>
+									<xs:documentation>Data de emissão da ordem de coleta</xs:documentation>
+									<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="emiOcc">
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="CNPJ" type="TCnpj">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+												<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="cInt" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Código interno de uso da transportadora</xs:documentation>
+												<xs:documentation>Uso intermo das transportadoras.</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="1"/>
+													<xs:maxLength value="10"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="IE" type="TIe">
+											<xs:annotation>
+												<xs:documentation>Inscrição Estadual</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="UF" type="TUf">
+											<xs:annotation>
+												<xs:documentation>Sigla da UF</xs:documentation>
+												<xs:documentation>Informar EX para operações com o exterior.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="fone" type="TFone" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Telefone</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cteMultiModal_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cteMultiModal_v4.00.xsd
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="tiposGeralCTe_v4.00.xsd"/>
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="multimodal">
+		<xs:annotation>
+			<xs:documentation>Informações do Multimodal</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="COTM">
+					<xs:annotation>
+						<xs:documentation>Número do Certificado do Operador de Transporte Multimodal</xs:documentation>
+						<xs:documentation/>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:minLength value="1"/>
+							<xs:maxLength value="20"/>
+							<xs:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="indNegociavel">
+					<xs:annotation>
+						<xs:documentation>Indicador Negociável
+Preencher com: 0 - Não Negociável; 1 - Negociável</xs:documentation>
+						<xs:documentation/>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="0"/>
+							<xs:enumeration value="1"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="seg" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Informações de Seguro do Multimodal</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="infSeg">
+								<xs:annotation>
+									<xs:documentation>Informações da seguradora</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="xSeg">
+											<xs:annotation>
+												<xs:documentation>Nome da Seguradora</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="1"/>
+													<xs:maxLength value="30"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="CNPJ" type="TCnpjOpc">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ da seguradora</xs:documentation>
+												<xs:documentation>Obrigatório apenas se responsável pelo seguro for (2) responsável pela contratação do transporte - pessoa jurídica</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="nApol">
+								<xs:annotation>
+									<xs:documentation>Número da Apólice</xs:documentation>
+									<xs:documentation>Obrigatório pela lei 11.442/07 (RCTRC)</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="20"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="nAver">
+								<xs:annotation>
+									<xs:documentation>Número da Averbação</xs:documentation>
+									<xs:documentation>Não é obrigatório, pois muitas averbações ocorrem aapós a emissão do CT, mensalmente, por exemplo.</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="20"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cteOS_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cteOS_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="CTeOS" type="TCTeOS">
+		<xs:annotation>
+			<xs:documentation>Conhecimento de Transporte Eletrônico Outros Serviços</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cteSimp_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cteSimp_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="CTeSimp" type="TCTeSimp">
+		<xs:annotation>
+			<xs:documentation>Conhecimento de Transporte Eletrônico Simplificado</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cteTiposBasico_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cteTiposBasico_v4.00.xsd
@@ -1,0 +1,8038 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2025 rel. 2 (x64) (https://www.altova.com) by PROCERGS (Procergs - Centro de Tecnologia da Informação e Comunicação do Estado do Rio Grande do Sul S.A.) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v1.01.xsd"/>
+	<xs:include schemaLocation="tiposGeralCTe_v4.00.xsd"/>
+	<xs:include schemaLocation="DFeTiposBasicos_v1.00.xsd"/>
+	<xs:simpleType name="TModTranspGTVe">
+		<xs:annotation>
+			<xs:documentation> Tipo Modal transporte GTVe</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="01"/>
+			<xs:enumeration value="06"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TFinGTVe">
+		<xs:annotation>
+			<xs:documentation>Tipo Finalidade da GTV-e</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="TGTVe">
+		<xs:annotation>
+			<xs:documentation>Tipo Guia de Transporte de Valores Eletrônica (Modelo 64)</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infCte">
+				<xs:annotation>
+					<xs:documentation>Informações do CT-e do tipo GTV-e</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ide">
+							<xs:annotation>
+								<xs:documentation>Identificação da GTV-e </xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="cUF" type="TCodUfIBGE">
+										<xs:annotation>
+											<xs:documentation>Código da UF do emitente da GTV-e.</xs:documentation>
+											<xs:documentation>Utilizar a Tabela do IBGE.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="cCT">
+										<xs:annotation>
+											<xs:documentation>Código numérico que compõe a Chave de Acesso. </xs:documentation>
+											<xs:documentation>Número aleatório gerado pelo emitente para cada CT-e, com o objetivo de evitar acessos indevidos ao documento.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{8}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="CFOP" type="TCfop">
+										<xs:annotation>
+											<xs:documentation>Código Fiscal de Operações e Prestações</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="natOp">
+										<xs:annotation>
+											<xs:documentation>Natureza da Operação</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="mod" type="TModGTVe">
+										<xs:annotation>
+											<xs:documentation>Modelo do documento fiscal</xs:documentation>
+											<xs:documentation>Utilizar o código 64 para identificação do CT-e Guia de Transporte de Valores</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="serie">
+										<xs:annotation>
+											<xs:documentation>Série da GTV-e</xs:documentation>
+											<xs:documentation>Preencher com "0" no caso de série única</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TSerie"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="nCT" type="TNF">
+										<xs:annotation>
+											<xs:documentation>Número da GTV-e</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="dhEmi">
+										<xs:annotation>
+											<xs:documentation>Data e hora de emissão da GTV-e</xs:documentation>
+											<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TDateTimeUTC"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpImp">
+										<xs:annotation>
+											<xs:documentation>Formato de impressão do DACTE</xs:documentation>
+											<xs:documentation>Preencher com: 1 - Retrato; 2 - Paisagem.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpEmis">
+										<xs:annotation>
+											<xs:documentation>Forma de emissão da GTV-e</xs:documentation>
+											<xs:documentation>Preencher com:
+1 - Normal;
+2- Contingencia offline </xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cDV">
+										<xs:annotation>
+											<xs:documentation>Digito Verificador da chave de acesso da GTV-e</xs:documentation>
+											<xs:documentation>Informar o dígito  de controle da chave de acesso do CT-e, que deve ser calculado com a aplicação do algoritmo módulo 11 (base 2,9) da chave de acesso. </xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{1}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpAmb" type="TAmb">
+										<xs:annotation>
+											<xs:documentation>Tipo do Ambiente</xs:documentation>
+											<xs:documentation>Preencher com:1 - Produção; 2 - Homologação</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpCTe">
+										<xs:annotation>
+											<xs:documentation>Tipo da GTV-e</xs:documentation>
+											<xs:documentation>Preencher com:
+ 4 - GTV-e</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TFinGTVe"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="verProc">
+										<xs:annotation>
+											<xs:documentation>Versão do processo de emissão</xs:documentation>
+											<xs:documentation>Iinformar a versão do aplicativo emissor de CT-e.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="20"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cMunEnv" type="TCodMunIBGE">
+										<xs:annotation>
+											<xs:documentation>Código do Município de envio da GTV-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Utilizar a tabela do IBGE. Informar 9999999 para as operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="xMunEnv">
+										<xs:annotation>
+											<xs:documentation>Nome do Município de envio da GTV-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Informar PAIS/Municipio para as operações com o exterior.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="UFEnv" type="TUf">
+										<xs:annotation>
+											<xs:documentation>Sigla da UF de envio da GTV-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="modal">
+										<xs:annotation>
+											<xs:documentation>Modal da GTV-e</xs:documentation>
+											<xs:documentation>Preencher com:
+01-Rodoviário 
+06-Multimodal</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TModTranspGTVe">
+												<xs:enumeration value="01"/>
+												<xs:enumeration value="06"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpServ">
+										<xs:annotation>
+											<xs:documentation>Tipo do Serviço</xs:documentation>
+											<xs:documentation>Preencher com: 
+
+9 - GTV</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="9"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="indIEToma">
+										<xs:annotation>
+											<xs:documentation>Indicador da IE do tomador:
+1 – Contribuinte ICMS;
+2 – Contribuinte isento de inscrição;
+9 – Não Contribuinte</xs:documentation>
+											<xs:documentation>Aplica-se ao tomador que for indicado no toma3 ou toma4</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="9"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="dhSaidaOrig">
+										<xs:annotation>
+											<xs:documentation>Data e hora de saida da origem</xs:documentation>
+											<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TDateTimeUTC"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="dhChegadaDest">
+										<xs:annotation>
+											<xs:documentation>Data e hora de chegada no destino</xs:documentation>
+											<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TDateTimeUTC"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:choice>
+										<xs:element name="toma">
+											<xs:annotation>
+												<xs:documentation>Indicador do "papel" do tomador do serviço no GT-e</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="toma">
+														<xs:annotation>
+															<xs:documentation>Tomador do Serviço</xs:documentation>
+															<xs:documentation>Preencher com:
+															0-Remetente;
+															1-Destinatário
+															</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:whiteSpace value="preserve"/>
+																<xs:enumeration value="0"/>
+																<xs:enumeration value="1"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="tomaTerceiro">
+											<xs:annotation>
+												<xs:documentation>Indicador do "papel" do tomador do serviço no CTV-e</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="toma">
+														<xs:annotation>
+															<xs:documentation>Tomador do Serviço</xs:documentation>
+															<xs:documentation>Preencher com: 
+															4 - Outros
+															Obs: Informar os dados cadastrais do tomador do serviço</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:whiteSpace value="preserve"/>
+																<xs:enumeration value="4"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:choice>
+														<xs:element name="CNPJ" type="TCnpjOpc">
+															<xs:annotation>
+																<xs:documentation>Número do CNPJ</xs:documentation>
+																<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.															
+Informar os zeros não significativos.</xs:documentation>
+															</xs:annotation>
+														</xs:element>
+														<xs:element name="CPF" type="TCpf">
+															<xs:annotation>
+																<xs:documentation>Número do CPF</xs:documentation>
+																<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+															</xs:annotation>
+														</xs:element>
+													</xs:choice>
+													<xs:element name="IE" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Inscrição Estadual</xs:documentation>
+															<xs:documentation>Informar a IE do tomador ou ISENTO se tomador é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o tomador não seja contribuinte do ICMS não informar o conteúdo.</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TIeDest"/>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="xNome">
+														<xs:annotation>
+															<xs:documentation>Razão Social ou Nome</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:maxLength value="60"/>
+																<xs:minLength value="2"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="xFant" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Nome Fantasia</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:maxLength value="60"/>
+																<xs:minLength value="2"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="fone" type="TFone" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Telefone</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="enderToma" type="TEndereco">
+														<xs:annotation>
+															<xs:documentation>Dados do endereço</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="email" type="TEmail" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Endereço de email</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+									</xs:choice>
+									<xs:sequence minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informar apenas
+para tpEmis diferente de 1</xs:documentation>
+										</xs:annotation>
+										<xs:element name="dhCont" type="TDateTimeUTC">
+											<xs:annotation>
+												<xs:documentation>Data e Hora da entrada em contingência</xs:documentation>
+												<xs:documentation>Informar a data e hora no formato AAAA-MM-DDTHH:MM:SS</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="xJust">
+											<xs:annotation>
+												<xs:documentation>Justificativa da entrada em contingência</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="15"/>
+													<xs:maxLength value="256"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="compl" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Dados complementares da GTV-e para fins operacionais ou comerciais</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="xCaracAd" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Característica adicional do transporte</xs:documentation>
+											<xs:documentation>Texto livre:
+REENTREGA; DEVOLUÇÃO; REFATURAMENTO; etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="15"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xCaracSer" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Característica adicional do serviço</xs:documentation>
+											<xs:documentation>Texto livre:
+											ENTREGA EXPRESSA; LOGÍSTICA REVERSA; CONVENCIONAL; EMERGENCIAL; etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="30"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xEmi" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Funcionário emissor da GTV-e</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="20"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xObs" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Observações Gerais</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="2000"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="ObsCont" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Campo de uso livre do contribuinte</xs:documentation>
+											<xs:documentation>Informar o nome do campo no atributo xCampo e o conteúdo do campo no XTexto</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xTexto">
+													<xs:annotation>
+														<xs:documentation>Conteúdo do campo</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="160"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="xCampo" use="required">
+												<xs:annotation>
+													<xs:documentation>Identificação do campo</xs:documentation>
+												</xs:annotation>
+												<xs:simpleType>
+													<xs:restriction base="TString">
+														<xs:minLength value="1"/>
+														<xs:maxLength value="20"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="ObsFisco" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Campo de uso livre do contribuinte</xs:documentation>
+											<xs:documentation>Informar o nome do campo no atributo xCampo e o conteúdo do campo no XTexto</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xTexto">
+													<xs:annotation>
+														<xs:documentation>Conteúdo do campo</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="xCampo" use="required">
+												<xs:annotation>
+													<xs:documentation>Identificação do campo</xs:documentation>
+												</xs:annotation>
+												<xs:simpleType>
+													<xs:restriction base="TString">
+														<xs:minLength value="1"/>
+														<xs:maxLength value="20"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="emit">
+							<xs:annotation>
+								<xs:documentation>Identificação do Emitente da GTV-e </xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="CNPJ" type="TCnpj">
+										<xs:annotation>
+											<xs:documentation>CNPJ do emitente</xs:documentation>
+											<xs:documentation>Informar zeros não significativos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="IE">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual do Emitente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIe"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="IEST" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual do Substituto Tributário</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIe"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão social ou Nome do emitente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xFant" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Nome fantasia</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="enderEmit" type="TEndeEmi">
+										<xs:annotation>
+											<xs:documentation>Endereço do emitente</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="rem">
+							<xs:annotation>
+								<xs:documentation>Informações do Remetente </xs:documentation>
+								<xs:documentation>Poderá não ser informado para os CT-e de redespacho intermediário e serviço vinculado a multimodal. Nos demais casos deverá sempre ser informado.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpjOpc">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+												<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.
+												Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>Número do CPF</xs:documentation>
+												<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="IE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual</xs:documentation>
+											<xs:documentation>Informar a IE do remetente ou ISENTO se remetente é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o remetente não seja contribuinte do ICMS não informar a tag.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIeDest"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão social ou nome do remetente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xFant" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Nome fantasia</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fone" type="TFone" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Telefone</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="enderReme" type="TEndereco">
+										<xs:annotation>
+											<xs:documentation>Dados do endereço</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="email" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Endereço de email</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TEmail"/>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="dest">
+							<xs:annotation>
+								<xs:documentation>Informações do Destinatário </xs:documentation>
+								<xs:documentation>Poderá não ser informado para os CT-e de redespacho intermediário e serviço vinculado a multimodal. Nos demais casos deverá sempre ser informado.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpjOpc">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+												<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.
+												Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>Número do CPF</xs:documentation>
+												<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="IE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual</xs:documentation>
+											<xs:documentation>Informar a IE do destinatário ou ISENTO se destinatário é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o destinatário não seja contribuinte do ICMS não informar o conteúdo.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIeDest"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão Social ou Nome do destinatário</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fone" type="TFone" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Telefone</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="ISUF" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição na SUFRAMA</xs:documentation>
+											<xs:documentation>(Obrigatório nas operações com as áreas com benefícios de incentivos fiscais sob controle da SUFRAMA)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{8,9}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="enderDest" type="TEndereco">
+										<xs:annotation>
+											<xs:documentation>Dados do endereço</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="email" type="TEmail" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Endereço de email</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="origem" type="TEndeEmi" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do endereço da origem do serviço</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="destino" type="TEndeEmi" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do endereço do destino do serviço</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="detGTV">
+							<xs:annotation>
+								<xs:documentation>Grupo de informações detalhadas da GTV-e </xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="infEspecie" maxOccurs="unbounded">
+										<xs:annotation>
+											<xs:documentation>Informações das Espécies transportadas</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="tpEspecie">
+													<xs:annotation>
+														<xs:documentation>Tipo da Espécie</xs:documentation>
+														<xs:documentation>1 - Cédula
+2 - Cheque
+3 - Moeda
+4 - Outros</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:enumeration value="1"/>
+															<xs:enumeration value="2"/>
+															<xs:enumeration value="3"/>
+															<xs:enumeration value="4"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="vEspecie" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor Transportada em Espécie indicada</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="tpNumerario">
+													<xs:annotation>
+														<xs:documentation>Nacionalidade do Numerário</xs:documentation>
+														<xs:documentation>1 - Nacional
+2 - Estrangeiro</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:enumeration value="1"/>
+															<xs:enumeration value="2"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="xMoedaEstr" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Nome da Moeda</xs:documentation>
+														<xs:documentation>Informar somente se tipo de numerário for 2 - Estrangeiro</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="60"/>
+															<xs:minLength value="2"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="qCarga" type="TDec_1104">
+										<xs:annotation>
+											<xs:documentation>Quantidade de volumes/malotes</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="infVeiculo" maxOccurs="unbounded">
+										<xs:annotation>
+											<xs:documentation>Grupo de informações dos veículos utilizados no transporte de valores</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="placa" type="TPlaca">
+													<xs:annotation>
+														<xs:documentation>Placa do veículo </xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="UF" type="TUf" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>UF em que veículo está licenciado</xs:documentation>
+														<xs:documentation>Sigla da UF de licenciamento do veículo.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="RNTRC" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>RNTRC do transportador</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="[0-9]{8}|ISENTO"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="autXML" minOccurs="0" maxOccurs="10">
+							<xs:annotation>
+								<xs:documentation>Autorizados para download do XML do DF-e</xs:documentation>
+								<xs:documentation>Informar CNPJ ou CPF. Preencher os zeros não significativos.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpj">
+											<xs:annotation>
+												<xs:documentation>CNPJ do autorizado</xs:documentation>
+												<xs:documentation>Informar zeros não significativos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>CPF do autorizado</xs:documentation>
+												<xs:documentation>Informar zeros não significativos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infRespTec" type="TRespTec" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do Responsável Técnico pela emissão do DF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="versao" use="required">
+						<xs:annotation>
+							<xs:documentation>Versão do leiaute</xs:documentation>
+							<xs:documentation>Ex: "4.00"</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="TVerCTe"/>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="Id" use="required">
+						<xs:annotation>
+							<xs:documentation>Identificador da tag a ser assinada</xs:documentation>
+							<xs:documentation>Informar a chave de acesso do CT-e OS e precedida do literal "CTe"</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:ID">
+								<xs:pattern value="CTe[0-9]{6}[A-Z0-9]{12}[0-9]{26}"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="infCTeSupl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informações suplementares da GTV-e</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="qrCodCTe">
+							<xs:annotation>
+								<xs:documentation>Texto com o QR-Code impresso no DACTE</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:minLength value="50"/>
+									<xs:maxLength value="1000"/>
+									<xs:pattern value="((HTTPS?|https?)://.*\?chCTe=[0-9]{6}[A-Z0-9]{12}[0-9]{26}&amp;tpAmb=[1-2](&amp;sign=[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1})?)"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature"/>
+		</xs:sequence>
+		<xs:attribute name="versao" use="required">
+			<xs:annotation>
+				<xs:documentation>Versão do leiaute</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="TVerCTe"/>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="TProtCTe">
+		<xs:annotation>
+			<xs:documentation>Tipo Protocolo de status resultado do processamento da CT-e</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infProt">
+				<xs:annotation>
+					<xs:documentation>Dados do protocolo de status</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="verAplic" type="TVerAplic">
+							<xs:annotation>
+								<xs:documentation>Versão do Aplicativo que processou o CT-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="chCTe" type="TChDFe">
+							<xs:annotation>
+								<xs:documentation>Chaves de acesso da CT-e, </xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="dhRecbto" type="TDateTimeUTC">
+							<xs:annotation>
+								<xs:documentation>Data e hora de processamento, no formato AAAA-MM-DDTHH:MM:SS TZD. </xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nProt" type="TProt" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número do Protocolo de Status do CT-e. </xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="digVal" type="ds:DigestValueType" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Digest Value da CT-e processado. Utilizado para conferir a integridade do CT-e original.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cStat">
+							<xs:annotation>
+								<xs:documentation>Código do status do CT-e.</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TStat"/>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="xMotivo" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Descrição literal do status do CT-e.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" type="xs:ID" use="optional"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="infFisco" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Mensagem do Fisco</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="cMsg">
+							<xs:annotation>
+								<xs:documentation>Código do status da mensagem do fisco</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TStat"/>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="xMsg" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Mensagem do Fisco</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="versao" use="required">
+			<xs:simpleType>
+				<xs:restriction base="TVerCTe"/>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="TProtCTeOS">
+		<xs:annotation>
+			<xs:documentation>Tipo Protocolo de status resultado do processamento do CT-e OS (Modelo 67)</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infProt">
+				<xs:annotation>
+					<xs:documentation>Dados do protocolo de status</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="verAplic" type="TVerAplic">
+							<xs:annotation>
+								<xs:documentation>Versão do Aplicativo que processou o CT-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="chCTe" type="TChDFe">
+							<xs:annotation>
+								<xs:documentation>Chaves de acesso da CT-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="dhRecbto" type="TDateTimeUTC">
+							<xs:annotation>
+								<xs:documentation>Data e hora de processamento, no formato AAAA-MM-DDTHH:MM:SS TZD. </xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nProt" type="TProt" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número do Protocolo de Status do CT-e.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="digVal" type="ds:DigestValueType" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Digest Value da CT-e processado. Utilizado para conferir a integridade do CT-e original.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cStat">
+							<xs:annotation>
+								<xs:documentation>Código do status do CT-e.</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TStat"/>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="xMotivo" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Descrição literal do status do CT-e.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" type="xs:ID" use="optional"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="infFisco" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Mensagem do Fisco</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="cMsg">
+							<xs:annotation>
+								<xs:documentation>Código do status da mensagem do fisco</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TStat"/>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="xMsg" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Mensagem do Fisco</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="versao" use="required">
+			<xs:simpleType>
+				<xs:restriction base="TVerCTe"/>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="TProtGTVe">
+		<xs:annotation>
+			<xs:documentation>Tipo Protocolo de status resultado do processamento da GTV-e (Modelo 64)</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infProt">
+				<xs:annotation>
+					<xs:documentation>Dados do protocolo de status</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="verAplic" type="TVerAplic">
+							<xs:annotation>
+								<xs:documentation>Versão do Aplicativo que processou a GTV-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="chCTe" type="TChDFe">
+							<xs:annotation>
+								<xs:documentation>Chaves de acesso da CT-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="dhRecbto" type="TDateTimeUTC">
+							<xs:annotation>
+								<xs:documentation>Data e hora de processamento, no formato AAAA-MM-DDTHH:MM:SS TZD. </xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nProt" type="TProt" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número do Protocolo de Status da GTV-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="digVal" type="ds:DigestValueType" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Digest Value da GTV-e processado. Utilizado para conferir a integridade da GTV-e original.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cStat">
+							<xs:annotation>
+								<xs:documentation>Código do status da GTV-e.</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TStat"/>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="xMotivo" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Descrição literal do status da GTV-e.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" type="xs:ID" use="optional"/>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="infFisco" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Mensagem do Fisco</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="cMsg">
+							<xs:annotation>
+								<xs:documentation>Código do status da mensagem do fisco</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TStat"/>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="xMsg" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Mensagem do Fisco</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="versao" use="required">
+			<xs:simpleType>
+				<xs:restriction base="TVerCTe"/>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="TRetCTeSimp">
+		<xs:annotation>
+			<xs:documentation>Tipo Retorno do Pedido de Autorização de CT-e Simplificado (Modelo 57)</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>Identificação da UF</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="verAplic" type="TVerAplic">
+				<xs:annotation>
+					<xs:documentation>Versão do Aplicativo que processou a CT-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cStat" type="TStat">
+				<xs:annotation>
+					<xs:documentation>código do status do retorno da consulta.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMotivo" type="TMotivo">
+				<xs:annotation>
+					<xs:documentation>Descrição literal do status do do retorno da consulta.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="protCTe" type="TProtCTe" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Reposta ao processamento do CT-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerCTe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetCTe">
+		<xs:annotation>
+			<xs:documentation>Tipo Retorno do Pedido de Autorização de CT-e (Modelo 57)</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>Identificação da UF</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="verAplic" type="TVerAplic">
+				<xs:annotation>
+					<xs:documentation>Versão do Aplicativo que processou a CT-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cStat">
+				<xs:annotation>
+					<xs:documentation>código do status do retorno da consulta.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TStat">
+						<xs:pattern value="[0-9]{3}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xMotivo" type="TMotivo">
+				<xs:annotation>
+					<xs:documentation>Descrição literal do status do do retorno da consulta.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="protCTe" type="TProtCTe" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Reposta ao processamento do CT-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerCTe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetGTVe">
+		<xs:annotation>
+			<xs:documentation>Tipo Retorno do Pedido de Autorização de GTV-e (Modelo 64)</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>Identificação da UF</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="verAplic" type="TVerAplic">
+				<xs:annotation>
+					<xs:documentation>Versão do Aplicativo que processou a GTV-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cStat" type="TStat">
+				<xs:annotation>
+					<xs:documentation>código do status do retorno da consulta.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMotivo" type="TMotivo">
+				<xs:annotation>
+					<xs:documentation>Descrição literal do status do do retorno da consulta.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="protCTe" type="TProtGTVe" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Reposta ao processamento do CT-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerCTe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetCTeOS">
+		<xs:annotation>
+			<xs:documentation>Tipo Retorno do Pedido de Autorização de CT-e OS (Modelo 67)</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpAmb" type="TAmb">
+				<xs:annotation>
+					<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cUF" type="TCodUfIBGE">
+				<xs:annotation>
+					<xs:documentation>Identificação da UF</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="verAplic" type="TVerAplic">
+				<xs:annotation>
+					<xs:documentation>Versão do Aplicativo que processou a CT-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cStat" type="TStat">
+				<xs:annotation>
+					<xs:documentation>código do status do retorno da consulta.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMotivo" type="TMotivo">
+				<xs:annotation>
+					<xs:documentation>Descrição literal do status do do retorno da consulta.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="protCTe" type="TProtCTeOS" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Reposta ao processamento do CT-e</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerCTe" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TCTeSimp">
+		<xs:annotation>
+			<xs:documentation>Tipo Conhecimento de Transporte Eletrônico (Modelo 57) - Modelo Simplificado</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infCte">
+				<xs:annotation>
+					<xs:documentation>Informações do CT-e</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ide">
+							<xs:annotation>
+								<xs:documentation>Identificação do CT-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="cUF" type="TCodUfIBGE">
+										<xs:annotation>
+											<xs:documentation>Código da UF do emitente do CT-e.</xs:documentation>
+											<xs:documentation>Utilizar a Tabela do IBGE.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="cCT">
+										<xs:annotation>
+											<xs:documentation>Código numérico que compõe a Chave de Acesso. </xs:documentation>
+											<xs:documentation>Número aleatório gerado pelo emitente para cada CT-e, com o objetivo de evitar acessos indevidos ao documento.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{8}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="CFOP" type="TCfop">
+										<xs:annotation>
+											<xs:documentation>Código Fiscal de Operações e Prestações</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="natOp">
+										<xs:annotation>
+											<xs:documentation>Natureza da Operação</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="mod" type="TModCT">
+										<xs:annotation>
+											<xs:documentation>Modelo do documento fiscal</xs:documentation>
+											<xs:documentation>Utilizar o código 57 para identificação do CT-e, emitido em substituição aos modelos de conhecimentos em papel.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="serie">
+										<xs:annotation>
+											<xs:documentation>Série do CT-e</xs:documentation>
+											<xs:documentation>Preencher com "0" no caso de série única</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TSerie"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="nCT" type="TNF">
+										<xs:annotation>
+											<xs:documentation>Número do CT-e</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="dhEmi">
+										<xs:annotation>
+											<xs:documentation>Data e hora de emissão do CT-e</xs:documentation>
+											<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TDateTimeUTC"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpImp">
+										<xs:annotation>
+											<xs:documentation>Formato de impressão do DACTE</xs:documentation>
+											<xs:documentation>Preencher com: 1 - Retrato; 2 - Paisagem.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpEmis">
+										<xs:annotation>
+											<xs:documentation>Forma de emissão do CT-e </xs:documentation>
+											<xs:documentation>Preencher com:
+1 - Normal;
+3 - Regime Especial NFF;  
+4 - EPEC pela SVC; 
+7 - Autorização pela SVC-RS;
+8 - Autorização pela SVC-SP</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="3"/>
+												<xs:enumeration value="4"/>
+												<xs:enumeration value="7"/>
+												<xs:enumeration value="8"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cDV">
+										<xs:annotation>
+											<xs:documentation>Digito Verificador da chave de acesso do CT-e</xs:documentation>
+											<xs:documentation>Informar o dígito  de controle da chave de acesso do CT-e, que deve ser calculado com a aplicação do algoritmo módulo 11 (base 2,9) da chave de acesso. </xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{1}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpAmb" type="TAmb">
+										<xs:annotation>
+											<xs:documentation>Tipo do Ambiente</xs:documentation>
+											<xs:documentation>Preencher com:1 - Produção; 2 - Homologação.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpCTe" type="TFinCTeSimp">
+										<xs:annotation>
+											<xs:documentation>Tipo do CT-e Simplificado</xs:documentation>
+											<xs:documentation>Preencher com:
+5 - CTe Simplificado
+6 - Substituição CTe Simplificado</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="procEmi" type="TProcEmi">
+										<xs:annotation>
+											<xs:documentation>Identificador do processo de emissão do CT-e</xs:documentation>
+											<xs:documentation>Preencher com: 
+											0 - emissão de CT-e com aplicativo do contribuinte;
+											3- emissão CT-e pelo contribuinte com aplicativo fornecido pelo SEBRAE.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="verProc">
+										<xs:annotation>
+											<xs:documentation>Versão do processo de emissão</xs:documentation>
+											<xs:documentation>Informar a versão do aplicativo emissor de CT-e.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="20"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cMunEnv" type="TCodMunIBGE">
+										<xs:annotation>
+											<xs:documentation>Código do Município de envio do CT-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Utilizar a tabela do IBGE. Informar 9999999 para as operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="xMunEnv">
+										<xs:annotation>
+											<xs:documentation>Nome do Município de envio do CT-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Informar PAIS/Municipio para as operações com o exterior.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="UFEnv" type="TUf">
+										<xs:annotation>
+											<xs:documentation>Sigla da UF de envio do CT-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="modal" type="TModTranspSimp">
+										<xs:annotation>
+											<xs:documentation>Modal</xs:documentation>
+											<xs:documentation>Preencher com:
+01-Rodoviário
+02-Aéreo
+03-Aquaviário</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpServ">
+										<xs:annotation>
+											<xs:documentation>Tipo do Serviço</xs:documentation>
+											<xs:documentation>Preencher com: 
+0 - Normal;
+1 - Subcontratação;
+2 - Redespacho;</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="UFIni" type="TUf">
+										<xs:annotation>
+											<xs:documentation>UF do início da prestação</xs:documentation>
+											<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="UFFim" type="TUf">
+										<xs:annotation>
+											<xs:documentation>UF do término da prestação</xs:documentation>
+											<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="retira">
+										<xs:annotation>
+											<xs:documentation>Indicador se o Recebedor retira no Aeroporto, Filial, Porto ou Estação de Destino?</xs:documentation>
+											<xs:documentation>Preencher com: 0 - sim; 1 - não</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xDetRetira" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Detalhes do retira</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="160"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:sequence minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informar apenas
+para tpEmis diferente de 1</xs:documentation>
+										</xs:annotation>
+										<xs:element name="dhCont" type="TDateTimeUTC">
+											<xs:annotation>
+												<xs:documentation>Data e Hora da entrada em contingência</xs:documentation>
+												<xs:documentation>Informar a data e hora no formato AAAA-MM-DDTHH:MM:SS</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="xJust">
+											<xs:annotation>
+												<xs:documentation>Justificativa da entrada em contingência</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="15"/>
+													<xs:maxLength value="256"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+									<xs:element name="gCompraGov" type="TCompraGovReduzido" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Grupo de Compras Governamentais</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="compl" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Dados complementares do CT-e para fins operacionais ou comerciais</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="xCaracAd" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Característica adicional do transporte</xs:documentation>
+											<xs:documentation>Texto livre:
+REENTREGA; DEVOLUÇÃO; REFATURAMENTO; etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="15"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xCaracSer" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Característica adicional do serviço</xs:documentation>
+											<xs:documentation>Texto livre:
+											ENTREGA EXPRESSA; LOGÍSTICA REVERSA; CONVENCIONAL; EMERGENCIAL; etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="30"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fluxo" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Previsão do fluxo da carga</xs:documentation>
+											<xs:documentation>Preenchimento obrigatório para o modal aéreo.</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xOrig" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Sigla ou código interno da Filial/Porto/Estação/ Aeroporto de Origem</xs:documentation>
+														<xs:documentation>Observações para o modal aéreo:
+														- Preenchimento obrigatório para o modal aéreo.
+														- O código de três letras IATA do aeroporto de partida deverá ser incluído como primeira anotação. Quando não for possível, utilizar a sigla OACI.</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="pass" minOccurs="0" maxOccurs="unbounded">
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="xPass" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Sigla ou código interno da Filial/Porto/Estação/Aeroporto de Passagem</xs:documentation>
+																	<xs:documentation>Observação para o modal aéreo:
+																	- O código de três letras IATA, referente ao aeroporto de transferência, deverá ser incluído, quando for o caso. Quando não for possível,  utilizar a sigla OACI. Qualquer solicitação de itinerário deverá ser incluída.</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="15"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="xDest" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Sigla ou código interno da Filial/Porto/Estação/Aeroporto de Destino</xs:documentation>
+														<xs:documentation>Observações para o modal aéreo:
+														- Preenchimento obrigatório para o modal aéreo.
+														- Deverá ser incluído o código de três letras IATA do aeroporto de destino. Quando não for possível, utilizar a sigla OACI.</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="xRota" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Código da Rota de Entrega</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="10"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="xObs" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Observações Gerais</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="2000"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="ObsCont" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Campo de uso livre do contribuinte</xs:documentation>
+											<xs:documentation>Informar o nome do campo no atributo xCampo e o conteúdo do campo no XTexto</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xTexto">
+													<xs:annotation>
+														<xs:documentation>Conteúdo do campo</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="160"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="xCampo" use="required">
+												<xs:annotation>
+													<xs:documentation>Identificação do campo</xs:documentation>
+												</xs:annotation>
+												<xs:simpleType>
+													<xs:restriction base="TString">
+														<xs:minLength value="1"/>
+														<xs:maxLength value="20"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="ObsFisco" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Campo de uso livre do contribuinte</xs:documentation>
+											<xs:documentation>Informar o nome do campo no atributo xCampo e o conteúdo do campo no XTexto</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xTexto">
+													<xs:annotation>
+														<xs:documentation>Conteúdo do campo</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="xCampo" use="required">
+												<xs:annotation>
+													<xs:documentation>Identificação do campo</xs:documentation>
+												</xs:annotation>
+												<xs:simpleType>
+													<xs:restriction base="TString">
+														<xs:minLength value="1"/>
+														<xs:maxLength value="20"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="emit">
+							<xs:annotation>
+								<xs:documentation>Identificação do Emitente do CT-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpj">
+											<xs:annotation>
+												<xs:documentation>CNPJ do emitente</xs:documentation>
+												<xs:documentation>Informar zeros não significativos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>CPF do emitente</xs:documentation>
+												<xs:documentation>Informar zeros não significativos.
+
+Usar com série específica 920-969 para emitente pessoa física com inscrição estadual</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="IE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual do Emitente</xs:documentation>
+											<xs:documentation>A IE do emitente somente ficará sem informação para o caso do Regime Especial da NFF (tpEmis=3)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIe"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="IEST" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual do Substituto Tributário</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIe"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão social ou Nome do emitente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xFant" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Nome fantasia</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="enderEmit" type="TEndeEmi">
+										<xs:annotation>
+											<xs:documentation>Endereço do emitente</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="CRT" type="TCRT">
+										<xs:annotation>
+											<xs:documentation>Código do Regime Tributário</xs:documentation>
+											<xs:documentation>Informar: 1=Simples Nacional; 
+2=Simples Nacional, excesso sublimite de receita bruta;
+3=Regime Normal. 
+4=Simples Nacional - Microempreendedor Individual – MEI.
+</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="toma">
+							<xs:annotation>
+								<xs:documentation>Identificação do tomador do serviço no CT-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="toma">
+										<xs:annotation>
+											<xs:documentation>Tomador do Serviço</xs:documentation>
+											<xs:documentation>Preencher com:
+
+0-Remetente;
+1-Expedidor;
+2-Recebedor;
+3-Destinatário
+4-Terceiro</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="3"/>
+												<xs:enumeration value="4"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="indIEToma">
+										<xs:annotation>
+											<xs:documentation>Indicador do papel do tomador na prestação do serviço:
+1 – Contribuinte ICMS;
+2 – Contribuinte isento de inscrição;
+9 – Não Contribuinte</xs:documentation>
+											<xs:documentation>Aplica-se ao tomador que for indicado no toma</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="9"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpjOpc">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+												<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.															
+Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>Número do CPF</xs:documentation>
+												<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="IE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual</xs:documentation>
+											<xs:documentation>Informar a IE do tomador ou ISENTO se tomador é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o tomador não seja contribuinte do ICMS não informar o conteúdo.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIeDest"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão Social ou Nome</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="ISUF" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição na SUFRAMA</xs:documentation>
+											<xs:documentation>(Obrigatório nas operações com as áreas com benefícios de incentivos fiscais sob controle da SUFRAMA)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{8,9}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fone" type="TFone" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Telefone</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="enderToma" type="TEndereco">
+										<xs:annotation>
+											<xs:documentation>Dados do endereço</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="email" type="TEmail" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Endereço de email</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infCarga">
+							<xs:annotation>
+								<xs:documentation>Informações da Carga do CT-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vCarga" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor total da carga</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="proPred">
+										<xs:annotation>
+											<xs:documentation>Produto predominante</xs:documentation>
+											<xs:documentation>Informar a descrição do produto predominante</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xOutCat" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Outras características da carga</xs:documentation>
+											<xs:documentation>"FRIA", "GRANEL", "REFRIGERADA", "Medidas: 12X12X12"</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="30"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="infQ" maxOccurs="unbounded">
+										<xs:annotation>
+											<xs:documentation>Informações de quantidades da Carga do CT-e</xs:documentation>
+											<xs:documentation>Para o Aéreo é obrigatório o preenchimento desse campo da seguinte forma.
+1 - Peso Bruto, sempre em quilogramas (obrigatório);
+2 - Peso Cubado; sempre em quilogramas;
+3 - Quantidade de volumes, sempre em unidades (obrigatório);
+4 - Cubagem, sempre em metros cúbicos (obrigatório apenas quando for impossível preencher as dimensões da(s) embalagem(ens) na tag xDime do leiaute do Aéreo).</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="cUnid">
+													<xs:annotation>
+														<xs:documentation>Código da Unidade de Medida </xs:documentation>
+														<xs:documentation>Preencher com:
+00-M3;
+01-KG;
+02-TON;
+03-UNIDADE;
+04-LITROS;
+05-MMBTU</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:enumeration value="00"/>
+															<xs:enumeration value="01"/>
+															<xs:enumeration value="02"/>
+															<xs:enumeration value="03"/>
+															<xs:enumeration value="04"/>
+															<xs:enumeration value="05"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="tpMed">
+													<xs:annotation>
+														<xs:documentation>Tipo da Medida</xs:documentation>
+														<xs:documentation>Informar com:
+00-Cubagem da NF-e
+01-Cubagem Aferida pelo Transportador
+02-Peso Bruto da NF-e
+03-Peso Bruto Aferido pelo Transportador
+04-Peso Cubado
+05-Peso Base do Cálculo do Frete
+06-Peso para uso Operacional
+07-Caixas
+08-Paletes
+09-Sacas
+10-Containers
+11-Rolos
+12-Bombonas
+13-Latas
+14-Litragem
+15-Milhão de BTU (British Thermal Units)
+99-Outros</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="2"/>
+															<xs:enumeration value="00"/>
+															<xs:enumeration value="01"/>
+															<xs:enumeration value="02"/>
+															<xs:enumeration value="03"/>
+															<xs:enumeration value="04"/>
+															<xs:enumeration value="05"/>
+															<xs:enumeration value="06"/>
+															<xs:enumeration value="07"/>
+															<xs:enumeration value="08"/>
+															<xs:enumeration value="09"/>
+															<xs:enumeration value="10"/>
+															<xs:enumeration value="11"/>
+															<xs:enumeration value="12"/>
+															<xs:enumeration value="13"/>
+															<xs:enumeration value="14"/>
+															<xs:enumeration value="15"/>
+															<xs:enumeration value="99"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="qCarga" type="TDec_1104">
+													<xs:annotation>
+														<xs:documentation>Quantidade</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="vCargaAverb" type="TDec_1302Opc" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor da Carga para efeito de averbação</xs:documentation>
+											<xs:documentation>Normalmente igual ao valor declarado da mercadoria, diferente por exemplo, quando a mercadoria transportada é isenta de tributos nacionais para exportação, onde é preciso averbar um valor maior, pois no caso de indenização, o valor a ser pago será maior</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="det" maxOccurs="999">
+							<xs:annotation>
+								<xs:documentation>Detalhamento das entregas / prestações do CTe Simplificado</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:sequence>
+										<xs:element name="cMunIni" type="TCodMunIBGE">
+											<xs:annotation>
+												<xs:documentation>Código do Município de início da prestação</xs:documentation>
+												<xs:documentation>Utilizar a tabela do IBGE. Informar 9999999 para operações com o exterior.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="xMunIni">
+											<xs:annotation>
+												<xs:documentation>Nome do Município do início da prestação</xs:documentation>
+												<xs:documentation>Informar 'EXTERIOR' para operações com o exterior.</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="2"/>
+													<xs:maxLength value="60"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+									<xs:sequence>
+										<xs:element name="cMunFim" type="TCodMunIBGE">
+											<xs:annotation>
+												<xs:documentation>Código do Município de término da prestação</xs:documentation>
+												<xs:documentation>Utilizar a tabela do IBGE. Informar 9999999 para operações com o exterior.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="xMunFim">
+											<xs:annotation>
+												<xs:documentation>Nome do Município do término da prestação</xs:documentation>
+												<xs:documentation>Informar 'EXTERIOR' para operações com o exterior.</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="2"/>
+													<xs:maxLength value="60"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+									<xs:element name="vPrest" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valorl da Prestação do Serviço</xs:documentation>
+											<xs:documentation>Pode conter zeros quando o CT-e for de complemento de ICMS</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vRec" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor a Receber</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="Comp" minOccurs="0" maxOccurs="unbounded">
+										<xs:annotation>
+											<xs:documentation>Componentes do Valor da Prestação</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xNome">
+													<xs:annotation>
+														<xs:documentation>Nome do componente</xs:documentation>
+														<xs:documentation>Exxemplos: FRETE PESO, FRETE VALOR, SEC/CAT, ADEME, AGENDAMENTO, etc</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="15"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="vComp" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do componente</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:choice>
+										<xs:element name="infNFe" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>Informações das NF-e</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="chNFe">
+														<xs:annotation>
+															<xs:documentation>Chave de acesso da NF-e</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TChDFe">
+																<xs:pattern value="[0-9]{6}[A-Z0-9]{12}[0-9]{26}"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="PIN" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>PIN SUFRAMA</xs:documentation>
+															<xs:documentation>PIN atribuído pela SUFRAMA para a operação.</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:whiteSpace value="preserve"/>
+																<xs:minLength value="2"/>
+																<xs:maxLength value="9"/>
+																<xs:pattern value="[1-9]{1}[0-9]{1,8}"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="dPrev" type="TData" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Data prevista de entrega</xs:documentation>
+															<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:choice>
+														<xs:element name="infUnidCarga" type="TUnidCarga" minOccurs="0" maxOccurs="unbounded">
+															<xs:annotation>
+																<xs:documentation>Informações das Unidades de Carga (Containeres/ULD/Outros)</xs:documentation>
+																<xs:documentation>Dispositivo de carga utilizada (Unit Load Device - ULD) significa todo tipo de contêiner de carga, vagão, contêiner de avião, palete de aeronave com rede ou palete de aeronave com rede sobre um iglu. </xs:documentation>
+															</xs:annotation>
+														</xs:element>
+														<xs:element name="infUnidTransp" type="TUnidadeTransp" minOccurs="0" maxOccurs="unbounded">
+															<xs:annotation>
+																<xs:documentation>Informações das Unidades de Transporte (Carreta/Reboque/Vagão)</xs:documentation>
+																<xs:documentation>Deve ser preenchido com as informações das unidades de transporte utilizadas.</xs:documentation>
+															</xs:annotation>
+														</xs:element>
+													</xs:choice>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infDocAnt" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>Documentos anteriores</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="chCTe" type="TChDFe">
+														<xs:annotation>
+															<xs:documentation>Chave de acesso do CT-e</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="tpPrest">
+														<xs:annotation>
+															<xs:documentation>indica se a prestação é total ou parcial em relação as notas do documento anterior</xs:documentation>
+															<xs:documentation>Preencher com:
+
+1 - Total
+2 - Parcial</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:whiteSpace value="preserve"/>
+																<xs:enumeration value="1"/>
+																<xs:enumeration value="2"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="infNFeTranspParcial" minOccurs="0" maxOccurs="unbounded">
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="chNFe" type="TChDFe">
+																	<xs:annotation>
+																		<xs:documentation>Chave de acesso da NF-e</xs:documentation>
+																		<xs:documentation>Informando o tpPrest com “2 – Parcial” deve-se informar as chaves de acesso das NF-e que acobertam a carga transportada.</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+									</xs:choice>
+								</xs:sequence>
+								<xs:attribute name="nItem" use="required">
+									<xs:annotation>
+										<xs:documentation>Número identificador do item agrupador da prestação</xs:documentation>
+									</xs:annotation>
+									<xs:simpleType>
+										<xs:restriction base="xs:string">
+											<xs:whiteSpace value="preserve"/>
+											<xs:pattern value="[1-9]{1}[0-9]{0,1}|[1-8]{1}[0-9]{2}|[9]{1}[0-8]{1}[0-9]{1}|[9]{1}[9]{1}[0]{1}"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infModal">
+							<xs:annotation>
+								<xs:documentation>Informações do modal</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:any processContents="skip">
+										<xs:annotation>
+											<xs:documentation>XML do modal
+Insira neste local o XML específico do modal (rodoviário, aéreo, ferroviário, aquaviário ou dutoviário).  </xs:documentation>
+											<xs:documentation>O elemento do tipo -any- permite estender o documento XML com elementos não especificados pelo schema.
+															Insira neste local - any- o XML específico do modal (rodoviário, aéreo, ferroviário, aquaviário ou dutoviário). A especificação do schema XML para cada modal pode ser encontrada nos arquivos que acompanham este pacote de liberação:
+													Rodoviário - ver arquivo CTeModalRodoviario_v9.99
+			Aéreo - ver arquivo CTeModalAereo_v9.99
+				Aquaviário - arquivo CTeModalAquaviario_v9.99
+				Ferroviário - arquivo CTeModalFerroviario_v9.99
+				Dutoviário - arquivo CTeModalDutoviario_v9.99
+
+Onde v9.99 é a a designação genérica para a versão do arquivo. Por exemplo, o arquivo para o schema do modal Rodoviário na versão 1.04 será denominado "CTeModalRodoviario_v1.04".</xs:documentation>
+										</xs:annotation>
+									</xs:any>
+								</xs:sequence>
+								<xs:attribute name="versaoModal" use="required">
+									<xs:annotation>
+										<xs:documentation>Versão do leiaute específico para o Modal</xs:documentation>
+									</xs:annotation>
+									<xs:simpleType>
+										<xs:restriction base="xs:string">
+											<xs:whiteSpace value="preserve"/>
+											<xs:pattern value="4\.(0[0-9]|[1-9][0-9])"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="cobr" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Dados da cobrança do CT-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="fat" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Dados da fatura</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="nFat" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Número da fatura</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="vOrig" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor original da fatura</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vDesc" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor do desconto da fatura</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vLiq" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor líquido da fatura</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="dup" minOccurs="0" maxOccurs="unbounded">
+										<xs:annotation>
+											<xs:documentation>Dados das duplicatas</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="nDup" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Número da duplicata</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="60"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="dVenc" type="TData" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Data de vencimento da duplicata (AAAA-MM-DD)</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vDup" type="TDec_1302Opc" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor da duplicata</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infCteSub" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do CT-e de substituição </xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="chCte">
+										<xs:annotation>
+											<xs:documentation>Chave de acesso do CT-e a ser substituído (original)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:pattern value="[0-9]{44}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="indAlteraToma" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Indicador de CT-e Alteração de Tomador</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:enumeration value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="imp">
+							<xs:annotation>
+								<xs:documentation>Informações relativas aos Impostos</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="ICMS" type="TImp">
+										<xs:annotation>
+											<xs:documentation>Informações relativas ao ICMS</xs:documentation>
+											<xs:documentation/>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vTotTrib" type="TDec_1302" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor Total dos Tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="infAdFisco" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações adicionais de interesse do Fisco</xs:documentation>
+											<xs:documentation>Norma referenciada, informações complementares, etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="2000"/>
+												<xs:minLength value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="ICMSUFFim" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações do ICMS de partilha com a UF de término do serviço de transporte na operação interestadual</xs:documentation>
+											<xs:documentation>Grupo a ser informado nas prestações interestaduais para consumidor final, não contribuinte do ICMS</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="vBCUFFim" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor da BC do ICMS na UF de término da prestação do serviço de transporte</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pFCPUFFim" type="TDec_0302">
+													<xs:annotation>
+														<xs:documentation>Percentual do ICMS relativo ao Fundo de Combate à pobreza (FCP) na UF de término da prestação do serviço de transporte</xs:documentation>
+														<xs:documentation>Alíquota adotada nas operações internas na UF do destinatário</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pICMSUFFim" type="TDec_0302">
+													<xs:annotation>
+														<xs:documentation>Alíquota interna da UF de término da prestação do serviço de transporte</xs:documentation>
+														<xs:documentation>Alíquota adotada nas operações internas na UF do destinatário</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pICMSInter" type="TDec_0302">
+													<xs:annotation>
+														<xs:documentation>Alíquota interestadual das UF envolvidas</xs:documentation>
+														<xs:documentation>Alíquota interestadual das UF envolvidas
+</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vFCPUFFim" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS relativo ao Fundo de Combate á Pobreza (FCP) da UF de término da prestação</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSUFFim" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS de partilha para a UF de término da prestação do serviço de transporte</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSUFIni" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS de partilha para a UF de início da prestação do serviço de transporte</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="IBSCBS" type="TTribCTe" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Grupo de informações do IBS e CBS</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="total">
+							<xs:annotation>
+								<xs:documentation>Valores Totais do CTe</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vTPrest" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor Total da Prestação do Serviço</xs:documentation>
+											<xs:documentation>Pode conter zeros quando o CT-e for de complemento de ICMS</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vTRec" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor total a Receber</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vTotDFe" type="TDec_1302" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor total do documento fiscal 
+(vTPrest + total do IBS + total da CBS) 
+</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="autXML" minOccurs="0" maxOccurs="10">
+							<xs:annotation>
+								<xs:documentation>Autorizados para download do XML do DF-e</xs:documentation>
+								<xs:documentation>Informar CNPJ ou CPF. Preencher os zeros não significativos.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpj">
+											<xs:annotation>
+												<xs:documentation>CNPJ do autorizado</xs:documentation>
+												<xs:documentation>Informar zeros não significativos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>CPF do autorizado</xs:documentation>
+												<xs:documentation>Informar zeros não significativos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infRespTec" type="TRespTec" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do Responsável Técnico pela emissão do DF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="infSolicNFF" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de informações do pedido de emissão da Nota Fiscal Fácil</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="xSolic">
+										<xs:annotation>
+											<xs:documentation>Solicitação do pedido de emissão da NFF.</xs:documentation>
+											<xs:documentation>Será preenchido com a totalidade de campos informados no aplicativo emissor serializado.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="8000"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infPAA" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de Informação do Provedor de Assinatura e Autorização</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="CNPJPAA" type="TCnpj">
+										<xs:annotation>
+											<xs:documentation>CNPJ do Provedor de Assinatura e Autorização</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="PAASignature">
+										<xs:annotation>
+											<xs:documentation>Assinatura RSA do Emitente para DFe gerados por PAA</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="SignatureValue" type="xs:base64Binary">
+													<xs:annotation>
+														<xs:documentation>Assinatura digital padrão RSA</xs:documentation>
+														<xs:documentation>Converter o atributo Id do DFe para array de bytes e assinar com a chave privada do RSA com algoritmo SHA1 gerando um valor no formato base64.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="RSAKeyValue" type="TRSAKeyValueType">
+													<xs:annotation>
+														<xs:documentation>Chave Publica no padrão XML RSA Key</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="versao" use="required">
+						<xs:annotation>
+							<xs:documentation>Versão do leiaute</xs:documentation>
+							<xs:documentation>Ex: "4.00"</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="TVerCTe"/>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="Id" use="required">
+						<xs:annotation>
+							<xs:documentation>Identificador da tag a ser assinada</xs:documentation>
+							<xs:documentation>Informar a chave de acesso do CT-e e precedida do literal "CTe"</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:ID">
+								<xs:pattern value="CTe[0-9]{6}[A-Z0-9]{12}[0-9]{26}"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+				<xs:unique name="pk_nItem">
+					<xs:selector xpath="./*"/>
+					<xs:field xpath="@nItem"/>
+				</xs:unique>
+			</xs:element>
+			<xs:element name="infCTeSupl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informações suplementares do CT-e</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="qrCodCTe">
+							<xs:annotation>
+								<xs:documentation>Texto com o QR-Code impresso no DACTE</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:minLength value="50"/>
+									<xs:maxLength value="1000"/>
+									<xs:pattern value="((HTTPS?|https?)://.*\?chCTe=[0-9]{6}[A-Z0-9]{12}[0-9]{26}&amp;tpAmb=[1-2](&amp;sign=[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1})?)"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCTe">
+		<xs:annotation>
+			<xs:documentation>Tipo Conhecimento de Transporte Eletrônico (Modelo 57)</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infCte">
+				<xs:annotation>
+					<xs:documentation>Informações do CT-e</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ide">
+							<xs:annotation>
+								<xs:documentation>Identificação do CT-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="cUF" type="TCodUfIBGE">
+										<xs:annotation>
+											<xs:documentation>Código da UF do emitente do CT-e.</xs:documentation>
+											<xs:documentation>Utilizar a Tabela do IBGE.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="cCT">
+										<xs:annotation>
+											<xs:documentation>Código numérico que compõe a Chave de Acesso. </xs:documentation>
+											<xs:documentation>Número aleatório gerado pelo emitente para cada CT-e, com o objetivo de evitar acessos indevidos ao documento.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{8}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="CFOP" type="TCfop">
+										<xs:annotation>
+											<xs:documentation>Código Fiscal de Operações e Prestações</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="natOp">
+										<xs:annotation>
+											<xs:documentation>Natureza da Operação</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="mod" type="TModCT">
+										<xs:annotation>
+											<xs:documentation>Modelo do documento fiscal</xs:documentation>
+											<xs:documentation>Utilizar o código 57 para identificação do CT-e, emitido em substituição aos modelos de conhecimentos em papel.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="serie">
+										<xs:annotation>
+											<xs:documentation>Série do CT-e</xs:documentation>
+											<xs:documentation>Preencher com "0" no caso de série única</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TSerie"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="nCT" type="TNF">
+										<xs:annotation>
+											<xs:documentation>Número do CT-e</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="dhEmi">
+										<xs:annotation>
+											<xs:documentation>Data e hora de emissão do CT-e</xs:documentation>
+											<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TDateTimeUTC"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpImp">
+										<xs:annotation>
+											<xs:documentation>Formato de impressão do DACTE</xs:documentation>
+											<xs:documentation>Preencher com: 1 - Retrato; 2 - Paisagem.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpEmis">
+										<xs:annotation>
+											<xs:documentation>Forma de emissão do CT-e </xs:documentation>
+											<xs:documentation>Preencher com:
+1 - Normal;
+ 3-Regime Especial NFF;  4-EPEC pela SVC; 5 - Contingência FSDA;
+	7 - Autorização pela SVC-RS;
+  8 - Autorização pela SVC-SP</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="3"/>
+												<xs:enumeration value="4"/>
+												<xs:enumeration value="5"/>
+												<xs:enumeration value="7"/>
+												<xs:enumeration value="8"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cDV">
+										<xs:annotation>
+											<xs:documentation>Digito Verificador da chave de acesso do CT-e</xs:documentation>
+											<xs:documentation>Informar o dígito  de controle da chave de acesso do CT-e, que deve ser calculado com a aplicação do algoritmo módulo 11 (base 2,9) da chave de acesso. </xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{1}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpAmb" type="TAmb">
+										<xs:annotation>
+											<xs:documentation>Tipo do Ambiente</xs:documentation>
+											<xs:documentation>Preencher com:1 - Produção; 2 - Homologação.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpCTe" type="TFinCTe">
+										<xs:annotation>
+											<xs:documentation>Tipo do CT-e</xs:documentation>
+											<xs:documentation>Preencher com:
+	0 - CT-e Normal;
+ 1 - CT-e de Complemento de Valores;
+ 3 - CT-e de Substituição</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="procEmi" type="TProcEmi">
+										<xs:annotation>
+											<xs:documentation>Identificador do processo de emissão do CT-e</xs:documentation>
+											<xs:documentation>Preencher com: 
+											0 - emissão de CT-e com aplicativo do contribuinte;
+											3- emissão CT-e pelo contribuinte com aplicativo fornecido pelo SEBRAE.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="verProc">
+										<xs:annotation>
+											<xs:documentation>Versão do processo de emissão</xs:documentation>
+											<xs:documentation>Iinformar a versão do aplicativo emissor de CT-e.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="20"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="indGlobalizado" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Indicador de CT-e Globalizado</xs:documentation>
+											<xs:documentation>Informar valor 1 quando for Globalizado e não informar a tag quando não tratar de CT-e Globalizado</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:enumeration value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cMunEnv" type="TCodMunIBGE">
+										<xs:annotation>
+											<xs:documentation>Código do Município de envio do CT-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Utilizar a tabela do IBGE. Informar 9999999 para as operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="xMunEnv">
+										<xs:annotation>
+											<xs:documentation>Nome do Município de envio do CT-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Informar PAIS/Municipio para as operações com o exterior.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="UFEnv" type="TUf">
+										<xs:annotation>
+											<xs:documentation>Sigla da UF de envio do CT-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="modal" type="TModTransp">
+										<xs:annotation>
+											<xs:documentation>Modal</xs:documentation>
+											<xs:documentation>Preencher com:01-Rodoviário;
+02-Aéreo;03-Aquaviário;04-Ferroviário;05-Dutoviário;06-Multimodal;</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpServ">
+										<xs:annotation>
+											<xs:documentation>Tipo do Serviço</xs:documentation>
+											<xs:documentation>Preencher com: 
+0 - Normal;
+1 - Subcontratação;
+2 - Redespacho;
+3 - Redespacho Intermediário; 
+4 - Serviço Vinculado a Multimodal</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="3"/>
+												<xs:enumeration value="4"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cMunIni" type="TCodMunIBGE">
+										<xs:annotation>
+											<xs:documentation>Código do Município de início da prestação</xs:documentation>
+											<xs:documentation>Utilizar a tabela do IBGE. Informar 9999999 para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="xMunIni">
+										<xs:annotation>
+											<xs:documentation>Nome do Município do início da prestação</xs:documentation>
+											<xs:documentation>Informar 'EXTERIOR' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="UFIni" type="TUf">
+										<xs:annotation>
+											<xs:documentation>UF do início da prestação</xs:documentation>
+											<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="cMunFim" type="TCodMunIBGE">
+										<xs:annotation>
+											<xs:documentation>Código do Município de término da prestação</xs:documentation>
+											<xs:documentation>Utilizar a tabela do IBGE. Informar 9999999 para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="xMunFim">
+										<xs:annotation>
+											<xs:documentation>Nome do Município do término da prestação</xs:documentation>
+											<xs:documentation>Informar 'EXTERIOR' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="UFFim" type="TUf">
+										<xs:annotation>
+											<xs:documentation>UF do término da prestação</xs:documentation>
+											<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="retira">
+										<xs:annotation>
+											<xs:documentation>Indicador se o Recebedor retira no Aeroporto, Filial, Porto ou Estação de Destino?</xs:documentation>
+											<xs:documentation>Preencher com: 0 - sim; 1 - não</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="0"/>
+												<xs:enumeration value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xDetRetira" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Detalhes do retira</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="160"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="indIEToma">
+										<xs:annotation>
+											<xs:documentation>Indicador do papel do tomador na prestação do serviço:
+1 – Contribuinte ICMS;
+2 – Contribuinte isento de inscrição;
+9 – Não Contribuinte</xs:documentation>
+											<xs:documentation>Aplica-se ao tomador que for indicado no toma3 ou toma4</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="9"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:choice>
+										<xs:element name="toma3">
+											<xs:annotation>
+												<xs:documentation>Indicador do "papel" do tomador do serviço no CT-e</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="toma">
+														<xs:annotation>
+															<xs:documentation>Tomador do Serviço</xs:documentation>
+															<xs:documentation>Preencher com:
+															0-Remetente;
+															1-Expedidor;
+															2-Recebedor;
+															3-Destinatário
+															Serão utilizadas as informações contidas no respectivo grupo, conforme indicado pelo conteúdo deste campo</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:whiteSpace value="preserve"/>
+																<xs:enumeration value="0"/>
+																<xs:enumeration value="1"/>
+																<xs:enumeration value="2"/>
+																<xs:enumeration value="3"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="toma4">
+											<xs:annotation>
+												<xs:documentation>Indicador do "papel" do tomador do serviço no CT-e</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="toma">
+														<xs:annotation>
+															<xs:documentation>Tomador do Serviço</xs:documentation>
+															<xs:documentation>Preencher com: 
+															4 - Outros
+															Obs: Informar os dados cadastrais do tomador do serviço</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:whiteSpace value="preserve"/>
+																<xs:enumeration value="4"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:choice>
+														<xs:element name="CNPJ" type="TCnpjOpc">
+															<xs:annotation>
+																<xs:documentation>Número do CNPJ</xs:documentation>
+																<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.															
+Informar os zeros não significativos.</xs:documentation>
+															</xs:annotation>
+														</xs:element>
+														<xs:element name="CPF" type="TCpf">
+															<xs:annotation>
+																<xs:documentation>Número do CPF</xs:documentation>
+																<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+															</xs:annotation>
+														</xs:element>
+													</xs:choice>
+													<xs:element name="IE" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Inscrição Estadual</xs:documentation>
+															<xs:documentation>Informar a IE do tomador ou ISENTO se tomador é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o tomador não seja contribuinte do ICMS não informar o conteúdo.</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TIeDest"/>
+														</xs:simpleType>
+													</xs:element>
+													<xs:sequence>
+														<xs:element name="xNome">
+															<xs:annotation>
+																<xs:documentation>Razão Social ou Nome</xs:documentation>
+															</xs:annotation>
+															<xs:simpleType>
+																<xs:restriction base="TString">
+																	<xs:maxLength value="60"/>
+																	<xs:minLength value="2"/>
+																</xs:restriction>
+															</xs:simpleType>
+														</xs:element>
+														<xs:element name="xFant" minOccurs="0">
+															<xs:annotation>
+																<xs:documentation>Nome Fantasia</xs:documentation>
+															</xs:annotation>
+															<xs:simpleType>
+																<xs:restriction base="TString">
+																	<xs:maxLength value="60"/>
+																	<xs:minLength value="2"/>
+																</xs:restriction>
+															</xs:simpleType>
+														</xs:element>
+														<xs:element name="fone" type="TFone" minOccurs="0">
+															<xs:annotation>
+																<xs:documentation>Telefone</xs:documentation>
+															</xs:annotation>
+														</xs:element>
+														<xs:element name="enderToma" type="TEndereco">
+															<xs:annotation>
+																<xs:documentation>Dados do endereço</xs:documentation>
+															</xs:annotation>
+														</xs:element>
+														<xs:element name="email" type="TEmail" minOccurs="0">
+															<xs:annotation>
+																<xs:documentation>Endereço de email</xs:documentation>
+															</xs:annotation>
+														</xs:element>
+													</xs:sequence>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+									</xs:choice>
+									<xs:sequence minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informar apenas
+para tpEmis diferente de 1</xs:documentation>
+										</xs:annotation>
+										<xs:element name="dhCont" type="TDateTimeUTC">
+											<xs:annotation>
+												<xs:documentation>Data e Hora da entrada em contingência</xs:documentation>
+												<xs:documentation>Informar a data e hora no formato AAAA-MM-DDTHH:MM:SS</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="xJust">
+											<xs:annotation>
+												<xs:documentation>Justificativa da entrada em contingência</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="15"/>
+													<xs:maxLength value="256"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+									<xs:element name="gCompraGov" type="TCompraGovReduzido" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Grupo de Compras Governamentais</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="compl" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Dados complementares do CT-e para fins operacionais ou comerciais</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="xCaracAd" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Característica adicional do transporte</xs:documentation>
+											<xs:documentation>Texto livre:
+REENTREGA; DEVOLUÇÃO; REFATURAMENTO; etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="15"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xCaracSer" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Característica adicional do serviço</xs:documentation>
+											<xs:documentation>Texto livre:
+											ENTREGA EXPRESSA; LOGÍSTICA REVERSA; CONVENCIONAL; EMERGENCIAL; etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="30"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xEmi" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Funcionário emissor do CTe</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="20"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fluxo" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Previsão do fluxo da carga</xs:documentation>
+											<xs:documentation>Preenchimento obrigatório para o modal aéreo.</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xOrig" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Sigla ou código interno da Filial/Porto/Estação/ Aeroporto de Origem</xs:documentation>
+														<xs:documentation>Observações para o modal aéreo:
+														- Preenchimento obrigatório para o modal aéreo.
+														- O código de três letras IATA do aeroporto de partida deverá ser incluído como primeira anotação. Quando não for possível, utilizar a sigla OACI.</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="pass" minOccurs="0" maxOccurs="unbounded">
+													<xs:complexType>
+														<xs:sequence>
+															<xs:element name="xPass" minOccurs="0">
+																<xs:annotation>
+																	<xs:documentation>Sigla ou código interno da Filial/Porto/Estação/Aeroporto de Passagem</xs:documentation>
+																	<xs:documentation>Observação para o modal aéreo:
+																	- O código de três letras IATA, referente ao aeroporto de transferência, deverá ser incluído, quando for o caso. Quando não for possível,  utilizar a sigla OACI. Qualquer solicitação de itinerário deverá ser incluída.</xs:documentation>
+																</xs:annotation>
+																<xs:simpleType>
+																	<xs:restriction base="TString">
+																		<xs:minLength value="1"/>
+																		<xs:maxLength value="15"/>
+																	</xs:restriction>
+																</xs:simpleType>
+															</xs:element>
+														</xs:sequence>
+													</xs:complexType>
+												</xs:element>
+												<xs:element name="xDest" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Sigla ou código interno da Filial/Porto/Estação/Aeroporto de Destino</xs:documentation>
+														<xs:documentation>Observações para o modal aéreo:
+														- Preenchimento obrigatório para o modal aéreo.
+														- Deverá ser incluído o código de três letras IATA do aeroporto de destino. Quando não for possível, utilizar a sigla OACI.</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="xRota" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Código da Rota de Entrega</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="10"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="Entrega" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações ref. a previsão de entrega</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:choice>
+													<xs:element name="semData">
+														<xs:annotation>
+															<xs:documentation>Entrega sem data definida</xs:documentation>
+															<xs:documentation>Esta opção é proibida para o modal aéreo.</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="tpPer">
+																	<xs:annotation>
+																		<xs:documentation>Tipo de data/período programado para entrega</xs:documentation>
+																		<xs:documentation>0- Sem data definida</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="0"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="comData">
+														<xs:annotation>
+															<xs:documentation>Entrega com data definida</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="tpPer">
+																	<xs:annotation>
+																		<xs:documentation>Tipo de data/período programado para entrega</xs:documentation>
+																		<xs:documentation>Preencher com:
+																		1-Na data;
+																		2-Até a data;
+																		3-A partir da data</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="1"/>
+																			<xs:enumeration value="2"/>
+																			<xs:enumeration value="3"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="dProg" type="TData">
+																	<xs:annotation>
+																		<xs:documentation>Data programada </xs:documentation>
+																		<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="noPeriodo">
+														<xs:annotation>
+															<xs:documentation>Entrega no período definido</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="tpPer">
+																	<xs:annotation>
+																		<xs:documentation>Tipo período</xs:documentation>
+																		<xs:documentation>4-no período</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="4"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="dIni" type="TData">
+																	<xs:annotation>
+																		<xs:documentation>Data inicial </xs:documentation>
+																		<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="dFim" type="TData">
+																	<xs:annotation>
+																		<xs:documentation>Data final </xs:documentation>
+																		<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+												</xs:choice>
+												<xs:choice>
+													<xs:element name="semHora">
+														<xs:annotation>
+															<xs:documentation>Entrega sem hora definida</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="tpHor">
+																	<xs:annotation>
+																		<xs:documentation>Tipo de hora</xs:documentation>
+																		<xs:documentation>0- Sem hora definida</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="0"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="comHora">
+														<xs:annotation>
+															<xs:documentation>Entrega com hora definida</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="tpHor">
+																	<xs:annotation>
+																		<xs:documentation>Tipo de hora</xs:documentation>
+																		<xs:documentation>Preencher com:
+																		1 - No horário;
+																		2 - Até o horário;
+																		3 - A partir do horário.</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="1"/>
+																			<xs:enumeration value="2"/>
+																			<xs:enumeration value="3"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="hProg" type="TTime">
+																	<xs:annotation>
+																		<xs:documentation>Hora programada </xs:documentation>
+																		<xs:documentation>Formato HH:MM:SS</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="noInter">
+														<xs:annotation>
+															<xs:documentation>Entrega no intervalo de horário definido</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="tpHor">
+																	<xs:annotation>
+																		<xs:documentation> Tipo de hora</xs:documentation>
+																		<xs:documentation>4 - No intervalo de tempo</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="4"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="hIni" type="TTime">
+																	<xs:annotation>
+																		<xs:documentation>Hora inicial </xs:documentation>
+																		<xs:documentation>Formato HH:MM:SS</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="hFim" type="TTime">
+																	<xs:annotation>
+																		<xs:documentation>Hora final </xs:documentation>
+																		<xs:documentation>Formato HH:MM:SS</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+												</xs:choice>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="origCalc" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Município de origem para efeito de cálculo do frete</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="40"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="destCalc" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Município de destino para efeito de cálculo do frete</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="40"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xObs" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Observações Gerais</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="2000"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="ObsCont" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Campo de uso livre do contribuinte</xs:documentation>
+											<xs:documentation>Informar o nome do campo no atributo xCampo e o conteúdo do campo no XTexto</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xTexto">
+													<xs:annotation>
+														<xs:documentation>Conteúdo do campo</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="160"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="xCampo" use="required">
+												<xs:annotation>
+													<xs:documentation>Identificação do campo</xs:documentation>
+												</xs:annotation>
+												<xs:simpleType>
+													<xs:restriction base="TString">
+														<xs:minLength value="1"/>
+														<xs:maxLength value="20"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="ObsFisco" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Campo de uso livre do contribuinte</xs:documentation>
+											<xs:documentation>Informar o nome do campo no atributo xCampo e o conteúdo do campo no XTexto</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xTexto">
+													<xs:annotation>
+														<xs:documentation>Conteúdo do campo</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="xCampo" use="required">
+												<xs:annotation>
+													<xs:documentation>Identificação do campo</xs:documentation>
+												</xs:annotation>
+												<xs:simpleType>
+													<xs:restriction base="TString">
+														<xs:minLength value="1"/>
+														<xs:maxLength value="20"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="emit">
+							<xs:annotation>
+								<xs:documentation>Identificação do Emitente do CT-e</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpj">
+											<xs:annotation>
+												<xs:documentation>CNPJ do emitente</xs:documentation>
+												<xs:documentation>Informar zeros não significativos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>CPF do emitente</xs:documentation>
+												<xs:documentation>Informar zeros não significativos.
+
+Usar com série específica 920-969 para emitente pessoa física com inscrição estadual</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="IE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual do Emitente</xs:documentation>
+											<xs:documentation>A IE do emitente somente ficará sem informação para o caso do Regime Especial da NFF (tpEmis=3)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIe"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="IEST" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual do Substituto Tributário</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIe"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão social ou Nome do emitente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xFant" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Nome fantasia</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="enderEmit" type="TEndeEmi">
+										<xs:annotation>
+											<xs:documentation>Endereço do emitente</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="CRT" type="TCRT">
+										<xs:annotation>
+											<xs:documentation>Código do Regime Tributário</xs:documentation>
+											<xs:documentation>Informar: 1=Simples Nacional; 
+2=Simples Nacional, excesso sublimite de receita bruta;
+3=Regime Normal. 
+4=Simples Nacional - Microempreendedor Individual – MEI.
+</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="rem" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do Remetente das mercadorias transportadas pelo CT-e</xs:documentation>
+								<xs:documentation>Poderá não ser informado para os CT-e de redespacho intermediário e serviço vinculado a multimodal. Nos demais casos deverá sempre ser informado.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpjOpc">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+												<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.
+												Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>Número do CPF</xs:documentation>
+												<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="IE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual</xs:documentation>
+											<xs:documentation>Informar a IE do remetente ou ISENTO se remetente é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o remetente não seja contribuinte do ICMS não informar a tag.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIeDest"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão social ou nome do remetente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xFant" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Nome fantasia</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fone" type="TFone" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Telefone</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="enderReme" type="TEndereco">
+										<xs:annotation>
+											<xs:documentation>Dados do endereço</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="email" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Endereço de email</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TEmail"/>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="exped" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do Expedidor da Carga</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpjOpc">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+												<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.
+												Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>Número do CPF</xs:documentation>
+												<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="IE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual</xs:documentation>
+											<xs:documentation>Informar a IE do expedidor ou ISENTO se expedidor é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o expedidor não seja contribuinte do ICMS não informar a tag.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIeDest"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão Social ou Nome</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fone" type="TFone" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Telefone</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="enderExped" type="TEndereco">
+										<xs:annotation>
+											<xs:documentation>Dados do endereço</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="email" type="TEmail" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Endereço de email</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="receb" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do Recebedor da Carga</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpjOpc">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+												<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.
+												Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>Número do CPF</xs:documentation>
+												<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="IE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual</xs:documentation>
+											<xs:documentation>Informar a IE do recebedor ou ISENTO se recebedor é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o recebedor não seja contribuinte do ICMS não informar o conteúdo.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIeDest"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão Social ou Nome </xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fone" type="TFone" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Telefone</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="enderReceb" type="TEndereco">
+										<xs:annotation>
+											<xs:documentation>Dados do endereço</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="email" type="TEmail" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Endereço de email</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="dest" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do Destinatário do CT-e</xs:documentation>
+								<xs:documentation>Poderá não ser informado para os CT-e de redespacho intermediário e serviço vinculado a multimodal. Nos demais casos deverá sempre ser informado.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpjOpc">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+												<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.
+												Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>Número do CPF</xs:documentation>
+												<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="IE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual</xs:documentation>
+											<xs:documentation>Informar a IE do destinatário ou ISENTO se destinatário é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o destinatário não seja contribuinte do ICMS não informar o conteúdo.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIeDest"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão Social ou Nome do destinatário</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fone" type="TFone" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Telefone</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="ISUF" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição na SUFRAMA</xs:documentation>
+											<xs:documentation>(Obrigatório nas operações com as áreas com benefícios de incentivos fiscais sob controle da SUFRAMA)</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{8,9}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="enderDest" type="TEndereco">
+										<xs:annotation>
+											<xs:documentation>Dados do endereço</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="email" type="TEmail" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Endereço de email</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="vPrest">
+							<xs:annotation>
+								<xs:documentation>Valores da Prestação de Serviço</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vTPrest" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor Total da Prestação do Serviço</xs:documentation>
+											<xs:documentation>Pode conter zeros quando o CT-e for de complemento de ICMS</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vRec" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor a Receber</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="Comp" minOccurs="0" maxOccurs="unbounded">
+										<xs:annotation>
+											<xs:documentation>Componentes do Valor da Prestação</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xNome">
+													<xs:annotation>
+														<xs:documentation>Nome do componente</xs:documentation>
+														<xs:documentation>Exxemplos: FRETE PESO, FRETE VALOR, SEC/CAT, ADEME, AGENDAMENTO, etc</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="15"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="vComp" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do componente</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="imp">
+							<xs:annotation>
+								<xs:documentation>Informações relativas aos Impostos</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="ICMS" type="TImp">
+										<xs:annotation>
+											<xs:documentation>Informações relativas ao ICMS</xs:documentation>
+											<xs:documentation/>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vTotTrib" type="TDec_1302" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor Total dos Tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="infAdFisco" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações adicionais de interesse do Fisco</xs:documentation>
+											<xs:documentation>Norma referenciada, informações complementares, etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="2000"/>
+												<xs:minLength value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="ICMSUFFim" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações do ICMS de partilha com a UF de término do serviço de transporte na operação interestadual</xs:documentation>
+											<xs:documentation>Grupo a ser informado nas prestações interestaduais para consumidor final, não contribuinte do ICMS</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="vBCUFFim" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor da BC do ICMS na UF de término da prestação do serviço de transporte</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pFCPUFFim" type="TDec_0302">
+													<xs:annotation>
+														<xs:documentation>Percentual do ICMS relativo ao Fundo de Combate à pobreza (FCP) na UF de término da prestação do serviço de transporte</xs:documentation>
+														<xs:documentation>Alíquota adotada nas operações internas na UF do destinatário</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pICMSUFFim" type="TDec_0302">
+													<xs:annotation>
+														<xs:documentation>Alíquota interna da UF de término da prestação do serviço de transporte</xs:documentation>
+														<xs:documentation>Alíquota adotada nas operações internas na UF do destinatário</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pICMSInter" type="TDec_0302">
+													<xs:annotation>
+														<xs:documentation>Alíquota interestadual das UF envolvidas</xs:documentation>
+														<xs:documentation>Alíquota interestadual das UF envolvidas
+</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vFCPUFFim" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS relativo ao Fundo de Combate á Pobreza (FCP) da UF de término da prestação</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSUFFim" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS de partilha para a UF de término da prestação do serviço de transporte</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSUFIni" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS de partilha para a UF de início da prestação do serviço de transporte</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="IBSCBS" type="TTribCTe" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Grupo de informações do IBS e CBS</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vTotDFe" type="TDec_1302" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor total do documento fiscal 
+(vTPrest + total do IBS + total da CBS) 
+</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:choice>
+							<xs:element name="infCTeNorm">
+								<xs:annotation>
+									<xs:documentation>Grupo de informações do CT-e Normal e Substituto</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="infCarga">
+											<xs:annotation>
+												<xs:documentation>Informações da Carga do CT-e</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="vCarga" type="TDec_1302" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Valor total da carga</xs:documentation>
+															<xs:documentation>Dever ser informado para todos os modais, com exceção para o Dutoviário.</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="proPred">
+														<xs:annotation>
+															<xs:documentation>Produto predominante</xs:documentation>
+															<xs:documentation>Informar a descrição do produto predominante</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="60"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="xOutCat" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Outras características da carga</xs:documentation>
+															<xs:documentation>"FRIA", "GRANEL", "REFRIGERADA", "Medidas: 12X12X12"</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="30"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="infQ" maxOccurs="unbounded">
+														<xs:annotation>
+															<xs:documentation>Informações de quantidades da Carga do CT-e</xs:documentation>
+															<xs:documentation>Para o Aéreo é obrigatório o preenchimento desse campo da seguinte forma.
+1 - Peso Bruto, sempre em quilogramas (obrigatório);
+2 - Peso Cubado; sempre em quilogramas;
+3 - Quantidade de volumes, sempre em unidades (obrigatório);
+4 - Cubagem, sempre em metros cúbicos (obrigatório apenas quando for impossível preencher as dimensões da(s) embalagem(ens) na tag xDime do leiaute do Aéreo).</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="cUnid">
+																	<xs:annotation>
+																		<xs:documentation>Código da Unidade de Medida </xs:documentation>
+																		<xs:documentation>Preencher com:
+																		00-M3;
+																		01-KG;
+																		02-TON;
+																		03-UNIDADE;
+																		04-LITROS;
+																		05-MMBTU</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="00"/>
+																			<xs:enumeration value="01"/>
+																			<xs:enumeration value="02"/>
+																			<xs:enumeration value="03"/>
+																			<xs:enumeration value="04"/>
+																			<xs:enumeration value="05"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="tpMed">
+																	<xs:annotation>
+																		<xs:documentation>Tipo da Medida</xs:documentation>
+																		<xs:documentation>Exemplos:
+PESO BRUTO, PESO DECLARADO, PESO CUBADO, PESO AFORADO, PESO AFERIDO, PESO BASE DE CÁLCULO, LITRAGEM, CAIXAS e etc</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="20"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="qCarga" type="TDec_1104">
+																	<xs:annotation>
+																		<xs:documentation>Quantidade</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="vCargaAverb" type="TDec_1302Opc" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Valor da Carga para efeito de averbação</xs:documentation>
+															<xs:documentation>Normalmente igual ao valor declarado da mercadoria, diferente por exemplo, quando a mercadoria transportada é isenta de tributos nacionais para exportação, onde é preciso averbar um valor maior, pois no caso de indenização, o valor a ser pago será maior</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infDoc" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Informações dos documentos transportados pelo CT-e
+Opcional para Redespacho Intermediario e Serviço vinculado a multimodal.</xs:documentation>
+												<xs:documentation>Poderá não ser informado para os CT-e de redespacho intermediário e serviço vinculado a multimodal. Nos demais casos deverá sempre ser informado.</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:choice>
+														<xs:element name="infNF" maxOccurs="unbounded">
+															<xs:annotation>
+																<xs:documentation>Informações das NF</xs:documentation>
+																<xs:documentation>Este grupo deve ser informado quando o documento originário for NF </xs:documentation>
+															</xs:annotation>
+															<xs:complexType>
+																<xs:sequence>
+																	<xs:element name="nRoma" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Número do Romaneio da NF</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="TString">
+																				<xs:minLength value="1"/>
+																				<xs:maxLength value="20"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="nPed" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Número do Pedido da NF</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="TString">
+																				<xs:minLength value="1"/>
+																				<xs:maxLength value="20"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="mod" type="TModNF">
+																		<xs:annotation>
+																			<xs:documentation>Modelo da Nota Fiscal</xs:documentation>
+																			<xs:documentation>Preencher com: 
+01 - NF Modelo 01/1A e Avulsa; 
+04 - NF de Produtor</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="serie">
+																		<xs:annotation>
+																			<xs:documentation>Série</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="TString">
+																				<xs:minLength value="1"/>
+																				<xs:maxLength value="3"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="nDoc">
+																		<xs:annotation>
+																			<xs:documentation>Número </xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="TString">
+																				<xs:minLength value="1"/>
+																				<xs:maxLength value="20"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="dEmi" type="TData">
+																		<xs:annotation>
+																			<xs:documentation>Data de Emissão</xs:documentation>
+																			<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vBC" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor da Base de Cálculo do ICMS</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vICMS" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor Total do ICMS</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vBCST" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor da Base de Cálculo do ICMS ST</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vST" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor Total do ICMS ST</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vProd" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor Total dos Produtos</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vNF" type="TDec_1302">
+																		<xs:annotation>
+																			<xs:documentation>Valor Total da NF</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="nCFOP" type="TCfop">
+																		<xs:annotation>
+																			<xs:documentation>CFOP Predominante</xs:documentation>
+																			<xs:documentation>CFOP da NF ou, na existência de mais de um, predominância pelo critério de valor econômico.</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="nPeso" type="TDec_1203Opc" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Peso total em Kg</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="PIN" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>PIN SUFRAMA</xs:documentation>
+																			<xs:documentation>PIN atribuído pela SUFRAMA para a operação.</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="xs:string">
+																				<xs:whiteSpace value="preserve"/>
+																				<xs:minLength value="2"/>
+																				<xs:maxLength value="9"/>
+																				<xs:pattern value="[1-9]{1}[0-9]{1,8}"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="dPrev" type="TData" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Data prevista de entrega</xs:documentation>
+																			<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:choice>
+																		<xs:element name="infUnidCarga" type="TUnidCarga" minOccurs="0" maxOccurs="unbounded">
+																			<xs:annotation>
+																				<xs:documentation>Informações das Unidades de Carga (Containeres/ULD/Outros)</xs:documentation>
+																				<xs:documentation>Dispositivo de carga utilizada (Unit Load Device - ULD) significa todo tipo de contêiner de carga, vagão, contêiner de avião, palete de aeronave com rede ou palete de aeronave com rede sobre um iglu. </xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="infUnidTransp" type="TUnidadeTransp" minOccurs="0" maxOccurs="unbounded">
+																			<xs:annotation>
+																				<xs:documentation>Informações das Unidades de Transporte (Carreta/Reboque/Vagão)</xs:documentation>
+																				<xs:documentation>Deve ser preenchido com as informações das unidades de transporte utilizadas.</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																	</xs:choice>
+																</xs:sequence>
+															</xs:complexType>
+														</xs:element>
+														<xs:element name="infNFe" maxOccurs="unbounded">
+															<xs:annotation>
+																<xs:documentation>Informações das NF-e</xs:documentation>
+															</xs:annotation>
+															<xs:complexType>
+																<xs:sequence>
+																	<xs:element name="chave" type="TChDFe">
+																		<xs:annotation>
+																			<xs:documentation>Chave de acesso da NF-e</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="PIN" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>PIN SUFRAMA</xs:documentation>
+																			<xs:documentation>PIN atribuído pela SUFRAMA para a operação.</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="xs:string">
+																				<xs:whiteSpace value="preserve"/>
+																				<xs:minLength value="2"/>
+																				<xs:maxLength value="9"/>
+																				<xs:pattern value="[1-9]{1}[0-9]{1,8}"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="dPrev" type="TData" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Data prevista de entrega</xs:documentation>
+																			<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:choice>
+																		<xs:element name="infUnidCarga" type="TUnidCarga" minOccurs="0" maxOccurs="unbounded">
+																			<xs:annotation>
+																				<xs:documentation>Informações das Unidades de Carga (Containeres/ULD/Outros)</xs:documentation>
+																				<xs:documentation>Dispositivo de carga utilizada (Unit Load Device - ULD) significa todo tipo de contêiner de carga, vagão, contêiner de avião, palete de aeronave com rede ou palete de aeronave com rede sobre um iglu. </xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="infUnidTransp" type="TUnidadeTransp" minOccurs="0" maxOccurs="unbounded">
+																			<xs:annotation>
+																				<xs:documentation>Informações das Unidades de Transporte (Carreta/Reboque/Vagão)</xs:documentation>
+																				<xs:documentation>Deve ser preenchido com as informações das unidades de transporte utilizadas.</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																	</xs:choice>
+																</xs:sequence>
+															</xs:complexType>
+														</xs:element>
+														<xs:element name="infOutros" maxOccurs="unbounded">
+															<xs:annotation>
+																<xs:documentation>Informações dos demais documentos</xs:documentation>
+															</xs:annotation>
+															<xs:complexType>
+																<xs:sequence>
+																	<xs:element name="tpDoc">
+																		<xs:annotation>
+																			<xs:documentation>Tipo de documento originário</xs:documentation>
+																			<xs:documentation>Preencher com:
+															00 - Declaração;
+															10 - Dutoviário;
+							
+
+59 - CF-e SAT;
+
+65 - NFC-e;
+								99 - Outros</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="xs:string">
+																				<xs:whiteSpace value="preserve"/>
+																				<xs:enumeration value="00"/>
+																				<xs:enumeration value="10"/>
+																				<xs:enumeration value="59"/>
+																				<xs:enumeration value="65"/>
+																				<xs:enumeration value="99"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="descOutros" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Descrição do documento</xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="TString">
+																				<xs:minLength value="1"/>
+																				<xs:maxLength value="100"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="nDoc" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Número </xs:documentation>
+																		</xs:annotation>
+																		<xs:simpleType>
+																			<xs:restriction base="TString">
+																				<xs:minLength value="1"/>
+																				<xs:maxLength value="20"/>
+																			</xs:restriction>
+																		</xs:simpleType>
+																	</xs:element>
+																	<xs:element name="dEmi" type="TData" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Data de Emissão</xs:documentation>
+																			<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="vDocFisc" type="TDec_1302Opc" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Valor do documento</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="dPrev" type="TData" minOccurs="0">
+																		<xs:annotation>
+																			<xs:documentation>Data prevista de entrega</xs:documentation>
+																			<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:choice>
+																		<xs:element name="infUnidCarga" type="TUnidCarga" minOccurs="0" maxOccurs="unbounded">
+																			<xs:annotation>
+																				<xs:documentation>Informações das Unidades de Carga (Containeres/ULD/Outros)</xs:documentation>
+																				<xs:documentation>Dispositivo de carga utilizada (Unit Load Device - ULD) significa todo tipo de contêiner de carga, vagão, contêiner de avião, palete de aeronave com rede ou palete de aeronave com rede sobre um iglu. </xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																		<xs:element name="infUnidTransp" type="TUnidadeTransp" minOccurs="0" maxOccurs="unbounded">
+																			<xs:annotation>
+																				<xs:documentation>Informações das Unidades de Transporte (Carreta/Reboque/Vagão)</xs:documentation>
+																				<xs:documentation>Deve ser preenchido com as informações das unidades de transporte utilizadas.</xs:documentation>
+																			</xs:annotation>
+																		</xs:element>
+																	</xs:choice>
+																</xs:sequence>
+															</xs:complexType>
+														</xs:element>
+														<xs:element name="infDCe" maxOccurs="unbounded">
+															<xs:annotation>
+																<xs:documentation>Informações das DCe</xs:documentation>
+															</xs:annotation>
+															<xs:complexType>
+																<xs:sequence>
+																	<xs:element name="chave" type="TChDFe">
+																		<xs:annotation>
+																			<xs:documentation>Chave de acesso da DCe</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																</xs:sequence>
+															</xs:complexType>
+														</xs:element>
+													</xs:choice>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="docAnt" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Documentos de Transporte Anterior</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="emiDocAnt" maxOccurs="unbounded">
+														<xs:annotation>
+															<xs:documentation>Emissor do documento anterior</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:choice>
+																	<xs:element name="CNPJ" type="TCnpjOpc">
+																		<xs:annotation>
+																			<xs:documentation>Número do CNPJ</xs:documentation>
+																			<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.
+																			Informar os zeros não significativos.</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="CPF" type="TCpf">
+																		<xs:annotation>
+																			<xs:documentation>Número do CPF</xs:documentation>
+																			<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																</xs:choice>
+																<xs:sequence minOccurs="0">
+																	<xs:element name="IE" type="TIe">
+																		<xs:annotation>
+																			<xs:documentation>Inscrição Estadual</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																	<xs:element name="UF" type="TUf">
+																		<xs:annotation>
+																			<xs:documentation>Sigla da UF</xs:documentation>
+																			<xs:documentation>Informar EX para operações com o exterior.</xs:documentation>
+																		</xs:annotation>
+																	</xs:element>
+																</xs:sequence>
+																<xs:element name="xNome">
+																	<xs:annotation>
+																		<xs:documentation>Razão Social ou Nome do expedidor</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:maxLength value="60"/>
+																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="idDocAnt" maxOccurs="2">
+																	<xs:annotation>
+																		<xs:documentation>Informações de identificação dos documentos de Transporte Anterior</xs:documentation>
+																	</xs:annotation>
+																	<xs:complexType>
+																		<xs:choice>
+																			<xs:element name="idDocAntPap" maxOccurs="unbounded">
+																				<xs:annotation>
+																					<xs:documentation>Documentos de transporte anterior em papel</xs:documentation>
+																				</xs:annotation>
+																				<xs:complexType>
+																					<xs:sequence>
+																						<xs:element name="tpDoc">
+																							<xs:annotation>
+																								<xs:documentation>Tipo do Documento de Transporte Anterior</xs:documentation>
+																								<xs:documentation>Preencher com:
+07-ATRE;							
+08-DTA (Despacho de Transito Aduaneiro);
+09-Conhecimento Aéreo Internacional;
+10 – Conhecimento - Carta de Porte Internacional;
+11 – Conhecimento Avulso;
+12-TIF (Transporte Internacional Ferroviário); 13-BL (Bill of Lading)</xs:documentation>
+																							</xs:annotation>
+																							<xs:simpleType>
+																								<xs:restriction base="TDocAssoc"/>
+																							</xs:simpleType>
+																						</xs:element>
+																						<xs:element name="serie">
+																							<xs:annotation>
+																								<xs:documentation>Série do Documento Fiscal</xs:documentation>
+																							</xs:annotation>
+																							<xs:simpleType>
+																								<xs:restriction base="TString">
+																									<xs:minLength value="1"/>
+																									<xs:maxLength value="3"/>
+																								</xs:restriction>
+																							</xs:simpleType>
+																						</xs:element>
+																						<xs:element name="subser" minOccurs="0">
+																							<xs:annotation>
+																								<xs:documentation>Série do Documento Fiscal</xs:documentation>
+																							</xs:annotation>
+																							<xs:simpleType>
+																								<xs:restriction base="TString">
+																									<xs:minLength value="1"/>
+																									<xs:maxLength value="2"/>
+																								</xs:restriction>
+																							</xs:simpleType>
+																						</xs:element>
+																						<xs:element name="nDoc">
+																							<xs:annotation>
+																								<xs:documentation>Número do Documento Fiscal</xs:documentation>
+																							</xs:annotation>
+																							<xs:simpleType>
+																								<xs:restriction base="TString">
+																									<xs:minLength value="1"/>
+																									<xs:maxLength value="30"/>
+																								</xs:restriction>
+																							</xs:simpleType>
+																						</xs:element>
+																						<xs:element name="dEmi" type="TData">
+																							<xs:annotation>
+																								<xs:documentation>Data de emissão (AAAA-MM-DD)</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																					</xs:sequence>
+																				</xs:complexType>
+																			</xs:element>
+																			<xs:element name="idDocAntEle" maxOccurs="unbounded">
+																				<xs:annotation>
+																					<xs:documentation>Documentos de transporte anterior eletrônicos</xs:documentation>
+																				</xs:annotation>
+																				<xs:complexType>
+																					<xs:sequence>
+																						<xs:element name="chCTe" type="TChDFe">
+																							<xs:annotation>
+																								<xs:documentation>Chave de acesso do CT-e</xs:documentation>
+																							</xs:annotation>
+																						</xs:element>
+																					</xs:sequence>
+																				</xs:complexType>
+																			</xs:element>
+																		</xs:choice>
+																	</xs:complexType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infModal">
+											<xs:annotation>
+												<xs:documentation>Informações do modal</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:any processContents="skip">
+														<xs:annotation>
+															<xs:documentation>XML do modal
+Insira neste local o XML específico do modal (rodoviário, aéreo, ferroviário, aquaviário ou dutoviário).  </xs:documentation>
+															<xs:documentation>O elemento do tipo -any- permite estender o documento XML com elementos não especificados pelo schema.
+															Insira neste local - any- o XML específico do modal (rodoviário, aéreo, ferroviário, aquaviário ou dutoviário). A especificação do schema XML para cada modal pode ser encontrada nos arquivos que acompanham este pacote de liberação:
+													Rodoviário - ver arquivo CTeModalRodoviario_v9.99
+			Aéreo - ver arquivo CTeModalAereo_v9.99
+				Aquaviário - arquivo CTeModalAquaviario_v9.99
+				Ferroviário - arquivo CTeModalFerroviario_v9.99
+				Dutoviário - arquivo CTeModalDutoviario_v9.99
+
+Onde v9.99 é a a designação genérica para a versão do arquivo. Por exemplo, o arquivo para o schema do modal Rodoviário na versão 1.04 será denominado "CTeModalRodoviario_v1.04".</xs:documentation>
+														</xs:annotation>
+													</xs:any>
+												</xs:sequence>
+												<xs:attribute name="versaoModal" use="required">
+													<xs:annotation>
+														<xs:documentation>Versão do leiaute específico para o Modal</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="4\.(0[0-9]|[1-9][0-9])"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:attribute>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="veicNovos" minOccurs="0" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>informações dos veículos transportados</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="chassi">
+														<xs:annotation>
+															<xs:documentation>Chassi do veículo</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:whiteSpace value="preserve"/>
+																<xs:length value="17"/>
+																<xs:pattern value="[A-Z0-9]+"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="cCor">
+														<xs:annotation>
+															<xs:documentation>Cor do veículo</xs:documentation>
+															<xs:documentation>Código de cada montadora</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="4"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="xCor">
+														<xs:annotation>
+															<xs:documentation>Descrição da cor</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="40"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="cMod">
+														<xs:annotation>
+															<xs:documentation>Código Marca Modelo</xs:documentation>
+															<xs:documentation>Utilizar tabela RENAVAM</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="6"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="vUnit" type="TDec_1302">
+														<xs:annotation>
+															<xs:documentation>Valor Unitário do Veículo</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+													<xs:element name="vFrete" type="TDec_1302">
+														<xs:annotation>
+															<xs:documentation>Frete Unitário</xs:documentation>
+														</xs:annotation>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="cobr" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Dados da cobrança do CT-e</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="fat" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Dados da fatura</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="nFat" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Número da fatura</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="60"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="vOrig" type="TDec_1302Opc" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor original da fatura</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="vDesc" type="TDec_1302Opc" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor do desconto da fatura</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="vLiq" type="TDec_1302Opc" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor líquido da fatura</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="dup" minOccurs="0" maxOccurs="unbounded">
+														<xs:annotation>
+															<xs:documentation>Dados das duplicatas</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="nDup" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Número da duplicata</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:maxLength value="60"/>
+																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="dVenc" type="TData" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Data de vencimento da duplicata (AAAA-MM-DD)</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="vDup" type="TDec_1302Opc" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor da duplicata</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infCteSub" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Informações do CT-e de substituição </xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="chCte">
+														<xs:annotation>
+															<xs:documentation>Chave de acesso do CT-e a ser substituído (original)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:pattern value="[0-9]{44}"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="indAlteraToma" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Indicador de CT-e Alteração de Tomador</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:enumeration value="1"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infGlobalizado" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Informações do CT-e Globalizado</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="xObs">
+														<xs:annotation>
+															<xs:documentation>Preencher com informações adicionais, legislação do regime especial, etc</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="15"/>
+																<xs:maxLength value="256"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infServVinc" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Informações do Serviço Vinculado a Multimodal</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="infCTeMultimodal" maxOccurs="unbounded">
+														<xs:annotation>
+															<xs:documentation>informações do CT-e multimodal vinculado</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="chCTeMultimodal" type="TChDFe">
+																	<xs:annotation>
+																		<xs:documentation>Chave de acesso do CT-e Multimodal</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="infCteComp" maxOccurs="10">
+								<xs:annotation>
+									<xs:documentation>Detalhamento do CT-e complementado</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="chCTe" type="TChDFe">
+											<xs:annotation>
+												<xs:documentation>Chave do CT-e complementado</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:choice>
+						<xs:element name="autXML" minOccurs="0" maxOccurs="10">
+							<xs:annotation>
+								<xs:documentation>Autorizados para download do XML do DF-e</xs:documentation>
+								<xs:documentation>Informar CNPJ ou CPF. Preencher os zeros não significativos.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpj">
+											<xs:annotation>
+												<xs:documentation>CNPJ do autorizado</xs:documentation>
+												<xs:documentation>Informar zeros não significativos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>CPF do autorizado</xs:documentation>
+												<xs:documentation>Informar zeros não significativos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infRespTec" type="TRespTec" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do Responsável Técnico pela emissão do DF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="infSolicNFF" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de informações do pedido de emissão da Nota Fiscal Fácil</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="xSolic">
+										<xs:annotation>
+											<xs:documentation>Solicitação do pedido de emissão da NFF.</xs:documentation>
+											<xs:documentation>Será preenchido com a totalidade de campos informados no aplicativo emissor serializado.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="8000"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infPAA" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de Informação do Provedor de Assinatura e Autorização</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="CNPJPAA" type="TCnpj">
+										<xs:annotation>
+											<xs:documentation>CNPJ do Provedor de Assinatura e Autorização</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="PAASignature">
+										<xs:annotation>
+											<xs:documentation>Assinatura RSA do Emitente para DFe gerados por PAA</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="SignatureValue" type="xs:base64Binary">
+													<xs:annotation>
+														<xs:documentation>Assinatura digital padrão RSA</xs:documentation>
+														<xs:documentation>Converter o atributo Id do DFe para array de bytes e assinar com a chave privada do RSA com algoritmo SHA1 gerando um valor no formato base64.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="RSAKeyValue" type="TRSAKeyValueType">
+													<xs:annotation>
+														<xs:documentation>Chave Publica no padrão XML RSA Key</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="versao" use="required">
+						<xs:annotation>
+							<xs:documentation>Versão do leiaute</xs:documentation>
+							<xs:documentation>Ex: "4.00"</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="TVerCTe"/>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="Id" use="required">
+						<xs:annotation>
+							<xs:documentation>Identificador da tag a ser assinada</xs:documentation>
+							<xs:documentation>Informar a chave de acesso do CT-e e precedida do literal "CTe"</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:ID">
+								<xs:pattern value="CTe[0-9]{6}[A-Z0-9]{12}[0-9]{26}"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="infCTeSupl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informações suplementares do CT-e</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="qrCodCTe">
+							<xs:annotation>
+								<xs:documentation>Texto com o QR-Code impresso no DACTE</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:minLength value="50"/>
+									<xs:maxLength value="1000"/>
+									<xs:pattern value="((HTTPS?|https?)://.*\?chCTe=[0-9]{6}[A-Z0-9]{12}[0-9]{26}&amp;tpAmb=[1-2](&amp;sign=[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1})?)"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature"/>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TCTeOS">
+		<xs:annotation>
+			<xs:documentation>Tipo Conhecimento de Transporte Eletrônico Outros Serviços (Modelo 67)</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infCte">
+				<xs:annotation>
+					<xs:documentation>Informações do CT-e Outros Serviços</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="ide">
+							<xs:annotation>
+								<xs:documentation>Identificação do CT-e Outros Serviços</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="cUF" type="TCodUfIBGE">
+										<xs:annotation>
+											<xs:documentation>Código da UF do emitente do CT-e.</xs:documentation>
+											<xs:documentation>Utilizar a Tabela do IBGE.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="cCT">
+										<xs:annotation>
+											<xs:documentation>Código numérico que compõe a Chave de Acesso. </xs:documentation>
+											<xs:documentation>Número aleatório gerado pelo emitente para cada CT-e, com o objetivo de evitar acessos indevidos ao documento.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{8}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="CFOP" type="TCfop">
+										<xs:annotation>
+											<xs:documentation>Código Fiscal de Operações e Prestações</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="natOp">
+										<xs:annotation>
+											<xs:documentation>Natureza da Operação</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="mod" type="TModCTOS">
+										<xs:annotation>
+											<xs:documentation>Modelo do documento fiscal</xs:documentation>
+											<xs:documentation>Utilizar o código 67 para identificação do CT-e Outros Serviços, emitido em substituição a Nota Fiscal Modelo 7 para transporte de pessoas, valores e excesso de bagagem.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="serie">
+										<xs:annotation>
+											<xs:documentation>Série do CT-e OS</xs:documentation>
+											<xs:documentation>Preencher com "0" no caso de série única</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TSerie"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="nCT" type="TNF">
+										<xs:annotation>
+											<xs:documentation>Número do CT-e OS</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="dhEmi">
+										<xs:annotation>
+											<xs:documentation>Data e hora de emissão do CT-e OS</xs:documentation>
+											<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TDateTimeUTC"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpImp">
+										<xs:annotation>
+											<xs:documentation>Formato de impressão do DACTE OS</xs:documentation>
+											<xs:documentation>Preencher com: 1 - Retrato; 2 - Paisagem.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpEmis">
+										<xs:annotation>
+											<xs:documentation>Forma de emissão do CT-e</xs:documentation>
+											<xs:documentation>Preencher com:
+1 - Normal;
+ 5 - Contingência FSDA;
+7 - Autorização pela SVC-RS;
+ 8 - Autorização pela SVC-SP</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="5"/>
+												<xs:enumeration value="7"/>
+												<xs:enumeration value="8"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cDV">
+										<xs:annotation>
+											<xs:documentation>Digito Verificador da chave de acesso do CT-e</xs:documentation>
+											<xs:documentation>Informar o dígito  de controle da chave de acesso do CT-e, que deve ser calculado com a aplicação do algoritmo módulo 11 (base 2,9) da chave de acesso. </xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:pattern value="[0-9]{1}"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="tpAmb" type="TAmb">
+										<xs:annotation>
+											<xs:documentation>Tipo do Ambiente</xs:documentation>
+											<xs:documentation>Preencher com:1 - Produção; 2 - Homologação</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpCTe" type="TFinCTe">
+										<xs:annotation>
+											<xs:documentation>Tipo do CT-e OS</xs:documentation>
+											<xs:documentation>Preencher com:
+0 - CT-e Normal; 
+1 - CT-e Complementar; 
+3 - CT-e de Substituição.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="procEmi" type="TProcEmi">
+										<xs:annotation>
+											<xs:documentation>Identificador do processo de emissão do CT-e OS</xs:documentation>
+											<xs:documentation>Preencher com: 
+											0 - emissão de CT-e com aplicativo do contribuinte;
+											3- emissão CT-e pelo contribuinte com aplicativo fornecido pelo Fisco.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="verProc">
+										<xs:annotation>
+											<xs:documentation>Versão do processo de emissão</xs:documentation>
+											<xs:documentation>Iinformar a versão do aplicativo emissor de CT-e.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="20"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cMunEnv" type="TCodMunIBGE">
+										<xs:annotation>
+											<xs:documentation>Código do Município de envio do CT-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Utilizar a tabela do IBGE. Informar 9999999 para as operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="xMunEnv">
+										<xs:annotation>
+											<xs:documentation>Nome do Município de envio do CT-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Informar PAIS/Municipio para as operações com o exterior.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="UFEnv" type="TUf">
+										<xs:annotation>
+											<xs:documentation>Sigla da UF de envio do CT-e (de onde o documento foi transmitido)</xs:documentation>
+											<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="modal" type="TModTranspOS">
+										<xs:annotation>
+											<xs:documentation>Modal do CT-e OS</xs:documentation>
+											<xs:documentation>Preencher com:
+01-Rodoviário;
+02- Aéreo;
+03 - Aquaviário;
+04 - Ferroviário.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="tpServ">
+										<xs:annotation>
+											<xs:documentation>Tipo do Serviço</xs:documentation>
+											<xs:documentation>Preencher com: 
+
+6 - Transporte de Pessoas;
+7 - Transporte de Valores;
+8 - Excesso de Bagagem.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="6"/>
+												<xs:enumeration value="7"/>
+												<xs:enumeration value="8"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="indIEToma">
+										<xs:annotation>
+											<xs:documentation>Indicador da IE do tomador:
+1 – Contribuinte ICMS;
+2 – Contribuinte isento de inscrição;
+9 – Não Contribuinte</xs:documentation>
+											<xs:documentation>Aplica-se ao tomador que for indicado no toma3 ou toma4</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="xs:string">
+												<xs:whiteSpace value="preserve"/>
+												<xs:enumeration value="1"/>
+												<xs:enumeration value="2"/>
+												<xs:enumeration value="9"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="cMunIni" type="TCodMunIBGE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Código do Município de início da prestação</xs:documentation>
+											<xs:documentation>Utilizar a tabela do IBGE. Informar 9999999 para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="xMunIni" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Nome do Município do início da prestação</xs:documentation>
+											<xs:documentation>Informar 'EXTERIOR' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="UFIni" type="TUf" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>UF do início da prestação</xs:documentation>
+											<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="cMunFim" type="TCodMunIBGE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Código do Município de término da prestação</xs:documentation>
+											<xs:documentation>Utilizar a tabela do IBGE. Informar 9999999 para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="xMunFim" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Nome do Município do término da prestação</xs:documentation>
+											<xs:documentation>Informar 'EXTERIOR' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="60"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="UFFim" type="TUf" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>UF do término da prestação</xs:documentation>
+											<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="infPercurso" minOccurs="0" maxOccurs="25">
+										<xs:annotation>
+											<xs:documentation source=" Municípios onde ocorreram os carregamentos">Informações do Percurso do CT-e Outros Serviços</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="UFPer" type="TUf">
+													<xs:annotation>
+														<xs:documentation>Sigla das Unidades da Federação do percurso do veículo.</xs:documentation>
+														<xs:documentation>Não é necessário repetir as UF de Início e Fim</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:sequence minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informar apenas
+para tpEmis diferente de 1</xs:documentation>
+										</xs:annotation>
+										<xs:element name="dhCont" type="TDateTimeUTC">
+											<xs:annotation>
+												<xs:documentation>Data e Hora da entrada em contingência</xs:documentation>
+												<xs:documentation>Informar a data e hora no formato AAAA-MM-DDTHH:MM:SS</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="xJust">
+											<xs:annotation>
+												<xs:documentation>Justificativa da entrada em contingência</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:minLength value="15"/>
+													<xs:maxLength value="256"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+									<xs:element name="gCompraGov" type="TCompraGovReduzido" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Grupo de Compras Governamentais</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="compl" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Dados complementares do CT-e para fins operacionais ou comerciais</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="xCaracAd" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Característica adicional do transporte</xs:documentation>
+											<xs:documentation>Texto livre:
+REENTREGA; DEVOLUÇÃO; REFATURAMENTO; etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="15"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xCaracSer" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Característica adicional do serviço</xs:documentation>
+											<xs:documentation>Texto livre:
+											ENTREGA EXPRESSA; LOGÍSTICA REVERSA; CONVENCIONAL; EMERGENCIAL; etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="30"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xEmi" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Funcionário emissor do CTe</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="20"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xObs" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Observações Gerais</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="1"/>
+												<xs:maxLength value="2000"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="ObsCont" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Campo de uso livre do contribuinte</xs:documentation>
+											<xs:documentation>Informar o nome do campo no atributo xCampo e o conteúdo do campo no XTexto</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xTexto">
+													<xs:annotation>
+														<xs:documentation>Conteúdo do campo</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="160"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="xCampo" use="required">
+												<xs:annotation>
+													<xs:documentation>Identificação do campo</xs:documentation>
+												</xs:annotation>
+												<xs:simpleType>
+													<xs:restriction base="TString">
+														<xs:minLength value="1"/>
+														<xs:maxLength value="20"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="ObsFisco" minOccurs="0" maxOccurs="10">
+										<xs:annotation>
+											<xs:documentation>Campo de uso livre do contribuinte</xs:documentation>
+											<xs:documentation>Informar o nome do campo no atributo xCampo e o conteúdo do campo no XTexto</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xTexto">
+													<xs:annotation>
+														<xs:documentation>Conteúdo do campo</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:minLength value="1"/>
+															<xs:maxLength value="60"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+											</xs:sequence>
+											<xs:attribute name="xCampo" use="required">
+												<xs:annotation>
+													<xs:documentation>Identificação do campo</xs:documentation>
+												</xs:annotation>
+												<xs:simpleType>
+													<xs:restriction base="TString">
+														<xs:minLength value="1"/>
+														<xs:maxLength value="20"/>
+													</xs:restriction>
+												</xs:simpleType>
+											</xs:attribute>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="emit">
+							<xs:annotation>
+								<xs:documentation>Identificação do Emitente do CT-e OS</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="CNPJ" type="TCnpj">
+										<xs:annotation>
+											<xs:documentation>CNPJ do emitente</xs:documentation>
+											<xs:documentation>Informar zeros não significativos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="IE">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual do Emitente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIe"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="IEST" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual do Substituto Tributário</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIe"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão social ou Nome do emitente</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xFant" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Nome fantasia</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="enderEmit" type="TEndeEmi">
+										<xs:annotation>
+											<xs:documentation>Endereço do emitente</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="CRT" type="TCRT">
+										<xs:annotation>
+											<xs:documentation>Código do Regime Tributário</xs:documentation>
+											<xs:documentation>Informar: 1=Simples Nacional; 
+2=Simples Nacional, excesso sublimite de receita bruta;
+3=Regime Normal;
+4=Simples Nacional - Microempreendedor Individual – MEI.
+</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="toma" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do Tomador/Usuário do Serviço</xs:documentation>
+								<xs:documentation>Opcional para Excesso de Bagagem</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpjOpc">
+											<xs:annotation>
+												<xs:documentation>Número do CNPJ</xs:documentation>
+												<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.
+												Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>Número do CPF</xs:documentation>
+												<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+									<xs:element name="IE" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Inscrição Estadual</xs:documentation>
+											<xs:documentation>Informar a IE do tomador ou ISENTO se tomador é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o tomador não seja contribuinte do ICMS não informar o conteúdo.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TIeDest"/>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xNome">
+										<xs:annotation>
+											<xs:documentation>Razão social ou nome do tomador</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="xFant" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Nome fantasia</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="60"/>
+												<xs:minLength value="2"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="fone" type="TFone" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Telefone</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="enderToma" type="TEndereco">
+										<xs:annotation>
+											<xs:documentation>Dados do endereço</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="email" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Endereço de email</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TEmail"/>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="vPrest">
+							<xs:annotation>
+								<xs:documentation>Valores da Prestação de Serviço</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="vTPrest" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor Total da Prestação do Serviço</xs:documentation>
+											<xs:documentation>Pode conter zeros quando o CT-e for de complemento de ICMS</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vRec" type="TDec_1302">
+										<xs:annotation>
+											<xs:documentation>Valor a Receber</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="Comp" minOccurs="0" maxOccurs="unbounded">
+										<xs:annotation>
+											<xs:documentation>Componentes do Valor da Prestação</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="xNome">
+													<xs:annotation>
+														<xs:documentation>Nome do componente</xs:documentation>
+														<xs:documentation>Exxemplos: FRETE PESO, FRETE VALOR, SEC/CAT, ADEME, AGENDAMENTO, etc</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="TString">
+															<xs:maxLength value="15"/>
+															<xs:minLength value="1"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:element>
+												<xs:element name="vComp" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do componente</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="imp">
+							<xs:annotation>
+								<xs:documentation>Informações relativas aos Impostos</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="ICMS" type="TImpOS">
+										<xs:annotation>
+											<xs:documentation>Informações relativas ao ICMS</xs:documentation>
+											<xs:documentation/>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vTotTrib" type="TDec_1302" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor Total dos Tributos</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="infAdFisco" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações adicionais de interesse do Fisco</xs:documentation>
+											<xs:documentation>Norma referenciada, informações complementares, etc</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:maxLength value="2000"/>
+												<xs:minLength value="1"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+									<xs:element name="ICMSUFFim" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações do ICMS de partilha com a UF de término do serviço de transporte na operação interestadual</xs:documentation>
+											<xs:documentation>Grupo a ser informado nas prestações interestaduais para consumidor final, não contribuinte do ICMS</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="vBCUFFim" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor da BC do ICMS na UF de término da prestação do serviço de transporte</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pFCPUFFim" type="TDec_0302">
+													<xs:annotation>
+														<xs:documentation>Percentual do ICMS relativo ao Fundo de Combate à pobreza (FCP) na UF de término da prestação do serviço de transporte</xs:documentation>
+														<xs:documentation>Alíquota adotada nas operações internas na UF do destinatário</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pICMSUFFim" type="TDec_0302">
+													<xs:annotation>
+														<xs:documentation>Alíquota interna da UF de término da prestação do serviço de transporte</xs:documentation>
+														<xs:documentation>Alíquota adotada nas operações internas na UF do destinatário</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="pICMSInter" type="TDec_0302">
+													<xs:annotation>
+														<xs:documentation>Alíquota interestadual das UF envolvidas</xs:documentation>
+														<xs:documentation>Alíquota interestadual das UF envolvidas
+</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vFCPUFFim" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS relativo ao Fundo de Combate á Pobreza (FCP) da UF de término da prestação</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSUFFim" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS de partilha para a UF de término da prestação do serviço de transporte</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vICMSUFIni" type="TDec_1302">
+													<xs:annotation>
+														<xs:documentation>Valor do ICMS de partilha para a UF de início da prestação do serviço de transporte</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="infTribFed" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Informações dos tributos federais</xs:documentation>
+											<xs:documentation>Grupo a ser informado nas prestações interestaduais para consumidor final, não contribuinte do ICMS</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="vPIS" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor do PIS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vCOFINS" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor COFINS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vIR" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor de Imposto de Renda</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vINSS" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor do INSS</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="vCSLL" type="TDec_1302" minOccurs="0">
+													<xs:annotation>
+														<xs:documentation>Valor do CSLL</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+									<xs:element name="IBSCBS" type="TTribCTe" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Grupo de informações do IBS e CBS</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="vTotDFe" type="TDec_1302" minOccurs="0">
+										<xs:annotation>
+											<xs:documentation>Valor total do documento fiscal 
+(vTPrest + total do IBS + total da CBS) 
+</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:choice>
+							<xs:element name="infCTeNorm">
+								<xs:annotation>
+									<xs:documentation>Grupo de informações do CT-e OS Normal</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="infServico">
+											<xs:annotation>
+												<xs:documentation>Informações da Prestação do Serviço</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="xDescServ">
+														<xs:annotation>
+															<xs:documentation>Descrição do Serviço prestado</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="30"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="infQ" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Informações de quantidades da Carga do CT-e</xs:documentation>
+															<xs:documentation>Para Transporte de Pessoas indicar número de passageiros, para excesso de bagagem e transporte de valores indicar número de Volumes/Malotes</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="qCarga" type="TDec_1104">
+																	<xs:annotation>
+																		<xs:documentation>Quantidade</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infDocRef" minOccurs="0" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>Informações dos documentos referenciados</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:choice>
+													<xs:sequence>
+														<xs:element name="nDoc">
+															<xs:annotation>
+																<xs:documentation>Número </xs:documentation>
+															</xs:annotation>
+															<xs:simpleType>
+																<xs:restriction base="TString">
+																	<xs:minLength value="1"/>
+																	<xs:maxLength value="20"/>
+																</xs:restriction>
+															</xs:simpleType>
+														</xs:element>
+														<xs:element name="serie" minOccurs="0">
+															<xs:annotation>
+																<xs:documentation>Série</xs:documentation>
+															</xs:annotation>
+															<xs:simpleType>
+																<xs:restriction base="TString">
+																	<xs:minLength value="1"/>
+																	<xs:maxLength value="3"/>
+																</xs:restriction>
+															</xs:simpleType>
+														</xs:element>
+														<xs:element name="subserie" minOccurs="0">
+															<xs:annotation>
+																<xs:documentation>Subsérie</xs:documentation>
+															</xs:annotation>
+															<xs:simpleType>
+																<xs:restriction base="TString">
+																	<xs:minLength value="1"/>
+																	<xs:maxLength value="3"/>
+																</xs:restriction>
+															</xs:simpleType>
+														</xs:element>
+														<xs:element name="dEmi" type="TData">
+															<xs:annotation>
+																<xs:documentation>Data de Emissão</xs:documentation>
+																<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+															</xs:annotation>
+														</xs:element>
+														<xs:element name="vDoc" type="TDec_1302" minOccurs="0">
+															<xs:annotation>
+																<xs:documentation>Valor Transportado</xs:documentation>
+															</xs:annotation>
+														</xs:element>
+													</xs:sequence>
+													<xs:element name="chBPe">
+														<xs:annotation>
+															<xs:documentation>Chave de acesso do BP-e que possui eventos excesso de bagagem</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TChDFe"/>
+														</xs:simpleType>
+													</xs:element>
+												</xs:choice>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="seg" minOccurs="0" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>Informações de Seguro da Carga</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="respSeg">
+														<xs:annotation>
+															<xs:documentation>Responsável pelo seguro</xs:documentation>
+															<xs:documentation>Preencher com:
+
+4 - Emitente do CT-e;
+
+5 - Tomador de Serviço.
+</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:whiteSpace value="preserve"/>
+																<xs:minLength value="1"/>
+																<xs:maxLength value="1"/>
+																<xs:enumeration value="4"/>
+																<xs:enumeration value="5"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="xSeg" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Nome da Seguradora</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="30"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="nApol" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Número da Apólice</xs:documentation>
+															<xs:documentation>Obrigatório pela lei 11.442/07 (RCTRC)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="TString">
+																<xs:minLength value="1"/>
+																<xs:maxLength value="20"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infModal" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Informações do modal
+Obrigatório para Pessoas e Bagagem</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:any processContents="skip">
+														<xs:annotation>
+															<xs:documentation>XML do modal
+Insira neste local o XML específico do modal</xs:documentation>
+															<xs:documentation>O elemento do tipo -any- permite estender o documento XML com elementos não especificados pelo schema.
+													Insira neste local - any- o XML específico do modal (rodoviário). A especificação do schema XML para cada modal pode ser encontrada nos arquivos que acompanham este pacote de liberação:
+											Rodoviário - ver arquivo CTeModalRodoviarioOS_v9.99
+
+Onde v9.99 é a a designação genérica para a versão do arquivo. Por exemplo, o arquivo para o schema do modal Rodoviário na versão 4.00 será denominado "CTeModalRodoviarioOS_v4.00".</xs:documentation>
+														</xs:annotation>
+													</xs:any>
+												</xs:sequence>
+												<xs:attribute name="versaoModal" use="required">
+													<xs:annotation>
+														<xs:documentation>Versão do leiaute específico para o Modal</xs:documentation>
+													</xs:annotation>
+													<xs:simpleType>
+														<xs:restriction base="xs:string">
+															<xs:whiteSpace value="preserve"/>
+															<xs:pattern value="4\.(0[0-9]|[1-9][0-9])"/>
+														</xs:restriction>
+													</xs:simpleType>
+												</xs:attribute>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infCteSub" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Informações do CT-e de substituição </xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="chCte">
+														<xs:annotation>
+															<xs:documentation>Chave de acesso do CT-e a ser substituído (original)</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:pattern value="[0-9]{44}"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="refCTeCanc" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Chave de acesso do CT-e Cancelado
+Somente para Transporte de Valores</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TChDFe"/>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="cobr" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Dados da cobrança do CT-e</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="fat" minOccurs="0">
+														<xs:annotation>
+															<xs:documentation>Dados da fatura</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="nFat" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Número da fatura</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:minLength value="1"/>
+																			<xs:maxLength value="60"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="vOrig" type="TDec_1302Opc" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor original da fatura</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="vDesc" type="TDec_1302Opc" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor do desconto da fatura</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="vLiq" type="TDec_1302Opc" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor líquido da fatura</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+													<xs:element name="dup" minOccurs="0" maxOccurs="unbounded">
+														<xs:annotation>
+															<xs:documentation>Dados das duplicatas</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="nDup" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Número da duplicata</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:maxLength value="60"/>
+																			<xs:minLength value="1"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="dVenc" type="TData" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Data de vencimento da duplicata (AAAA-MM-DD)</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="vDup" type="TDec_1302Opc" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Valor da duplicata</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+										<xs:element name="infGTVe" minOccurs="0" maxOccurs="unbounded">
+											<xs:annotation>
+												<xs:documentation>Informações das GTV-e relacionadas ao CT-e OS</xs:documentation>
+											</xs:annotation>
+											<xs:complexType>
+												<xs:sequence>
+													<xs:element name="chCTe">
+														<xs:annotation>
+															<xs:documentation>Chave de acesso da GTV-e</xs:documentation>
+														</xs:annotation>
+														<xs:simpleType>
+															<xs:restriction base="xs:string">
+																<xs:pattern value="[0-9]{44}"/>
+															</xs:restriction>
+														</xs:simpleType>
+													</xs:element>
+													<xs:element name="Comp" maxOccurs="unbounded">
+														<xs:annotation>
+															<xs:documentation>Componentes do Valor da GTVe</xs:documentation>
+														</xs:annotation>
+														<xs:complexType>
+															<xs:sequence>
+																<xs:element name="tpComp">
+																	<xs:annotation>
+																		<xs:documentation>Tipo do Componente</xs:documentation>
+																		<xs:documentation>1-Custodia
+2-Embarque
+3-Tempo de espera
+4-Malote
+5-Ad Valorem
+6-Outros</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="xs:string">
+																			<xs:whiteSpace value="preserve"/>
+																			<xs:enumeration value="1"/>
+																			<xs:enumeration value="2"/>
+																			<xs:enumeration value="3"/>
+																			<xs:enumeration value="4"/>
+																			<xs:enumeration value="5"/>
+																			<xs:enumeration value="6"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+																<xs:element name="vComp" type="TDec_1302">
+																	<xs:annotation>
+																		<xs:documentation>Valor do componente</xs:documentation>
+																	</xs:annotation>
+																</xs:element>
+																<xs:element name="xComp" minOccurs="0">
+																	<xs:annotation>
+																		<xs:documentation>Nome do componente (informar apenas para outros)</xs:documentation>
+																		<xs:documentation>Exemplos: FRETE PESO, FRETE VALOR, SEC/CAT, ADEME, AGENDAMENTO, etc</xs:documentation>
+																	</xs:annotation>
+																	<xs:simpleType>
+																		<xs:restriction base="TString">
+																			<xs:maxLength value="15"/>
+																			<xs:minLength value="0"/>
+																		</xs:restriction>
+																	</xs:simpleType>
+																</xs:element>
+															</xs:sequence>
+														</xs:complexType>
+													</xs:element>
+												</xs:sequence>
+											</xs:complexType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="infCteComp" maxOccurs="10">
+								<xs:annotation>
+									<xs:documentation>Detalhamento do CT-e complementado</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="chCTe" type="TChDFe">
+											<xs:annotation>
+												<xs:documentation>Chave do CT-e complementado</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+						</xs:choice>
+						<xs:element name="autXML" minOccurs="0" maxOccurs="10">
+							<xs:annotation>
+								<xs:documentation>Autorizados para download do XML do DF-e</xs:documentation>
+								<xs:documentation>Informar CNPJ ou CPF. Preencher os zeros não significativos.</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:choice>
+										<xs:element name="CNPJ" type="TCnpj">
+											<xs:annotation>
+												<xs:documentation>CNPJ do autorizado</xs:documentation>
+												<xs:documentation>Informar zeros não significativos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="CPF" type="TCpf">
+											<xs:annotation>
+												<xs:documentation>CPF do autorizado</xs:documentation>
+												<xs:documentation>Informar zeros não significativos</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:choice>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infRespTec" type="TRespTec" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Informações do Responsável Técnico pela emissão do DF-e</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="versao" use="required">
+						<xs:annotation>
+							<xs:documentation>Versão do leiaute</xs:documentation>
+							<xs:documentation>Ex: "4.00"</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="TVerCTe"/>
+						</xs:simpleType>
+					</xs:attribute>
+					<xs:attribute name="Id" use="required">
+						<xs:annotation>
+							<xs:documentation>Identificador da tag a ser assinada</xs:documentation>
+							<xs:documentation>Informar a chave de acesso do CT-e OS e precedida do literal "CTe"</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:ID">
+								<xs:pattern value="CTe[0-9]{6}[A-Z0-9]{12}[0-9]{26}"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="infCTeSupl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Informações suplementares do CT-e</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="qrCodCTe">
+							<xs:annotation>
+								<xs:documentation>Texto com o QR-Code impresso no DACTE</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:minLength value="50"/>
+									<xs:maxLength value="1000"/>
+									<xs:pattern value="((HTTPS?|https?)://.*\?chCTe=[0-9]{6}[A-Z0-9]{12}[0-9]{26}&amp;tpAmb=[1-2](&amp;sign=[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1})?)"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature"/>
+		</xs:sequence>
+		<xs:attribute name="versao" use="required">
+			<xs:annotation>
+				<xs:documentation>Versão do leiaute</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="TVerCTe"/>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="TEndeEmi">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Endereço</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="xLgr">
+				<xs:annotation>
+					<xs:documentation>Logradouro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="nro">
+				<xs:annotation>
+					<xs:documentation>Número</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xCpl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Complemento</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xBairro">
+				<xs:annotation>
+					<xs:documentation>Bairro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cMun" type="TCodMunIBGE">
+				<xs:annotation>
+					<xs:documentation>Código do município (utilizar a tabela do IBGE)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMun">
+				<xs:annotation>
+					<xs:documentation>Nome do município</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="CEP" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>CEP</xs:documentation>
+					<xs:documentation>Informar zeros não significativos</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{8}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUF_sem_EX">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="fone" type="TFone" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Telefone</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TEndereco">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Endereço</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="xLgr">
+				<xs:annotation>
+					<xs:documentation>Logradouro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="255"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="nro">
+				<xs:annotation>
+					<xs:documentation>Número</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xCpl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Complemento</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xBairro">
+				<xs:annotation>
+					<xs:documentation>Bairro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cMun" type="TCodMunIBGE">
+				<xs:annotation>
+					<xs:documentation>Código do município (utilizar a tabela do IBGE)</xs:documentation>
+					<xs:documentation>Informar 9999999 para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMun">
+				<xs:annotation>
+					<xs:documentation>Nome do município</xs:documentation>
+					<xs:documentation>Informar EXTERIOR para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="CEP" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>CEP</xs:documentation>
+					<xs:documentation>Informar os zeros não significativos</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{8}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUf">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF</xs:documentation>
+					<xs:documentation>Informar EX para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cPais" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Código do país</xs:documentation>
+					<xs:documentation>Utilizar a tabela do BACEN</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{1,4}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xPais" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Nome do país</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TEndernac">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Endereço</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="xLgr">
+				<xs:annotation>
+					<xs:documentation>Logradouro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="255"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="nro">
+				<xs:annotation>
+					<xs:documentation>Número</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xCpl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Complemento</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xBairro">
+				<xs:annotation>
+					<xs:documentation>Bairro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cMun" type="TCodMunIBGE">
+				<xs:annotation>
+					<xs:documentation>Código do município (utilizar a tabela do IBGE), informar 9999999 para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMun">
+				<xs:annotation>
+					<xs:documentation>Nome do município, , informar EXTERIOR para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="CEP" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>CEP</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{8}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUf">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF</xs:documentation>
+					<xs:documentation>Informar EX para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TEndOrg">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Endereço</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="xLgr">
+				<xs:annotation>
+					<xs:documentation>Logradouro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="nro">
+				<xs:annotation>
+					<xs:documentation>Número</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xCpl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Complemento</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xBairro">
+				<xs:annotation>
+					<xs:documentation>Bairro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cMun" type="TCodMunIBGE">
+				<xs:annotation>
+					<xs:documentation>Código do município (utilizar a tabela do IBGE), informar 9999999 para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMun">
+				<xs:annotation>
+					<xs:documentation>Nome do município</xs:documentation>
+					<xs:documentation>Informar EXTERIOR para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="CEP" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>CEP</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{8}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUf">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF</xs:documentation>
+					<xs:documentation>Informar EX para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="cPais" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Código do país</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{1,4}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xPais" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Nome do país</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="fone" type="TFone" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Telefone</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TLocal">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Local de Origem ou Destino</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="cMun" type="TCodMunIBGE">
+				<xs:annotation>
+					<xs:documentation>Código do município (utilizar a tabela do IBGE)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMun">
+				<xs:annotation>
+					<xs:documentation>Nome do município</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUf">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TEndReEnt">
+		<xs:annotation>
+			<xs:documentation> Tipo Dados do Local de Retirada ou Entrega</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:choice>
+				<xs:element name="CNPJ" type="TCnpj">
+					<xs:annotation>
+						<xs:documentation>Número do CNPJ</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="CPF" type="TCpf">
+					<xs:annotation>
+						<xs:documentation>Número do CPF</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:choice>
+			<xs:element name="xNome">
+				<xs:annotation>
+					<xs:documentation>Razão Social ou Nome</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xLgr">
+				<xs:annotation>
+					<xs:documentation>Logradouro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="255"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="nro">
+				<xs:annotation>
+					<xs:documentation>Número</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xCpl" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Complemento</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="xBairro">
+				<xs:annotation>
+					<xs:documentation>Bairro</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="cMun" type="TCodMunIBGE">
+				<xs:annotation>
+					<xs:documentation>Código do município (utilizar a tabela do IBGE) </xs:documentation>
+					<xs:documentation>Informar 9999999 para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xMun">
+				<xs:annotation>
+					<xs:documentation>Nome do município</xs:documentation>
+					<xs:documentation>Informar EXTERIOR para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="1"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="UF" type="TUf">
+				<xs:annotation>
+					<xs:documentation>Sigla da UF</xs:documentation>
+					<xs:documentation>Informar EX para operações com o exterior.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TImp">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Imposto CT-e</xs:documentation>
+		</xs:annotation>
+		<xs:choice>
+			<xs:element name="ICMS00">
+				<xs:annotation>
+					<xs:documentation>Prestação sujeito à tributação normal do ICMS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation>00 - tributação normal ICMS</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="00"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="vBC" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor da BC do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="pICMS" type="TDec_0302">
+							<xs:annotation>
+								<xs:documentation>Alíquota do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vICMS" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMS20">
+				<xs:annotation>
+					<xs:documentation>Prestação sujeito à tributação com redução de BC do ICMS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do serviço</xs:documentation>
+								<xs:documentation>20 - tributação com BC reduzida do ICMS</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="20"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="pRedBC" type="TDec_0302Opc">
+							<xs:annotation>
+								<xs:documentation>Percentual de redução da BC</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vBC" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor da BC do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="pICMS" type="TDec_0302">
+							<xs:annotation>
+								<xs:documentation>Alíquota do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vICMS" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:sequence minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Sequencia XML</xs:documentation>
+							</xs:annotation>
+							<xs:element name="vICMSDeson" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="cBenef">
+								<xs:annotation>
+									<xs:documentation>Código de Benefício Fiscal na UF</xs:documentation>
+									<xs:documentation>Código de Benefício Fiscal utilizado pela UF
+</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:whiteSpace value="preserve"/>
+										<xs:maxLength value="10"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMS45">
+				<xs:annotation>
+					<xs:documentation>ICMS  Isento, não Tributado ou diferido</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation>Preencher com:
+								40 - ICMS isenção;
+								41 - ICMS não tributada;
+								51 - ICMS diferido</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="40"/>
+									<xs:enumeration value="41"/>
+									<xs:enumeration value="51"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:sequence minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Sequencia XML</xs:documentation>
+							</xs:annotation>
+							<xs:element name="vICMSDeson" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="cBenef">
+								<xs:annotation>
+									<xs:documentation>Código de Benefício Fiscal na UF</xs:documentation>
+									<xs:documentation>Código de Benefício Fiscal utilizado pela UF
+</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:whiteSpace value="preserve"/>
+										<xs:maxLength value="10"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMS60">
+				<xs:annotation>
+					<xs:documentation>Tributação pelo ICMS60 - ICMS cobrado por substituição tributária.Responsabilidade do recolhimento do ICMS atribuído ao tomador ou 3º por ST</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation>60 - ICMS cobrado por substituição tributária</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="60"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="vBCSTRet" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor da BC do ICMS ST retido</xs:documentation>
+								<xs:documentation>Valor do frete sobre o qual será calculado o ICMS a ser substituído na Prestação. </xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vICMSSTRet" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor do ICMS ST retido</xs:documentation>
+								<xs:documentation>Resultado da multiplicação do “vBCSTRet” x “pICMSSTRet” – que será valor do ICMS a ser retido pelo Substituto. Podendo o valor do ICMS a ser retido efetivamente, sofrer ajustes conforme a opção tributaria do transportador substituído. </xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="pICMSSTRet" type="TDec_0302">
+							<xs:annotation>
+								<xs:documentation>Alíquota do ICMS</xs:documentation>
+								<xs:documentation>Percentual de Alíquota incidente na prestação de serviço de transporte.</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCred" type="TDec_1302" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Valor do Crédito outorgado/Presumido</xs:documentation>
+								<xs:documentation>Preencher somente quando o transportador substituído, for optante pelo crédito outorgado previsto no Convênio 106/96 e corresponde ao percentual de 20% do valor do ICMS ST retido. </xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:sequence minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Sequencia XML</xs:documentation>
+							</xs:annotation>
+							<xs:element name="vICMSDeson" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="cBenef">
+								<xs:annotation>
+									<xs:documentation>Código de Benefício Fiscal na UF</xs:documentation>
+									<xs:documentation>Código de Benefício Fiscal utilizado pela UF
+</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:whiteSpace value="preserve"/>
+										<xs:maxLength value="10"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMS90">
+				<xs:annotation>
+					<xs:documentation>ICMS Outros</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation> 90 - ICMS outros</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="90"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="pRedBC" type="TDec_0302Opc" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Percentual de redução da BC</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vBC" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor da BC do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="pICMS" type="TDec_0302">
+							<xs:annotation>
+								<xs:documentation>Alíquota do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vICMS" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCred" type="TDec_1302" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Valor do Crédito Outorgado/Presumido</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:sequence minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Sequencia XML</xs:documentation>
+							</xs:annotation>
+							<xs:element name="vICMSDeson" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="cBenef">
+								<xs:annotation>
+									<xs:documentation>Código de Benefício Fiscal na UF</xs:documentation>
+									<xs:documentation>Código de Benefício Fiscal utilizado pela UF
+</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:whiteSpace value="preserve"/>
+										<xs:maxLength value="10"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMSOutraUF">
+				<xs:annotation>
+					<xs:documentation>ICMS devido à UF de origem da prestação, quando  diferente da UF do emitente</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation>90 - ICMS Outra UF</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="90"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="pRedBCOutraUF" type="TDec_0302Opc" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Percentual de redução da BC</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vBCOutraUF" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor da BC do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="pICMSOutraUF" type="TDec_0302">
+							<xs:annotation>
+								<xs:documentation>Alíquota do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vICMSOutraUF" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor do ICMS devido outra UF</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:sequence minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Sequencia XML</xs:documentation>
+							</xs:annotation>
+							<xs:element name="vICMSDeson" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="cBenef">
+								<xs:annotation>
+									<xs:documentation>Código de Benefício Fiscal na UF</xs:documentation>
+									<xs:documentation>Código de Benefício Fiscal utilizado pela UF
+</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:whiteSpace value="preserve"/>
+										<xs:maxLength value="10"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMSSN">
+				<xs:annotation>
+					<xs:documentation>Simples Nacional</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation>90 - ICMS Simples Nacional</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="90"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="indSN">
+							<xs:annotation>
+								<xs:documentation>Indica se o contribuinte é Simples Nacional			1=Sim</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="1"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="TImpOS">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados do Imposto para CT-e OS</xs:documentation>
+		</xs:annotation>
+		<xs:choice>
+			<xs:element name="ICMS00">
+				<xs:annotation>
+					<xs:documentation>Prestação sujeito à tributação normal do ICMS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation>00 - tributação normal ICMS</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="00"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="vBC" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor da BC do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="pICMS" type="TDec_0302">
+							<xs:annotation>
+								<xs:documentation>Alíquota do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vICMS" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMS20">
+				<xs:annotation>
+					<xs:documentation>Prestação sujeito à tributação com redução de BC do ICMS</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do serviço</xs:documentation>
+								<xs:documentation>20 - tributação com BC reduzida do ICMS</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="20"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="pRedBC" type="TDec_0302Opc">
+							<xs:annotation>
+								<xs:documentation>Percentual de redução da BC</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vBC" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor da BC do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="pICMS" type="TDec_0302">
+							<xs:annotation>
+								<xs:documentation>Alíquota do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vICMS" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:sequence minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Sequencia XML</xs:documentation>
+							</xs:annotation>
+							<xs:element name="vICMSDeson" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="cBenef">
+								<xs:annotation>
+									<xs:documentation>Código de Benefício Fiscal na UF</xs:documentation>
+									<xs:documentation>Código de Benefício Fiscal utilizado pela UF
+</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:whiteSpace value="preserve"/>
+										<xs:maxLength value="10"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMS45">
+				<xs:annotation>
+					<xs:documentation>ICMS  Isento, não Tributado ou diferido</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation>Preencher com:
+								40 - ICMS isenção;
+								41 - ICMS não tributada;
+								51 - ICMS diferido</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="40"/>
+									<xs:enumeration value="41"/>
+									<xs:enumeration value="51"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:sequence minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Sequencia XML</xs:documentation>
+							</xs:annotation>
+							<xs:element name="vICMSDeson" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="cBenef">
+								<xs:annotation>
+									<xs:documentation>Código de Benefício Fiscal na UF</xs:documentation>
+									<xs:documentation>Código de Benefício Fiscal utilizado pela UF
+</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:whiteSpace value="preserve"/>
+										<xs:maxLength value="10"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMS90">
+				<xs:annotation>
+					<xs:documentation>ICMS Outros</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation> 90 - Outros</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="90"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="pRedBC" type="TDec_0302Opc" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Percentual de redução da BC</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vBC" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor da BC do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="pICMS" type="TDec_0302">
+							<xs:annotation>
+								<xs:documentation>Alíquota do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vICMS" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vCred" type="TDec_1302" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Valor do Crédito Outorgado/Presumido</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:sequence minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Sequencia XML</xs:documentation>
+							</xs:annotation>
+							<xs:element name="vICMSDeson" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="cBenef">
+								<xs:annotation>
+									<xs:documentation>Código de Benefício Fiscal na UF</xs:documentation>
+									<xs:documentation>Código de Benefício Fiscal utilizado pela UF
+</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:whiteSpace value="preserve"/>
+										<xs:maxLength value="10"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMSOutraUF">
+				<xs:annotation>
+					<xs:documentation>ICMS devido à UF de origem da prestação, quando  diferente da UF do emitente</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation>90 - ICMS Outra UF</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="90"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="pRedBCOutraUF" type="TDec_0302Opc" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Percentual de redução da BC</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vBCOutraUF" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor da BC do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="pICMSOutraUF" type="TDec_0302">
+							<xs:annotation>
+								<xs:documentation>Alíquota do ICMS</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="vICMSOutraUF" type="TDec_1302">
+							<xs:annotation>
+								<xs:documentation>Valor do ICMS devido outra UF</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:sequence minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Sequencia XML</xs:documentation>
+							</xs:annotation>
+							<xs:element name="vICMSDeson" type="TDec_1302">
+								<xs:annotation>
+									<xs:documentation>Valor do ICMS de desoneração</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="cBenef">
+								<xs:annotation>
+									<xs:documentation>Código de Benefício Fiscal na UF</xs:documentation>
+									<xs:documentation>Código de Benefício Fiscal utilizado pela UF
+</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:whiteSpace value="preserve"/>
+										<xs:maxLength value="10"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="ICMSSN">
+				<xs:annotation>
+					<xs:documentation>Simples Nacional</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="CST">
+							<xs:annotation>
+								<xs:documentation>Classificação Tributária do Serviço</xs:documentation>
+								<xs:documentation>90 - ICMS Simples Nacional</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="90"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="indSN">
+							<xs:annotation>
+								<xs:documentation>Indica se o contribuinte é Simples Nacional			1=Sim</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:enumeration value="1"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:choice>
+	</xs:complexType>
+	<xs:complexType name="TUnidadeTransp">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados Unidade de Transporte</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpUnidTransp" type="TtipoUnidTransp">
+				<xs:annotation>
+					<xs:documentation>Tipo da Unidade de Transporte</xs:documentation>
+					<xs:documentation>1 - Rodoviário Tração
+2 - Rodoviário Reboque
+3 - Navio
+4 - Balsa
+5 - Aeronave
+6 - Vagão
+7 - Outros</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="idUnidTransp" type="TContainer">
+				<xs:annotation>
+					<xs:documentation>Identificação da Unidade de Transporte</xs:documentation>
+					<xs:documentation>Informar a identificação conforme o tipo de unidade de transporte.
+Por exemplo: para rodoviário tração ou reboque deverá preencher com a placa do veículo.
+</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="lacUnidTransp" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Lacres das Unidades de Transporte</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="nLacre">
+							<xs:annotation>
+								<xs:documentation>Número do lacre</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TString">
+									<xs:minLength value="1"/>
+									<xs:maxLength value="20"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="infUnidCarga" type="TUnidCarga" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Informações das Unidades de Carga (Containeres/ULD/Outros)</xs:documentation>
+					<xs:documentation>Dispositivo de carga utilizada (Unit Load Device - ULD) significa todo tipo de contêiner de carga, vagão, contêiner de avião, palete de aeronave com rede ou palete de aeronave com rede sobre um iglu. </xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="qtdRat" type="TDec_0302_0303" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Quantidade rateada (Peso,Volume)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TUnidCarga">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados Unidade de Carga</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="tpUnidCarga" type="TtipoUnidCarga">
+				<xs:annotation>
+					<xs:documentation>Tipo da Unidade de Carga</xs:documentation>
+					<xs:documentation>1 - Container
+2 - ULD
+3 - Pallet
+4 - Outros</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="idUnidCarga" type="TContainer">
+				<xs:annotation>
+					<xs:documentation>Identificação da Unidade de Carga</xs:documentation>
+					<xs:documentation>Informar a identificação da unidade de carga, por exemplo: número do container.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="lacUnidCarga" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Lacres das Unidades de Carga</xs:documentation>
+				</xs:annotation>
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="nLacre">
+							<xs:annotation>
+								<xs:documentation>Número do lacre</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TString">
+									<xs:minLength value="1"/>
+									<xs:maxLength value="20"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+			<xs:element name="qtdRat" type="TDec_0302_0303" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Quantidade rateada (Peso,Volume)</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TRespTec">
+		<xs:annotation>
+			<xs:documentation>Tipo Dados da Responsável Técnico</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="CNPJ" type="TCnpj">
+				<xs:annotation>
+					<xs:documentation>CNPJ da pessoa jurídica responsável técnica pelo sistema utilizado na emissão do documento fiscal eletrônico</xs:documentation>
+					<xs:documentation>Informar o CNPJ da pessoa jurídica desenvolvedora do sistema utilizado na emissão do documento fiscal eletrônico.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="xContato">
+				<xs:annotation>
+					<xs:documentation>Nome da pessoa a ser contatada</xs:documentation>
+					<xs:documentation>Informar o nome da pessoa a ser contatada na empresa desenvolvedora do sistema utilizado na emissão do documento fiscal eletrônico. No caso de pessoa física, informar o respectivo nome.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="TString">
+						<xs:maxLength value="60"/>
+						<xs:minLength value="2"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:element name="email" type="TEmail">
+				<xs:annotation>
+					<xs:documentation>Email da pessoa jurídica a ser contatada</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="fone">
+				<xs:annotation>
+					<xs:documentation>Telefone da pessoa jurídica a ser contatada</xs:documentation>
+					<xs:documentation>Preencher com o Código DDD + número do telefone.</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:whiteSpace value="preserve"/>
+						<xs:pattern value="[0-9]{7,12}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:element>
+			<xs:sequence minOccurs="0">
+				<xs:element name="idCSRT">
+					<xs:annotation>
+						<xs:documentation>Identificador do código de segurança do responsável técnico</xs:documentation>
+						<xs:documentation>Identificador do CSRT utilizado para geração do hash</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:pattern value="[0-9]{3}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="hashCSRT">
+					<xs:annotation>
+						<xs:documentation>Hash do token do código de segurança do responsável técnico</xs:documentation>
+						<xs:documentation>O hashCSRT é o resultado das funções SHA-1 e base64 do token CSRT fornecido pelo fisco + chave de acesso do DF-e. (Implementação em futura NT)
+
+Observação: 28 caracteres são representados no schema como 20 bytes do tipo base64Binary</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:base64Binary">
+							<xs:length value="20"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:simpleType name="TCfop">
+		<xs:annotation>
+			<xs:documentation>Tipo CFOP</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[123567][0-9]([0-9][1-9]|[1-9][0-9])"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCListServ">
+		<xs:annotation>
+			<xs:documentation>Tipo Código da Lista de Serviços LC 116/2003</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="101"/>
+			<xs:enumeration value="102"/>
+			<xs:enumeration value="103"/>
+			<xs:enumeration value="104"/>
+			<xs:enumeration value="105"/>
+			<xs:enumeration value="106"/>
+			<xs:enumeration value="107"/>
+			<xs:enumeration value="108"/>
+			<xs:enumeration value="201"/>
+			<xs:enumeration value="302"/>
+			<xs:enumeration value="303"/>
+			<xs:enumeration value="304"/>
+			<xs:enumeration value="305"/>
+			<xs:enumeration value="401"/>
+			<xs:enumeration value="402"/>
+			<xs:enumeration value="403"/>
+			<xs:enumeration value="404"/>
+			<xs:enumeration value="405"/>
+			<xs:enumeration value="406"/>
+			<xs:enumeration value="407"/>
+			<xs:enumeration value="408"/>
+			<xs:enumeration value="409"/>
+			<xs:enumeration value="410"/>
+			<xs:enumeration value="411"/>
+			<xs:enumeration value="412"/>
+			<xs:enumeration value="413"/>
+			<xs:enumeration value="414"/>
+			<xs:enumeration value="415"/>
+			<xs:enumeration value="416"/>
+			<xs:enumeration value="417"/>
+			<xs:enumeration value="418"/>
+			<xs:enumeration value="419"/>
+			<xs:enumeration value="420"/>
+			<xs:enumeration value="421"/>
+			<xs:enumeration value="422"/>
+			<xs:enumeration value="423"/>
+			<xs:enumeration value="501"/>
+			<xs:enumeration value="502"/>
+			<xs:enumeration value="503"/>
+			<xs:enumeration value="504"/>
+			<xs:enumeration value="505"/>
+			<xs:enumeration value="506"/>
+			<xs:enumeration value="507"/>
+			<xs:enumeration value="508"/>
+			<xs:enumeration value="509"/>
+			<xs:enumeration value="601"/>
+			<xs:enumeration value="602"/>
+			<xs:enumeration value="603"/>
+			<xs:enumeration value="604"/>
+			<xs:enumeration value="605"/>
+			<xs:enumeration value="701"/>
+			<xs:enumeration value="702"/>
+			<xs:enumeration value="703"/>
+			<xs:enumeration value="704"/>
+			<xs:enumeration value="705"/>
+			<xs:enumeration value="706"/>
+			<xs:enumeration value="707"/>
+			<xs:enumeration value="708"/>
+			<xs:enumeration value="709"/>
+			<xs:enumeration value="710"/>
+			<xs:enumeration value="711"/>
+			<xs:enumeration value="712"/>
+			<xs:enumeration value="713"/>
+			<xs:enumeration value="716"/>
+			<xs:enumeration value="717"/>
+			<xs:enumeration value="718"/>
+			<xs:enumeration value="719"/>
+			<xs:enumeration value="720"/>
+			<xs:enumeration value="721"/>
+			<xs:enumeration value="722"/>
+			<xs:enumeration value="801"/>
+			<xs:enumeration value="802"/>
+			<xs:enumeration value="901"/>
+			<xs:enumeration value="902"/>
+			<xs:enumeration value="903"/>
+			<xs:enumeration value="1001"/>
+			<xs:enumeration value="1002"/>
+			<xs:enumeration value="1003"/>
+			<xs:enumeration value="1004"/>
+			<xs:enumeration value="1005"/>
+			<xs:enumeration value="1006"/>
+			<xs:enumeration value="1007"/>
+			<xs:enumeration value="1008"/>
+			<xs:enumeration value="1009"/>
+			<xs:enumeration value="1010"/>
+			<xs:enumeration value="1101"/>
+			<xs:enumeration value="1102"/>
+			<xs:enumeration value="1103"/>
+			<xs:enumeration value="1104"/>
+			<xs:enumeration value="1201"/>
+			<xs:enumeration value="1202"/>
+			<xs:enumeration value="1203"/>
+			<xs:enumeration value="1204"/>
+			<xs:enumeration value="1205"/>
+			<xs:enumeration value="1206"/>
+			<xs:enumeration value="1207"/>
+			<xs:enumeration value="1208"/>
+			<xs:enumeration value="1209"/>
+			<xs:enumeration value="1210"/>
+			<xs:enumeration value="1211"/>
+			<xs:enumeration value="1212"/>
+			<xs:enumeration value="1213"/>
+			<xs:enumeration value="1214"/>
+			<xs:enumeration value="1215"/>
+			<xs:enumeration value="1216"/>
+			<xs:enumeration value="1217"/>
+			<xs:enumeration value="1302"/>
+			<xs:enumeration value="1303"/>
+			<xs:enumeration value="1304"/>
+			<xs:enumeration value="1305"/>
+			<xs:enumeration value="1401"/>
+			<xs:enumeration value="1402"/>
+			<xs:enumeration value="1403"/>
+			<xs:enumeration value="1404"/>
+			<xs:enumeration value="1405"/>
+			<xs:enumeration value="1406"/>
+			<xs:enumeration value="1407"/>
+			<xs:enumeration value="1408"/>
+			<xs:enumeration value="1409"/>
+			<xs:enumeration value="1410"/>
+			<xs:enumeration value="1411"/>
+			<xs:enumeration value="1412"/>
+			<xs:enumeration value="1413"/>
+			<xs:enumeration value="1501"/>
+			<xs:enumeration value="1502"/>
+			<xs:enumeration value="1503"/>
+			<xs:enumeration value="1504"/>
+			<xs:enumeration value="1505"/>
+			<xs:enumeration value="1506"/>
+			<xs:enumeration value="1507"/>
+			<xs:enumeration value="1508"/>
+			<xs:enumeration value="1509"/>
+			<xs:enumeration value="1510"/>
+			<xs:enumeration value="1511"/>
+			<xs:enumeration value="1512"/>
+			<xs:enumeration value="1513"/>
+			<xs:enumeration value="1514"/>
+			<xs:enumeration value="1515"/>
+			<xs:enumeration value="1516"/>
+			<xs:enumeration value="1517"/>
+			<xs:enumeration value="1518"/>
+			<xs:enumeration value="1601"/>
+			<xs:enumeration value="1701"/>
+			<xs:enumeration value="1702"/>
+			<xs:enumeration value="1703"/>
+			<xs:enumeration value="1704"/>
+			<xs:enumeration value="1705"/>
+			<xs:enumeration value="1706"/>
+			<xs:enumeration value="1708"/>
+			<xs:enumeration value="1709"/>
+			<xs:enumeration value="1710"/>
+			<xs:enumeration value="1711"/>
+			<xs:enumeration value="1712"/>
+			<xs:enumeration value="1713"/>
+			<xs:enumeration value="1714"/>
+			<xs:enumeration value="1715"/>
+			<xs:enumeration value="1716"/>
+			<xs:enumeration value="1717"/>
+			<xs:enumeration value="1718"/>
+			<xs:enumeration value="1719"/>
+			<xs:enumeration value="1720"/>
+			<xs:enumeration value="1721"/>
+			<xs:enumeration value="1722"/>
+			<xs:enumeration value="1723"/>
+			<xs:enumeration value="1724"/>
+			<xs:enumeration value="1801"/>
+			<xs:enumeration value="1901"/>
+			<xs:enumeration value="2001"/>
+			<xs:enumeration value="2002"/>
+			<xs:enumeration value="2003"/>
+			<xs:enumeration value="2101"/>
+			<xs:enumeration value="2201"/>
+			<xs:enumeration value="2301"/>
+			<xs:enumeration value="2401"/>
+			<xs:enumeration value="2501"/>
+			<xs:enumeration value="2502"/>
+			<xs:enumeration value="2503"/>
+			<xs:enumeration value="2504"/>
+			<xs:enumeration value="2601"/>
+			<xs:enumeration value="2701"/>
+			<xs:enumeration value="2801"/>
+			<xs:enumeration value="2901"/>
+			<xs:enumeration value="3001"/>
+			<xs:enumeration value="3101"/>
+			<xs:enumeration value="3201"/>
+			<xs:enumeration value="3301"/>
+			<xs:enumeration value="3401"/>
+			<xs:enumeration value="3501"/>
+			<xs:enumeration value="3601"/>
+			<xs:enumeration value="3701"/>
+			<xs:enumeration value="3801"/>
+			<xs:enumeration value="3901"/>
+			<xs:enumeration value="4001"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TContainer">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do Container</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="20"/>
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[A-Z0-9]+"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDocAssoc">
+		<xs:annotation>
+			<xs:documentation> Tipo Documento Associado</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="07"/>
+			<xs:enumeration value="08"/>
+			<xs:enumeration value="09"/>
+			<xs:enumeration value="10"/>
+			<xs:enumeration value="11"/>
+			<xs:enumeration value="12"/>
+			<xs:enumeration value="13"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TEmail">
+		<xs:annotation>
+			<xs:documentation>Tipo Email</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:minLength value="1"/>
+			<xs:maxLength value="60"/>
+			<xs:pattern value="[^@]+@[^\.]+\..+"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TFinCTe">
+		<xs:annotation>
+			<xs:documentation>Tipo Finalidade da CT-e</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="0"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="3"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TFinCTeSimp">
+		<xs:annotation>
+			<xs:documentation>Tipos Finalidade de CT-e Simplificado</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="5"/>
+			<xs:enumeration value="6"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TIdLote">
+		<xs:annotation>
+			<xs:documentation>Tipo Identificador de controle do envio do lote. Número seqüencial auto-incremental, de controle correspondente ao identificador único do lote enviado. A responsabilidade de gerar e controlar esse número é do próprio contribuinte.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{1,15}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TModDoc">
+		<xs:annotation>
+			<xs:documentation> Tipo Modelo do Documento</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="01"/>
+			<xs:enumeration value="1B"/>
+			<xs:enumeration value="02"/>
+			<xs:enumeration value="2D"/>
+			<xs:enumeration value="2E"/>
+			<xs:enumeration value="04"/>
+			<xs:enumeration value="06"/>
+			<xs:enumeration value="07"/>
+			<xs:enumeration value="08"/>
+			<xs:enumeration value="8B"/>
+			<xs:enumeration value="09"/>
+			<xs:enumeration value="10"/>
+			<xs:enumeration value="11"/>
+			<xs:enumeration value="13"/>
+			<xs:enumeration value="14"/>
+			<xs:enumeration value="15"/>
+			<xs:enumeration value="16"/>
+			<xs:enumeration value="17"/>
+			<xs:enumeration value="18"/>
+			<xs:enumeration value="20"/>
+			<xs:enumeration value="21"/>
+			<xs:enumeration value="22"/>
+			<xs:enumeration value="23"/>
+			<xs:enumeration value="24"/>
+			<xs:enumeration value="25"/>
+			<xs:enumeration value="26"/>
+			<xs:enumeration value="27"/>
+			<xs:enumeration value="28"/>
+			<xs:enumeration value="55"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TModTranspOS">
+		<xs:annotation>
+			<xs:documentation> Tipo Modal transporte Outros Serviços</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="01"/>
+			<xs:enumeration value="02"/>
+			<xs:enumeration value="03"/>
+			<xs:enumeration value="04"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TModTransp">
+		<xs:annotation>
+			<xs:documentation> Tipo Modal transporte</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="01"/>
+			<xs:enumeration value="02"/>
+			<xs:enumeration value="03"/>
+			<xs:enumeration value="04"/>
+			<xs:enumeration value="05"/>
+			<xs:enumeration value="06"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TModTranspSimp">
+		<xs:annotation>
+			<xs:documentation> Tipo Modal transporte do CTe Simplificado</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="01"/>
+			<xs:enumeration value="02"/>
+			<xs:enumeration value="03"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TRNTRC">
+		<xs:annotation>
+			<xs:documentation>Tipo RNTRC - Registro Nacional Transportadores Rodoviários de Carga</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{8}|ISENTO"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCIOT">
+		<xs:annotation>
+			<xs:documentation>Tipo CIOT - Código Identificador da Operação de Transporte</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{12}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCRT">
+		<xs:annotation>
+			<xs:documentation>Tipo Código Regime Tributário</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:minLength value="1"/>
+			<xs:maxLength value="1"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+			<xs:enumeration value="3"/>
+			<xs:enumeration value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TProcEmi">
+		<xs:annotation>
+			<xs:documentation>Tipo processo de emissão do CT-e</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="0"/>
+			<xs:enumeration value="3"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TTime">
+		<xs:annotation>
+			<xs:documentation>Tipo hora</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="(([0-1][0-9])|([2][0-3])):([0-5][0-9]):([0-5][0-9])"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TVerCTe">
+		<xs:annotation>
+			<xs:documentation>Tipo Versão do CT-e - 4.00</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="4\.00"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cte_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/cte_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="CTe" type="TCTe">
+		<xs:annotation>
+			<xs:documentation>Conhecimento de Transporte Eletrônico</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evCCeCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evCCeCTe_v4.00.xsd
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evCCeCTe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento carta de correção 
+110110</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “Carta de Correção”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="Carta de Correção"/>
+							<xs:enumeration value="Carta de Correcao"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="infCorrecao" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Grupo de Informações de Correção</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="grupoAlterado">
+								<xs:annotation>
+									<xs:documentation>Indicar o grupo de informações que pertence o campoAlterado. Ex: ide</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:minLength value="1"/>
+										<xs:maxLength value="20"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="campoAlterado">
+								<xs:annotation>
+									<xs:documentation>Nome do campo modificado do CT-e Original.</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:minLength value="1"/>
+										<xs:maxLength value="20"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="valorAlterado">
+								<xs:annotation>
+									<xs:documentation>Valor correspondente à alteração.</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:minLength value="1"/>
+										<xs:maxLength value="500"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="nroItemAlterado" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Preencher com o indice do item alterado caso a alteração ocorra em uma lista. 
+OBS: O indice inicia sempre  em 1</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:pattern value="[1-9][0-9]|0?[1-9]"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="xCondUso">
+					<xs:annotation>
+						<xs:documentation>Condições de uso da Carta de Correção,</xs:documentation>
+						<xs:documentation>informar a literal :Condições de uso da Carta de Correção, informar a literal:
+“A Carta de Correção é disciplinada pelo Art. 58-B do CONVÊNIO/SINIEF 06/89: Fica permitida a utilização de carta de correção, para regularização de erro ocorrido na emissão de documentos fiscais relativos à prestação de serviço de transporte, desde que o erro não esteja relacionado com: I - as variáveis que determinam o valor do imposto tais como: base de cálculo, alíquota, diferença de preço, quantidade, valor da prestação;II - a correção de dados cadastrais que implique mudança do emitente, tomador, remetente ou do destinatário;III - a data de emissão ou de saída.” (texto com acentuação)  ou “A Carta de Correcao e disciplinada pelo Art. 58-B do CONVENIO/SINIEF 06/89: Fica permitida a utilizacao de carta de correcao, para regularizacao de erro ocorrido na emissao de documentos fiscais relativos a prestacao de servico de transporte, desde que o erro nao esteja relacionado com: I - as variaveis que determinam o valor do imposto tais como: base de calculo, aliquota, diferenca de preco, quantidade, valor da prestacao;II - a correcao de dados cadastrais que implique mudança do emitente, tomador, remetente ou do destinatario;III - a data de emissao ou de saida.” (texto sem acentuação)</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="A Carta de Correção é disciplinada pelo Art. 58-B do CONVÊNIO/SINIEF 06/89: Fica permitida a utilização de carta de correção, para regularização de erro ocorrido na emissão de documentos fiscais relativos à prestação de serviço de transporte, desde que o erro não esteja relacionado com: I - as variáveis que determinam o valor do imposto tais como: base de cálculo, alíquota, diferença de preço, quantidade, valor da prestação;II - a correção de dados cadastrais que implique mudança do emitente, tomador, remetente ou do destinatário;III - a data de emissão ou de saída."/>
+							<xs:enumeration value="A Carta de Correcao e disciplinada pelo Art. 58-B do CONVENIO/SINIEF 06/89: Fica permitida a utilizacao de carta de correcao, para regularizacao de erro ocorrido na emissao de documentos fiscais relativos a prestacao de servico de transporte, desde que o erro nao esteja relacionado com: I - as variaveis que determinam o valor do imposto tais como: base de calculo, aliquota, diferenca de preco, quantidade, valor da prestacao;II - a correcao de dados cadastrais que implique mudanca do emitente, tomador, remetente ou do destinatario;III - a data de emissao ou de saida."/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evCECTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evCECTe_v4.00.xsd
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evCECTe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento comprovante de entrega eletrônico do CT-e 
+110180</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “Comprovante de Entrega do CT-e”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="Comprovante de Entrega do CT-e"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nProt" type="TProt">
+					<xs:annotation>
+						<xs:documentation>Número do Protocolo de autorização do CT-e</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="dhEntrega">
+					<xs:annotation>
+						<xs:documentation>Data e hora de conclusão da entrega da NF-e</xs:documentation>
+						<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TDateTimeUTC"/>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nDoc">
+					<xs:annotation>
+						<xs:documentation>Número do Documento de identificação da pessoa que recebeu a entrega</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TString">
+							<xs:minLength value="2"/>
+							<xs:maxLength value="20"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="xNome">
+					<xs:annotation>
+						<xs:documentation>Nome da pessoa que recebeu a entrega</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TString">
+							<xs:maxLength value="60"/>
+							<xs:minLength value="2"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="latitude" type="TLatitude" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Latitude do ponto de entrega</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="longitude" type="TLongitude" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Longitude do ponto de entrega</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="hashEntrega">
+					<xs:annotation>
+						<xs:documentation>Hash (SHA1) no formato Base64 resultante da concatenação: Chave de acesso do CT-e + Base64 da imagem capturada da entrega (Exemplo: imagem capturada da assinatura eletrônica, digital do recebedor, foto, etc)</xs:documentation>
+						<xs:documentation>O hashCSRT é o resultado das funções SHA-1 e base64 do token CSRT fornecido pelo fisco + chave de acesso do DF-e. (Implementação em futura NT)
+Observação: 28 caracteres são representados no schema como 20 bytes do tipo base64Binary</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:base64Binary">
+							<xs:length value="20"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="dhHashEntrega">
+					<xs:annotation>
+						<xs:documentation>Data e hora de geração do hash entrega</xs:documentation>
+						<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TDateTimeUTC"/>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="infEntrega" minOccurs="0" maxOccurs="2000">
+					<xs:annotation>
+						<xs:documentation>Grupo de informações das NF-e que foram entregues ao Destinatário</xs:documentation>
+						<xs:documentation>Informar o grupo apenas para CT-e com tipo de serviço Normal</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="chNFe" type="TChDFe">
+								<xs:annotation>
+									<xs:documentation>Chave de acesso da NF-e entregue</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evCancCECTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evCancCECTe_v4.00.xsd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evCancCECTe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento cancelamento do comprovante de entrega eletrônico do CT-e 
+110181</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “Cancelamento do Comprovante de Entrega do CT-e”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="Cancelamento do Comprovante de Entrega do CT-e"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nProt" type="TProt">
+					<xs:annotation>
+						<xs:documentation>Número do Protocolo de autorização do CT-e</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="nProtCE" type="TProt">
+					<xs:annotation>
+						<xs:documentation>Número do Protocolo de autorização do evento a ser cancelado </xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evCancCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evCancCTe_v4.00.xsd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evCancCTe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento do cancelamento 
+110111</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “Cancelamento”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="Cancelamento"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nProt" type="TProt">
+					<xs:annotation>
+						<xs:documentation>Número do Protocolo de Status do CT-e</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="xJust" type="TJust">
+					<xs:annotation>
+						<xs:documentation>Justificativa do Cancelamento</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evCancIECTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evCancIECTe_v4.00.xsd
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2014 rel. 2 (http://www.altova.com) by private (private) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evCancIECTe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento cancelamento do insucesso de entrega eletrônico do CT-e 
+110191</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “Cancelamento do Insucesso de Entrega do CT-e”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="Cancelamento do Insucesso de Entrega do CT-e"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nProt" type="TProt">
+					<xs:annotation>
+						<xs:documentation>Número do Protocolo de autorização do CT-e</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="nProtIE" type="TProt">
+					<xs:annotation>
+						<xs:documentation>Número do Protocolo de autorização do evento a ser cancelado </xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evCancPrestDesacordo_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evCancPrestDesacordo_v4.00.xsd
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evCancPrestDesacordo">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento Cancelamento Prestação do Serviço em Desacordo 610111</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “Cancelamento Prestação do Serviço em Desacordo”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="Cancelamento Prestação do Serviço em Desacordo"/>
+							<xs:enumeration value="Cancelamento Prestacao do Servico em Desacordo"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nProtEvPrestDes" type="TProt">
+					<xs:annotation>
+						<xs:documentation>Protocolo do evento que será cancelado</xs:documentation>
+						<xs:documentation>Informar o número do protocolo de autorização do evento de prestação de serviço em desacordo que será cancelado </xs:documentation>
+					</xs:annotation>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evEPECCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evEPECCTe_v4.00.xsd
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:ns1="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evEPECCTe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento de emissão prévia de emissão em contingência 
+110113</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “EPEC”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="EPEC"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="xJust" type="TJust">
+					<xs:annotation>
+						<xs:documentation>Justificativa da Entrada em Contingencia</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vICMS" type="TDec_1302">
+					<xs:annotation>
+						<xs:documentation>Valor do ICMS</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vICMSST" type="TDec_1302" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Valor do ICMS ST</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vTPrest" type="TDec_1302">
+					<xs:annotation>
+						<xs:documentation>Valor Total da Prestação do Serviço</xs:documentation>
+						<xs:documentation>Pode conter zeros quando o CT-e for de complemento de ICMS</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="vCarga" type="TDec_1302">
+					<xs:annotation>
+						<xs:documentation>Valor total da carga</xs:documentation>
+						<xs:documentation>Dever ser informado para todos os modais, com exceção para o Dutoviário.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="toma4">
+					<xs:annotation>
+						<xs:documentation>Indicador do "papel" do tomador do serviço no CT-e</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="toma">
+								<xs:annotation>
+									<xs:documentation>Tomador do Serviço</xs:documentation>
+									<xs:documentation>Preencher com: 
+0-Remetente;
+1-Expedidor;2-Recebedor;3-Destinatário
+;4 - Outros</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:enumeration value="0"/>
+										<xs:enumeration value="1"/>
+										<xs:enumeration value="2"/>
+										<xs:enumeration value="3"/>
+										<xs:enumeration value="4"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="UF" type="TUf">
+								<xs:annotation>
+									<xs:documentation>UF do tomador do serviço</xs:documentation>
+									<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:choice>
+								<xs:element name="CNPJ" type="TCnpjOpc">
+									<xs:annotation>
+										<xs:documentation>Número do CNPJ</xs:documentation>
+										<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.															
+Informar os zeros não significativos.</xs:documentation>
+									</xs:annotation>
+								</xs:element>
+								<xs:element name="CPF" type="TCpf">
+									<xs:annotation>
+										<xs:documentation>Número do CPF</xs:documentation>
+										<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+									</xs:annotation>
+								</xs:element>
+							</xs:choice>
+							<xs:element name="IE" type="TIeDest" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Inscrição Estadual</xs:documentation>
+									<xs:documentation>Informar a IE do tomador ou ISENTO se tomador é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o tomador não seja contribuinte do ICMS não informar o conteúdo.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+				<xs:element name="modal" type="TModTransp">
+					<xs:annotation>
+						<xs:documentation>Modal</xs:documentation>
+						<xs:documentation>Preencher com:
+ 
+01-Rodoviário;
+
+02-Aéreo;
+03-Aquaviário;
+
+04-Ferroviário;
+
+05-Dutoviário;
+06-Multimodal;</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="UFIni" type="TUf">
+					<xs:annotation>
+						<xs:documentation>UF do início da prestação</xs:documentation>
+						<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="UFFim" type="TUf">
+					<xs:annotation>
+						<xs:documentation>UF do término da prestação</xs:documentation>
+						<xs:documentation>Informar 'EX' para operações com o exterior.</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="tpCTe">
+					<xs:annotation>
+						<xs:documentation>Tipo do CT-e - Aceitar apenas Tipo Normal = 0</xs:documentation>
+						<xs:documentation>Preencher com:
+	0 - CT-e Normal;
+ 1 - CT-e de Complemento de Valores;	2 - CT-e de Anulação;
+ 3 - CT-e Substituto</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:length value="1"/>
+							<xs:enumeration value="0"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="dhEmi">
+					<xs:annotation>
+						<xs:documentation>Data e hora de emissão do CT-e</xs:documentation>
+						<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TDateTimeUTC"/>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evGTV_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evGTV_v4.00.xsd
@@ -1,0 +1,255 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evGTV">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento informações da GTV 110170</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “Informações da GTV”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="Informações da GTV"/>
+							<xs:enumeration value="Informacoes da GTV"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="infGTV" maxOccurs="unbounded">
+					<xs:annotation>
+						<xs:documentation>Grupo de Informações das GTV</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="nDoc">
+								<xs:annotation>
+									<xs:documentation>Número da GTV</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="20"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="id">
+								<xs:annotation>
+									<xs:documentation>Identificador para diferenciar GTV de mesmo número (Usar número do AIDF ou  identificador interno da empresa),</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="20"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="serie" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Série</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="3"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="subserie" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Subsérie</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="3"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="dEmi" type="TData">
+								<xs:annotation>
+									<xs:documentation>Data de Emissão</xs:documentation>
+									<xs:documentation>Formato AAAA-MM-DD</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="nDV">
+								<xs:annotation>
+									<xs:documentation>Número Dígito Verificador </xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="TString">
+										<xs:minLength value="1"/>
+										<xs:maxLength value="1"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+							<xs:element name="qCarga" type="TDec_1104">
+								<xs:annotation>
+									<xs:documentation>Quantidade de volumes/malotes</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="infEspecie" maxOccurs="unbounded">
+								<xs:annotation>
+									<xs:documentation>Informações das Espécies transportadas</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:element name="tpEspecie">
+											<xs:annotation>
+												<xs:documentation>Tipo da Espécie</xs:documentation>
+												<xs:documentation>1 - Numerário
+2 - Cheque
+3 - Moeda
+4 - Outros</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="xs:string">
+													<xs:whiteSpace value="preserve"/>
+													<xs:enumeration value="1"/>
+													<xs:enumeration value="2"/>
+													<xs:enumeration value="3"/>
+													<xs:enumeration value="4"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="vEspecie" type="TDec_1302" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Valor Transportada em Espécie indicada</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="rem">
+								<xs:annotation>
+									<xs:documentation>Informações do Remetente da GTV</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:choice>
+											<xs:element name="CNPJ" type="TCnpjOpc">
+												<xs:annotation>
+													<xs:documentation>Número do CNPJ</xs:documentation>
+													<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.
+												Informar os zeros não significativos.</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+											<xs:element name="CPF" type="TCpf">
+												<xs:annotation>
+													<xs:documentation>Número do CPF</xs:documentation>
+													<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+										</xs:choice>
+										<xs:element name="IE" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Inscrição Estadual</xs:documentation>
+												<xs:documentation>Informar a IE do remetente ou ISENTO se remetente é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o remetente não seja contribuinte do ICMS não informar o conteúdo.</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TIeDest"/>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="UF" type="TUf">
+											<xs:annotation>
+												<xs:documentation>Sigla da UF</xs:documentation>
+												<xs:documentation>Informar EX para operações com o exterior.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="xNome">
+											<xs:annotation>
+												<xs:documentation>Razão social ou nome do remetente</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:maxLength value="60"/>
+													<xs:minLength value="2"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="dest">
+								<xs:annotation>
+									<xs:documentation>Informações do Destinatário da GTV</xs:documentation>
+								</xs:annotation>
+								<xs:complexType>
+									<xs:sequence>
+										<xs:choice>
+											<xs:element name="CNPJ" type="TCnpjOpc">
+												<xs:annotation>
+													<xs:documentation>Número do CNPJ</xs:documentation>
+													<xs:documentation>Em caso de empresa não estabelecida no Brasil, será informado o CNPJ com zeros.
+							Informar os zeros não significativos.</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+											<xs:element name="CPF" type="TCpf">
+												<xs:annotation>
+													<xs:documentation>Número do CPF</xs:documentation>
+													<xs:documentation>Informar os zeros não significativos.</xs:documentation>
+												</xs:annotation>
+											</xs:element>
+										</xs:choice>
+										<xs:element name="IE" minOccurs="0">
+											<xs:annotation>
+												<xs:documentation>Inscrição Estadual</xs:documentation>
+												<xs:documentation>Informar a IE do destinatário ou ISENTO se remetente é contribuinte do ICMS isento de inscrição no cadastro de contribuintes do ICMS. Caso o remetente não seja contribuinte do ICMS não informar o conteúdo.</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TIeDest"/>
+											</xs:simpleType>
+										</xs:element>
+										<xs:element name="UF" type="TUf">
+											<xs:annotation>
+												<xs:documentation>Sigla da UF</xs:documentation>
+												<xs:documentation>Informar EX para operações com o exterior.</xs:documentation>
+											</xs:annotation>
+										</xs:element>
+										<xs:element name="xNome">
+											<xs:annotation>
+												<xs:documentation>Razão social ou nome do destinatário</xs:documentation>
+											</xs:annotation>
+											<xs:simpleType>
+												<xs:restriction base="TString">
+													<xs:maxLength value="60"/>
+													<xs:minLength value="2"/>
+												</xs:restriction>
+											</xs:simpleType>
+										</xs:element>
+									</xs:sequence>
+								</xs:complexType>
+							</xs:element>
+							<xs:element name="placa" type="TPlaca" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>Placa do veículo </xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="UF" type="TUf" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>UF em que veículo está licenciado</xs:documentation>
+									<xs:documentation>Sigla da UF de licenciamento do veículo.</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="RNTRC" minOccurs="0">
+								<xs:annotation>
+									<xs:documentation>RNTRC do transportador</xs:documentation>
+								</xs:annotation>
+								<xs:simpleType>
+									<xs:restriction base="xs:string">
+										<xs:whiteSpace value="preserve"/>
+										<xs:pattern value="[0-9]{8}|ISENTO"/>
+									</xs:restriction>
+								</xs:simpleType>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evIECTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evIECTe_v4.00.xsd
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2014 rel. 2 (http://www.altova.com) by private (private) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evIECTe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento insucesso na entrega eletrônico do CT-e 
+110190</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “Insucesso na Entrega do CT-e”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="Insucesso na Entrega do CT-e"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nProt" type="TProt">
+					<xs:annotation>
+						<xs:documentation>Número do Protocolo de autorização do CT-e</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="dhTentativaEntrega">
+					<xs:annotation>
+						<xs:documentation>Data e hora da tentativa da entrega da NF-e</xs:documentation>
+						<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TDateTimeUTC"/>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nTentativa" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Número da tentativa de entrega que não teve insucesso</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:pattern value="[0-9]{3}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="tpMotivo">
+					<xs:annotation>
+						<xs:documentation>Motivo do insucesso</xs:documentation>
+						<xs:documentation>1- Recebedor não encontrado;
+2- Recusa do recebedor;
+3- Endereço inexistente;
+4- Outros (exige informar justificativa)</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="1"/>
+							<xs:enumeration value="2"/>
+							<xs:enumeration value="3"/>
+							<xs:enumeration value="4"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="xJustMotivo" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Justificativa do Motivo de insucesso, informar apenas para tpMotivo = 4</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TString">
+							<xs:minLength value="15"/>
+							<xs:maxLength value="256"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="latitude" type="TLatitude" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Latitude do ponto de entrega</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="longitude" type="TLongitude" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Longitude do ponto de entrega</xs:documentation>
+					</xs:annotation>
+				</xs:element>
+				<xs:element name="hashTentativaEntrega" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Hash (SHA1) no formato Base64 resultante da concatenação: Chave de acesso do CT-e + Base64 da imagem capturada da tentativa com insucesso da entrega (Exemplo: foto do local que não recebeu a entrega ou do local sem recebedor)</xs:documentation>
+						<xs:documentation>O hashCSRT é o resultado das funções SHA-1 e base64 do token CSRT fornecido pelo fisco + chave de acesso do DF-e. (Implementação em futura NT)
+Observação: 28 caracteres são representados no schema como 20 bytes do tipo base64Binary</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:base64Binary">
+							<xs:length value="20"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="dhHashTentativaEntrega" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Data e hora de geração do hash tentativa entrega</xs:documentation>
+						<xs:documentation>Formato AAAA-MM-DDTHH:MM:DD TZD</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="TDateTimeUTC"/>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="infEntrega" minOccurs="0" maxOccurs="2000">
+					<xs:annotation>
+						<xs:documentation>Grupo de informações das NF-e que não tiveram sucesso na entrega ao Destinatário</xs:documentation>
+						<xs:documentation>Informar o grupo apenas para CT-e com tipo de serviço Normal</xs:documentation>
+					</xs:annotation>
+					<xs:complexType>
+						<xs:sequence>
+							<xs:element name="chNFe" type="TChDFe">
+								<xs:annotation>
+									<xs:documentation>Chave de acesso da NF-e com insucesso na tentativa de entrega</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:sequence>
+					</xs:complexType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evPrestDesacordo_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evPrestDesacordo_v4.00.xsd
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evPrestDesacordo">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento Prestação do Serviço em Desacordo 610110</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “Prestação do Serviço em Desacordo”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="Prestação do Serviço em Desacordo"/>
+							<xs:enumeration value="Prestacao do Servico em Desacordo"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="indDesacordoOper">
+					<xs:annotation>
+						<xs:documentation>Indicador de operação em desacordo</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:enumeration value="1"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="xObs">
+					<xs:annotation>
+						<xs:documentation>Observações do tomador</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:minLength value="15"/>
+							<xs:maxLength value="255"/>
+							<xs:whiteSpace value="preserve"/>
+							<xs:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evRegMultimodal_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/evRegMultimodal_v4.00.xsd
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="evRegMultimodal">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do evento Registro Multimodal 110160</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="descEvento">
+					<xs:annotation>
+						<xs:documentation>Descrição do Evento - “Registro Multimodal”</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:whiteSpace value="preserve"/>
+							<xs:enumeration value="Registro Multimodal"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="xRegistro">
+					<xs:annotation>
+						<xs:documentation>Informação complementar sobre o registro, indicação do tipo de documento utilizado e demais situações ocorridas no Multimodal (Texto Livre).</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:minLength value="15"/>
+							<xs:maxLength value="1000"/>
+							<xs:whiteSpace value="preserve"/>
+							<xs:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+				<xs:element name="nDoc" minOccurs="0">
+					<xs:annotation>
+						<xs:documentation>Numero do Documento lançado no CT-e Multimodal</xs:documentation>
+					</xs:annotation>
+					<xs:simpleType>
+						<xs:restriction base="xs:string">
+							<xs:minLength value="1"/>
+							<xs:maxLength value="44"/>
+							<xs:whiteSpace value="preserve"/>
+							<xs:pattern value="[0-9]{1,44}"/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/eventoCTeTiposBasico_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/eventoCTeTiposBasico_v4.00.xsd
@@ -1,0 +1,331 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2014 rel. 2 (http://www.altova.com) by private (private) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="xmldsig-core-schema_v1.01.xsd"/>
+	<xs:include schemaLocation="tiposGeralCTe_v4.00.xsd"/>
+	<xs:complexType name="TEvento">
+		<xs:annotation>
+			<xs:documentation>Tipo Evento</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infEvento">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="cOrgao" type="TCOrgaoIBGE">
+							<xs:annotation>
+								<xs:documentation>Código do órgão de recepção do Evento. Utilizar a Tabela do IBGE extendida, utilizar 90 para identificar SUFRAMA</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:choice>
+							<xs:element name="CNPJ" type="TCnpj">
+								<xs:annotation>
+									<xs:documentation>CNPJ do emissor do evento</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+							<xs:element name="CPF" type="TCpf">
+								<xs:annotation>
+									<xs:documentation>CPF do emissor do evento</xs:documentation>
+									<xs:documentation>Informar zeros não significativos.
+
+Usar com série específica 920-969 para emitente pessoa física com inscrição estadual</xs:documentation>
+								</xs:annotation>
+							</xs:element>
+						</xs:choice>
+						<xs:element name="chCTe" type="TChDFe">
+							<xs:annotation>
+								<xs:documentation>Chave de Acesso do CT-e vinculado ao evento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="dhEvento" type="TDateTimeUTC">
+							<xs:annotation>
+								<xs:documentation>Data e Hora do Evento, formato UTC (AAAA-MM-DDThh:mm:ssTZD)</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="tpEvento">
+							<xs:annotation>
+								<xs:documentation>Tipo do Evento</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:pattern value="[0-9]{6}"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="nSeqEvento">
+							<xs:annotation>
+								<xs:documentation>Seqüencial do evento para o mesmo tipo de evento.  Para maioria dos eventos será 1, nos casos em que possa existir mais de um evento o autor do evento deve numerar de forma seqüencial.</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:pattern value="[0-9]{1,3}"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="detEvento">
+							<xs:annotation>
+								<xs:documentation>Detalhamento do evento específico</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:any processContents="skip">
+										<xs:annotation>
+											<xs:documentation>XML do evento
+Insira neste local o XML específico do tipo de evento (cancelamento, encerramento, registro de passagem).  </xs:documentation>
+										</xs:annotation>
+									</xs:any>
+								</xs:sequence>
+								<xs:attribute name="versaoEvento" use="required">
+									<xs:simpleType>
+										<xs:restriction base="xs:string">
+											<xs:whiteSpace value="preserve"/>
+											<xs:pattern value="4\.(0[0-9]|[1-9][0-9])"/>
+										</xs:restriction>
+									</xs:simpleType>
+								</xs:attribute>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infSolicNFF" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de informações do pedido de registro de evento da Nota Fiscal Fácil</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="xSolic">
+										<xs:annotation>
+											<xs:documentation>Solicitação do pedido de registro de evento da NFF.</xs:documentation>
+											<xs:documentation>Será preenchido com a totalidade de campos informados no aplicativo emissor serializado.</xs:documentation>
+										</xs:annotation>
+										<xs:simpleType>
+											<xs:restriction base="TString">
+												<xs:minLength value="2"/>
+												<xs:maxLength value="8000"/>
+											</xs:restriction>
+										</xs:simpleType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+						<xs:element name="infPAA" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Grupo de Informação do Provedor de Assinatura e Autorização</xs:documentation>
+							</xs:annotation>
+							<xs:complexType>
+								<xs:sequence>
+									<xs:element name="CNPJPAA" type="TCnpj">
+										<xs:annotation>
+											<xs:documentation>CNPJ do Provedor de Assinatura e Autorização</xs:documentation>
+										</xs:annotation>
+									</xs:element>
+									<xs:element name="PAASignature">
+										<xs:annotation>
+											<xs:documentation>Assinatura RSA do Emitente para DFe gerados por PAA</xs:documentation>
+										</xs:annotation>
+										<xs:complexType>
+											<xs:sequence>
+												<xs:element name="SignatureValue" type="xs:base64Binary">
+													<xs:annotation>
+														<xs:documentation>Assinatura digital padrão RSA</xs:documentation>
+														<xs:documentation>Converter o atributo Id do DFe para array de bytes e assinar com a chave privada do RSA com algoritmo SHA1 gerando um valor no formato base64.</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+												<xs:element name="RSAKeyValue" type="TRSAKeyValueType">
+													<xs:annotation>
+														<xs:documentation>Chave Publica no padrão XML RSA Key</xs:documentation>
+													</xs:annotation>
+												</xs:element>
+											</xs:sequence>
+										</xs:complexType>
+									</xs:element>
+								</xs:sequence>
+							</xs:complexType>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" use="required">
+						<xs:annotation>
+							<xs:documentation>Identificador da TAG a ser assinada, a regra de formação do Id é:
+“ID” + tpEvento +  chave do CT-e + nSeqEvento</xs:documentation>
+						</xs:annotation>
+						<xs:simpleType>
+							<xs:restriction base="xs:ID">
+								<xs:pattern value="ID[0-9]{12}[A-Z0-9]{12}[0-9]{29}"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerEvento" use="required"/>
+	</xs:complexType>
+	<xs:complexType name="TRetEvento">
+		<xs:annotation>
+			<xs:documentation>Tipo retorno do Evento</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="infEvento">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="tpAmb" type="TAmb">
+							<xs:annotation>
+								<xs:documentation>Identificação do Ambiente:
+1 - Produção
+2 - Homologação</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="verAplic" type="TVerAplic">
+							<xs:annotation>
+								<xs:documentation>Versão do Aplicativo que recebeu o Evento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cOrgao" type="TCOrgaoIBGE">
+							<xs:annotation>
+								<xs:documentation>Código do órgão de recepção do Evento. Utilizar a Tabela do IBGE extendida, utilizar 90 para identificar SUFRAMA</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="cStat" type="TStat">
+							<xs:annotation>
+								<xs:documentation>Código do status da registro do Evento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="xMotivo" type="TMotivo">
+							<xs:annotation>
+								<xs:documentation>Descrição literal do status do registro do Evento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="chCTe" type="TChDFe" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Chave de Acesso CT-e vinculado</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="tpEvento" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Tipo do Evento vinculado</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:pattern value="[0-9]{6}"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="xEvento" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Descrição do Evento</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="TString">
+									<xs:minLength value="4"/>
+									<xs:maxLength value="60"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="nSeqEvento" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Seqüencial do evento</xs:documentation>
+							</xs:annotation>
+							<xs:simpleType>
+								<xs:restriction base="xs:string">
+									<xs:whiteSpace value="preserve"/>
+									<xs:pattern value="[0-9]{1,3}"/>
+								</xs:restriction>
+							</xs:simpleType>
+						</xs:element>
+						<xs:element name="dhRegEvento" type="TDateTimeUTC" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Data e Hora de do recebimento do evento ou do registro do evento formato AAAA-MM-DDThh:mm:ssTZD</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+						<xs:element name="nProt" type="TProt" minOccurs="0">
+							<xs:annotation>
+								<xs:documentation>Número do protocolo de registro do evento</xs:documentation>
+							</xs:annotation>
+						</xs:element>
+					</xs:sequence>
+					<xs:attribute name="Id" use="optional">
+						<xs:simpleType>
+							<xs:restriction base="xs:ID">
+								<xs:pattern value="ID[0-9]{15}"/>
+							</xs:restriction>
+						</xs:simpleType>
+					</xs:attribute>
+				</xs:complexType>
+			</xs:element>
+			<xs:element ref="ds:Signature" minOccurs="0"/>
+		</xs:sequence>
+		<xs:attribute name="versao" use="required">
+			<xs:simpleType>
+				<xs:restriction base="TVerEvento"/>
+			</xs:simpleType>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="TProcEvento">
+		<xs:annotation>
+			<xs:documentation>Tipo procEvento</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="eventoCTe" type="TEvento"/>
+			<xs:element name="retEventoCTe" type="TRetEvento"/>
+		</xs:sequence>
+		<xs:attribute name="versao" type="TVerEvento" use="required"/>
+		<xs:attribute name="ipTransmissor" type="TIPv4" use="optional">
+			<xs:annotation>
+				<xs:documentation>IP do transmissor do documento fiscal para o ambiente autorizador</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="nPortaCon" use="optional">
+			<xs:annotation>
+				<xs:documentation>Porta de origem utilizada na conexão (De 0 a 65535)</xs:documentation>
+			</xs:annotation>
+			<xs:simpleType>
+				<xs:restriction base="xs:string">
+					<xs:pattern value="[0-9]{1,5}"/>
+				</xs:restriction>
+			</xs:simpleType>
+		</xs:attribute>
+		<xs:attribute name="dhConexao" type="TDateTimeUTC" use="optional">
+			<xs:annotation>
+				<xs:documentation>Data e Hora da Conexão de Origem</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:simpleType name="TVerEvento">
+		<xs:annotation>
+			<xs:documentation>Tipo Versão do Evento</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="4\.00"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TModTransp">
+		<xs:annotation>
+			<xs:documentation> Tipo Modal transporte</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="01"/>
+			<xs:enumeration value="02"/>
+			<xs:enumeration value="03"/>
+			<xs:enumeration value="04"/>
+			<xs:enumeration value="05"/>
+			<xs:enumeration value="06"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TNSU">
+		<xs:annotation>
+			<xs:documentation> Tipo número sequencial único do AN</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:pattern value="[0-9]{15}"/>
+		</xs:restriction>
+	</xs:simpleType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/eventoCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/eventoCTe_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="eventoCTe" type="TEvento">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do Pedido de Registro de Evento do CT-e</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/procCTeOS_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/procCTeOS_v4.00.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="cteOSProc">
+		<xs:annotation>
+			<xs:documentation> CT-e OS processado</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="CTeOS" type="TCTeOS"/>
+				<xs:element name="protCTe" type="TProtCTeOS"/>
+			</xs:sequence>
+			<xs:attribute name="versao" type="TVerCTe" use="required"/>
+			<xs:attribute name="ipTransmissor" type="TIPv4" use="optional">
+				<xs:annotation>
+					<xs:documentation>IP do transmissor do documento fiscal para o ambiente autorizador</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="nPortaCon" use="optional">
+				<xs:annotation>
+					<xs:documentation>Porta de origem utilizada na conexão (De 0 a 65535)</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:pattern value="[0-9]{1,5}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="dhConexao" type="TDateTimeUTC" use="optional">
+				<xs:annotation>
+					<xs:documentation>Data e Hora da Conexão de Origem</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/procCTeSimp_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/procCTeSimp_v4.00.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="cteSimpProc">
+		<xs:annotation>
+			<xs:documentation> CT-e Simplificado processado</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="CTeSimp" type="TCTeSimp"/>
+				<xs:element name="protCTe" type="TProtCTe"/>
+			</xs:sequence>
+			<xs:attribute name="versao" type="TVerCTe" use="required"/>
+			<xs:attribute name="ipTransmissor" type="TIPv4" use="optional">
+				<xs:annotation>
+					<xs:documentation>IP do transmissor do documento fiscal para o ambiente autorizador</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="nPortaCon" use="optional">
+				<xs:annotation>
+					<xs:documentation>Porta de origem utilizada na conexão (De 0 a 65535)</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:pattern value="[0-9]{1,5}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="dhConexao" type="TDateTimeUTC" use="optional">
+				<xs:annotation>
+					<xs:documentation>Data e Hora da Conexão de Origem</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/procCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/procCTe_v4.00.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="cteProc">
+		<xs:annotation>
+			<xs:documentation> CT-e processado</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="CTe" type="TCTe"/>
+				<xs:element name="protCTe" type="TProtCTe"/>
+			</xs:sequence>
+			<xs:attribute name="versao" type="TVerCTe" use="required"/>
+			<xs:attribute name="ipTransmissor" type="TIPv4" use="optional">
+				<xs:annotation>
+					<xs:documentation>IP do transmissor do documento fiscal para o ambiente autorizador</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="nPortaCon" use="optional">
+				<xs:annotation>
+					<xs:documentation>Porta de origem utilizada na conexão (De 0 a 65535)</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:pattern value="[0-9]{1,5}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="dhConexao" type="TDateTimeUTC" use="optional">
+				<xs:annotation>
+					<xs:documentation>Data e Hora da Conexão de Origem</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/procEventoCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/procEventoCTe_v4.00.xsd
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="procEventoCTe">
+		<xs:annotation>
+			<xs:documentation>Pedido de Registro de Eventos de CT-e processado</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:complexContent>
+				<xs:extension base="TProcEvento"/>
+			</xs:complexContent>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/procGTVe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/procGTVe_v4.00.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="GTVeProc">
+		<xs:annotation>
+			<xs:documentation> GTV-e processada</xs:documentation>
+		</xs:annotation>
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name="GTVe" type="TGTVe"/>
+				<xs:element name="protCTe" type="TProtGTVe"/>
+			</xs:sequence>
+			<xs:attribute name="versao" type="TVerCTe" use="required"/>
+			<xs:attribute name="ipTransmissor" type="TIPv4" use="optional">
+				<xs:annotation>
+					<xs:documentation>IP do transmissor do documento fiscal para o ambiente autorizador</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+			<xs:attribute name="nPortaCon" use="optional">
+				<xs:annotation>
+					<xs:documentation>Porta de origem utilizada na conexão (De 0 a 65535)</xs:documentation>
+				</xs:annotation>
+				<xs:simpleType>
+					<xs:restriction base="xs:string">
+						<xs:pattern value="[0-9]{1,5}"/>
+					</xs:restriction>
+				</xs:simpleType>
+			</xs:attribute>
+			<xs:attribute name="dhConexao" type="TDateTimeUTC" use="optional">
+				<xs:annotation>
+					<xs:documentation>Data e Hora da Conexão de Origem</xs:documentation>
+				</xs:annotation>
+			</xs:attribute>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/retCTeOS_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/retCTeOS_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="retCTeOS" type="TRetCTeOS">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do retorno do recibo de envio do CT-e OS (Modelo 67)</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/retCTeSimp_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/retCTeSimp_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="retCTeSimp" type="TRetCTeSimp">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do retorno do recibo de envio do CT-e Simplificado (Modelo 57)</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/retCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/retCTe_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="retCTe" type="TRetCTe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do retorno do recibo de envio do CT-e (Modelo 57)</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/retConsSitCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/retConsSitCTe_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="consSitCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="retConsSitCTe" type="TRetConsSitCTe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do retorno da consulta da situação atual do CT-e.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/retConsStatServCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/retConsStatServCTe_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="consStatServTiposBasico_v4.00.xsd"/>
+	<xs:element name="retConsStatServCTe" type="TRetConsStatServ">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do Resultado da Consulta do Status do Serviço de CT-e</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/retEventoCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/retEventoCTe_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="eventoCTeTiposBasico_v4.00.xsd"/>
+	<xs:element name="retEventoCTe" type="TRetEvento">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do retorno Pedido de Evento do CT-e</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/retGTVe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/retGTVe_v4.00.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://www.portalfiscal.inf.br/cte" xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:include schemaLocation="cteTiposBasico_v4.00.xsd"/>
+	<xs:element name="retGTVe" type="TRetGTVe">
+		<xs:annotation>
+			<xs:documentation>Schema XML de validação do retorno do recibo de envio da GTV-e (Modelo 64)</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/tiposGeralCTe_v4.00.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/tiposGeralCTe_v4.00.xsd
@@ -1,0 +1,638 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- edited with XMLSpy v2008 (http://www.altova.com) by sas.softwares@procergs.rs.gov.br (PROCERGS) -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns="http://www.portalfiscal.inf.br/cte" targetNamespace="http://www.portalfiscal.inf.br/cte" elementFormDefault="qualified" attributeFormDefault="unqualified">
+	<xs:simpleType name="TDateTimeUTC">
+		<xs:annotation>
+			<xs:documentation>Data e Hora, formato UTC (AAAA-MM-DDThh:mm:ssTZD, onde TZD = +hh:mm ou -hh:mm)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="(((20(([02468][048])|([13579][26]))-02-29))|(20[0-9][0-9])-((((0[1-9])|(1[0-2]))-((0[1-9])|(1\d)|(2[0-8])))|((((0[13578])|(1[02]))-31)|(((0[1,3-9])|(1[0-2]))-(29|30)))))T(20|21|22|23|[0-1]\d):[0-5]\d:[0-5]\d([\-,\+](0[0-9]|10|11):00|([\+](12):00))"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TAmb">
+		<xs:annotation>
+			<xs:documentation>Tipo Ambiente</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="Tano">
+		<xs:annotation>
+			<xs:documentation> Tipo ano</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCodUfIBGE">
+		<xs:annotation>
+			<xs:documentation>Tipo Código da UF da tabela do IBGE</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="11"/>
+			<xs:enumeration value="12"/>
+			<xs:enumeration value="13"/>
+			<xs:enumeration value="14"/>
+			<xs:enumeration value="15"/>
+			<xs:enumeration value="16"/>
+			<xs:enumeration value="17"/>
+			<xs:enumeration value="21"/>
+			<xs:enumeration value="22"/>
+			<xs:enumeration value="23"/>
+			<xs:enumeration value="24"/>
+			<xs:enumeration value="25"/>
+			<xs:enumeration value="26"/>
+			<xs:enumeration value="27"/>
+			<xs:enumeration value="28"/>
+			<xs:enumeration value="29"/>
+			<xs:enumeration value="31"/>
+			<xs:enumeration value="32"/>
+			<xs:enumeration value="33"/>
+			<xs:enumeration value="35"/>
+			<xs:enumeration value="41"/>
+			<xs:enumeration value="42"/>
+			<xs:enumeration value="43"/>
+			<xs:enumeration value="50"/>
+			<xs:enumeration value="51"/>
+			<xs:enumeration value="52"/>
+			<xs:enumeration value="53"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCodMunIBGE">
+		<xs:annotation>
+			<xs:documentation>Tipo Código do Município da tabela do IBGE</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{7}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCOrgaoIBGE">
+		<xs:annotation>
+			<xs:documentation>Tipo Código de orgão (UF da tabela do IBGE + 90 SUFRAMA + 91 RFB +  94 SVC-RS + 95 SVC-SP + 96  Sinc. Chaves do RS para SVSP </xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="11"/>
+			<xs:enumeration value="12"/>
+			<xs:enumeration value="13"/>
+			<xs:enumeration value="14"/>
+			<xs:enumeration value="15"/>
+			<xs:enumeration value="16"/>
+			<xs:enumeration value="17"/>
+			<xs:enumeration value="21"/>
+			<xs:enumeration value="22"/>
+			<xs:enumeration value="23"/>
+			<xs:enumeration value="24"/>
+			<xs:enumeration value="25"/>
+			<xs:enumeration value="26"/>
+			<xs:enumeration value="27"/>
+			<xs:enumeration value="28"/>
+			<xs:enumeration value="29"/>
+			<xs:enumeration value="31"/>
+			<xs:enumeration value="32"/>
+			<xs:enumeration value="33"/>
+			<xs:enumeration value="35"/>
+			<xs:enumeration value="41"/>
+			<xs:enumeration value="42"/>
+			<xs:enumeration value="43"/>
+			<xs:enumeration value="50"/>
+			<xs:enumeration value="51"/>
+			<xs:enumeration value="52"/>
+			<xs:enumeration value="53"/>
+			<xs:enumeration value="90"/>
+			<xs:enumeration value="91"/>
+			<xs:enumeration value="93"/>
+			<xs:enumeration value="94"/>
+			<xs:enumeration value="95"/>
+			<xs:enumeration value="96"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TChDFe">
+		<xs:annotation>
+			<xs:documentation>Tipo Chave de Documento Fiscal Eletrônico</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="44"/>
+			<xs:pattern value="[0-9]{6}[A-Z0-9]{12}[0-9]{26}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCnpj">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do CNPJ</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[A-Z0-9]{12}[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TFone">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do Telefone</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{6,14}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCnpjOpc">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do CNPJ Opcional</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{0}|[A-Z0-9]{12}[0-9]{2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCpf">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do CPF</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{11}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TCpfVar">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do CPF de tamanho variável (3-11)</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{3,11}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TData">
+		<xs:annotation>
+			<xs:documentation> Tipo data AAAA-MM-DD</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="(((20(([02468][048])|([13579][26]))-02-29))|(20[0-9][0-9])-((((0[1-9])|(1[0-2]))-((0[1-9])|(1\d)|(2[0-8])))|((((0[13578])|(1[02]))-31)|(((0[1,3-9])|(1[0-2]))-(29|30)))))"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0302">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 5 dígitos, sendo 3 de corpo e 2 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,2}(\.[0-9]{2})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0303">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 6 dígitos, sendo 3 de corpo e 3 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{3}|[1-9]{1}[0-9]{0,2}(\.[0-9]{3})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0302_0303">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 6  ou 5 dígitos, sendo 3 de corpo e 3 ou 2 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{1,3}(\.[0-9]{2,3})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0302Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 5 dígitos, sendo 3 de corpo e 2 decimais, utilizado em tags opcionais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[0-9]{1}[1-9]{1}|0\.[1-9]{1}[0-9]{1}|[1-9]{1}[0-9]{0,2}(\.[0-9]{2})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0803">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 11 dígitos, sendo 8 de corpo e 3 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{3}|[1-9]{1}[0-9]{0,7}(\.[0-9]{3})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0803Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 11 dígitos, sendo 8 de corpo e 3 decimais utilizado em tags opcionais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[1-9]{1}[0-9]{2}|0\.[0-9]{2}[1-9]{1}|0\.[0-9]{1}[1-9]{1}[0-9]{1}|[1-9]{1}[0-9]{0,7}(\.[0-9]{3})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0804">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 12 dígitos, sendo 8 de corpo e 4decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{4}|[1-9]{1}[0-9]{0,7}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0804Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 12 dígitos, sendo 8 de corpo e 4 decimais, utilizado em tags opcionais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[1-9]{1}[0-9]{3}|0\.[0-9]{3}[1-9]{1}|0\.[0-9]{2}[1-9]{1}[0-9]{1}|0\.[0-9]{1}[1-9]{1}[0-9]{2}|[1-9]{1}[0-9]{0,7}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_0906Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 9 de corpo e 6 decimais, utilizado em tags opcionais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[1-9]{1}[0-9]{5}|0\.[0-9]{1}[1-9]{1}[0-9]{4}|0\.[0-9]{2}[1-9]{1}[0-9]{3}|0\.[0-9]{3}[1-9]{1}[0-9]{2}|0\.[0-9]{4}[1-9]{1}[0-9]{1}|0\.[0-9]{5}[1-9]{1}|[1-9]{1}[0-9]{0,8}(\.[0-9]{6})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1104">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 11 de corpo e 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{4}|[1-9]{1}[0-9]{0,10}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1104Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 11 de corpo e 4 decimais, utilizado em tags opcionais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[1-9]{1}[0-9]{3}|0\.[0-9]{3}[1-9]{1}|0\.[0-9]{2}[1-9]{1}[0-9]{1}|0\.[0-9]{1}[1-9]{1}[0-9]{2}|[1-9]{1}[0-9]{0,10}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1203">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 12 de corpo e 3 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{3}|[1-9]{1}[0-9]{0,11}(\.[0-9]{3})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1203Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 12 de corpo e 3 decimais, utilizado em tags opcionais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[1-9]{1}[0-9]{2}|0\.[0-9]{2}[1-9]{1}|0\.[0-9]{1}[1-9]{1}[0-9]{1}|[1-9]{1}[0-9]{0,11}(\.[0-9]{3})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1204">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 16 dígitos, sendo 12 de corpo e 4 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{4}|[1-9]{1}[0-9]{0,11}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1204Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 16 dígitos, sendo 12 de corpo e 4 decimais, utilizado em tags opcionais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[1-9]{1}[0-9]{3}|0\.[0-9]{3}[1-9]{1}|0\.[0-9]{2}[1-9]{1}[0-9]{1}|0\.[0-9]{1}[1-9]{1}[0-9]{2}|[1-9]{1}[0-9]{0,11}(\.[0-9]{4})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1302">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 13 de corpo e 2 decimais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|0\.[0-9]{2}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TDec_1302Opc">
+		<xs:annotation>
+			<xs:documentation>Tipo Decimal com 15 dígitos, sendo 13 de corpo e 2 decimais, utilizado em tags opcionais</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0\.[0-9]{1}[1-9]{1}|0\.[1-9]{1}[0-9]{1}|[1-9]{1}[0-9]{0,12}(\.[0-9]{2})?"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TIe">
+		<xs:annotation>
+			<xs:documentation>Tipo Inscrição Estadual do Emitente</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="14"/>
+			<xs:pattern value="[0-9]{2,14}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TIeDest">
+		<xs:annotation>
+			<xs:documentation>Tipo Inscrição Estadual do Destinatário</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:maxLength value="14"/>
+			<xs:pattern value="[0-9]{0,14}|ISENTO"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TJust">
+		<xs:annotation>
+			<xs:documentation>Tipo Justificativa</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="TString">
+			<xs:minLength value="15"/>
+			<xs:maxLength value="255"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TMed">
+		<xs:annotation>
+			<xs:documentation> Tipo temp médio em segundos</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{1,4}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TModCTOS">
+		<xs:annotation>
+			<xs:documentation>Tipo Modelo Documento Fiscal</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="67"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TModGTVe">
+		<xs:annotation>
+			<xs:documentation>Tipo Modelo Documento Fiscal</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="64"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TModCT_Carga_OS">
+		<xs:annotation>
+			<xs:documentation>Tipo Modelo Documento Fiscal</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="57"/>
+			<xs:enumeration value="67"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TModCT">
+		<xs:annotation>
+			<xs:documentation>Tipo Modelo Documento Fiscal</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="57"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TModNF">
+		<xs:annotation>
+			<xs:documentation>Tipo Modelo Documento Fiscal - NF Remetente</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="01"/>
+			<xs:enumeration value="04"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TtipoUnidTransp">
+		<xs:annotation>
+			<xs:documentation>Tipo da Unidade de Transporte</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+			<xs:enumeration value="3"/>
+			<xs:enumeration value="4"/>
+			<xs:enumeration value="5"/>
+			<xs:enumeration value="6"/>
+			<xs:enumeration value="7"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TtipoUnidCarga">
+		<xs:annotation>
+			<xs:documentation>Tipo da Unidade de Carga</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="1"/>
+			<xs:enumeration value="2"/>
+			<xs:enumeration value="3"/>
+			<xs:enumeration value="4"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TMotivo">
+		<xs:annotation>
+			<xs:documentation>Tipo Motivo</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="TString">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="255"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TNF">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do Documento Fiscal</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[1-9]{1}[0-9]{0,8}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TProt">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do Protocolo de Status</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{15}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TRec">
+		<xs:annotation>
+			<xs:documentation>Tipo Número do Recibo do envio de lote de NF-e</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{15}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TSerie">
+		<xs:annotation>
+			<xs:documentation>Tipo Série do Documento Fiscal </xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="0|[1-9]{1}[0-9]{0,2}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TServ">
+		<xs:annotation>
+			<xs:documentation>Tipo Serviço solicitado</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="TString"/>
+	</xs:simpleType>
+	<xs:simpleType name="TStat">
+		<xs:annotation>
+			<xs:documentation>Tipo Código da Mensagem enviada</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[0-9]{3,4}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TString">
+		<xs:annotation>
+			<xs:documentation> Tipo string genérico</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TUf">
+		<xs:annotation>
+			<xs:documentation>Tipo Sigla da UF</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="AC"/>
+			<xs:enumeration value="AL"/>
+			<xs:enumeration value="AM"/>
+			<xs:enumeration value="AP"/>
+			<xs:enumeration value="BA"/>
+			<xs:enumeration value="CE"/>
+			<xs:enumeration value="DF"/>
+			<xs:enumeration value="ES"/>
+			<xs:enumeration value="GO"/>
+			<xs:enumeration value="MA"/>
+			<xs:enumeration value="MG"/>
+			<xs:enumeration value="MS"/>
+			<xs:enumeration value="MT"/>
+			<xs:enumeration value="PA"/>
+			<xs:enumeration value="PB"/>
+			<xs:enumeration value="PE"/>
+			<xs:enumeration value="PI"/>
+			<xs:enumeration value="PR"/>
+			<xs:enumeration value="RJ"/>
+			<xs:enumeration value="RN"/>
+			<xs:enumeration value="RO"/>
+			<xs:enumeration value="RR"/>
+			<xs:enumeration value="RS"/>
+			<xs:enumeration value="SC"/>
+			<xs:enumeration value="SE"/>
+			<xs:enumeration value="SP"/>
+			<xs:enumeration value="TO"/>
+			<xs:enumeration value="EX"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TUF_sem_EX">
+		<xs:annotation>
+			<xs:documentation>Tipo Sigla da UF, sem Exterior</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:enumeration value="AC"/>
+			<xs:enumeration value="AL"/>
+			<xs:enumeration value="AM"/>
+			<xs:enumeration value="AP"/>
+			<xs:enumeration value="BA"/>
+			<xs:enumeration value="CE"/>
+			<xs:enumeration value="DF"/>
+			<xs:enumeration value="ES"/>
+			<xs:enumeration value="GO"/>
+			<xs:enumeration value="MA"/>
+			<xs:enumeration value="MG"/>
+			<xs:enumeration value="MS"/>
+			<xs:enumeration value="MT"/>
+			<xs:enumeration value="PA"/>
+			<xs:enumeration value="PB"/>
+			<xs:enumeration value="PE"/>
+			<xs:enumeration value="PI"/>
+			<xs:enumeration value="PR"/>
+			<xs:enumeration value="RJ"/>
+			<xs:enumeration value="RN"/>
+			<xs:enumeration value="RO"/>
+			<xs:enumeration value="RR"/>
+			<xs:enumeration value="RS"/>
+			<xs:enumeration value="SC"/>
+			<xs:enumeration value="SE"/>
+			<xs:enumeration value="SP"/>
+			<xs:enumeration value="TO"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TVerAplic">
+		<xs:annotation>
+			<xs:documentation>Tipo Versão do Aplicativo</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="TString">
+			<xs:minLength value="1"/>
+			<xs:maxLength value="20"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TLatitude">
+		<xs:annotation>
+			<xs:documentation>Coordenada geográfica Latitude</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="TString">
+			<xs:pattern value="[0-9]\.[0-9]{6}|[1-8][0-9]\.[0-9]{6}|90\.[0-9]{6}|-[0-9]\.[0-9]{6}|-[1-8][0-9]\.[0-9]{6}|-90\.[0-9]{6}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TLongitude">
+		<xs:annotation>
+			<xs:documentation>Coordenada geográfica Longitude</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="TString">
+			<xs:pattern value="[0-9]\.[0-9]{6}|[1-9][0-9]\.[0-9]{6}|1[0-7][0-9]\.[0-9]{6}|180\.[0-9]{6}|-[0-9]\.[0-9]{6}|-[1-9][0-9]\.[0-9]{6}|-1[0-7][0-9]\.[0-9]{6}|-180\.[0-9]{6}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TIPv4">
+		<xs:annotation>
+			<xs:documentation>Tipo IP versão 4</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:simpleType name="TPlaca">
+		<xs:annotation>
+			<xs:documentation>Tipo Placa </xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:whiteSpace value="preserve"/>
+			<xs:pattern value="[A-Z]{2,3}[0-9]{4}|[A-Z]{3,4}[0-9]{3}|[A-Z0-9]{7}"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="TRSAKeyValueType">
+		<xs:annotation>
+			<xs:documentation>Tipo que representa uma chave publica padrão RSA</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Modulus" type="xs:base64Binary"/>
+			<xs:element name="Exponent" type="xs:base64Binary"/>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>

--- a/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/xmldsig-core-schema_v1.01.xsd
+++ b/src/main/resources/schemas/PL_CTe_400_NT2025.001 RTC_1.14/xmldsig-core-schema_v1.01.xsd
@@ -1,0 +1,98 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!-- ***************************************************-->
+<!-- ***   Schema específico para assinaturas XML    ***-->
+<!-- *** a partir de certificados do padrão (X509)   ***-->
+<!-- *** ICP-Brasil - Projeto Nota Fiscal Eletrônica ***-->
+<!-- ***************************************************-->
+<!-- Schema for XML Signatures-->
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:ds="http://www.w3.org/2000/09/xmldsig#" targetNamespace="http://www.w3.org/2000/09/xmldsig#" elementFormDefault="qualified" attributeFormDefault="unqualified" version="0.1">
+	<element name="Signature" type="ds:SignatureType"/>
+	<complexType name="SignatureType">
+		<sequence>
+			<element name="SignedInfo" type="ds:SignedInfoType"/>
+			<element name="SignatureValue" type="ds:SignatureValueType"/>
+			<element name="KeyInfo" type="ds:KeyInfoType"/>
+		</sequence>
+		<attribute name="Id" type="ID" use="optional"/>
+	</complexType>
+	<complexType name="SignatureValueType">
+		<simpleContent>
+			<extension base="base64Binary">
+				<attribute name="Id" type="ID" use="optional"/>
+			</extension>
+		</simpleContent>
+	</complexType>
+	<complexType name="SignedInfoType">
+		<sequence>
+			<element name="CanonicalizationMethod">
+				<complexType>
+					<attribute name="Algorithm" type="anyURI" use="required" fixed="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+				</complexType>
+			</element>
+			<element name="SignatureMethod">
+				<complexType>
+					<attribute name="Algorithm" type="anyURI" use="required" fixed="http://www.w3.org/2000/09/xmldsig#rsa-sha1"/>
+				</complexType>
+			</element>
+			<element name="Reference" type="ds:ReferenceType"/>
+		</sequence>
+		<attribute name="Id" type="ID" use="optional"/>
+	</complexType>
+	<complexType name="ReferenceType">
+		<sequence>
+			<element name="Transforms" type="ds:TransformsType">
+				<!-- Garante a unicidade do atributo -->
+				<unique name="unique_Transf_Alg">
+					<selector xpath="./*"/>
+					<field xpath="@Algorithm"/>
+				</unique>
+			</element>
+			<element name="DigestMethod">
+				<complexType>
+					<attribute name="Algorithm" type="anyURI" use="required" fixed="http://www.w3.org/2000/09/xmldsig#sha1"/>
+				</complexType>
+			</element>
+			<element name="DigestValue" type="ds:DigestValueType"/>
+		</sequence>
+		<attribute name="Id" type="ID" use="optional"/>
+		<attribute name="URI" use="required">
+			<simpleType>
+				<restriction base="anyURI">
+					<minLength value="2"/>
+				</restriction>
+			</simpleType>
+		</attribute>
+		<attribute name="Type" type="anyURI" use="optional"/>
+	</complexType>
+	<complexType name="TransformsType">
+		<sequence>
+			<element name="Transform" type="ds:TransformType" minOccurs="2" maxOccurs="2"/>
+		</sequence>
+	</complexType>
+	<complexType name="TransformType">
+		<sequence minOccurs="0" maxOccurs="unbounded">
+			<element name="XPath" type="string"/>
+		</sequence>
+		<attribute name="Algorithm" type="ds:TTransformURI" use="required"/>
+	</complexType>
+	<complexType name="KeyInfoType">
+		<sequence>
+			<element name="X509Data" type="ds:X509DataType"/>
+		</sequence>
+		<attribute name="Id" type="ID" use="optional"/>
+	</complexType>
+	<complexType name="X509DataType">
+		<sequence>
+			<element name="X509Certificate" type="base64Binary"/>
+		</sequence>
+	</complexType>
+	<simpleType name="DigestValueType">
+		<restriction base="base64Binary"/>
+	</simpleType>
+	<simpleType name="TTransformURI">
+		<restriction base="anyURI">
+			<enumeration value="http://www.w3.org/2000/09/xmldsig#enveloped-signature"/>
+			<enumeration value="http://www.w3.org/TR/2001/REC-xml-c14n-20010315"/>
+		</restriction>
+	</simpleType>
+</schema>


### PR DESCRIPTION
Esta atualização corrige a inconsistência no schema PL_CTe_400_NT2025.001_RTC_1.05, que apresentava erro de validação devido à posição incorreta do campo vIBS em relação ao gCBS, migrando para a versão PL_CTe_400_NT2025.001 RTC_1.14 e ajustando o método validaCTe400 na classe DFXMLValidador para apontar para o novo diretório de XSDs, garantindo assim a conformidade com a sequência correta dos campos de tributação exigida pela Nota Técnica 2025.001 da SEFAZ.