### PR TITLE
mdfe3: corrige cardinalidade/posição de prodPred e categCombVeic conforme XSD 3.00

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/mdfe3/classes/nota/MDFInfo.java
+++ b/src/main/java/com/fincatto/documentofiscal/mdfe3/classes/nota/MDFInfo.java
@@ -45,8 +45,8 @@ public class MDFInfo extends DFBase {
     @ElementList(name = "seg", inline = true, required = false)
     private List<MDFInfoSeguro> seguro;
     
-    @ElementList(name = "prodPred", inline = true, required = false)
-    private List<MDFInfoProdutoPredominante> prodPred;
+    @Element(name = "prodPred", required = false)
+    private MDFInfoProdutoPredominante prodPred;
 
     @Element(name = "tot")
     private MDFInfoTotal infoTotal;
@@ -191,11 +191,11 @@ public class MDFInfo extends DFBase {
         this.seguro = seguro;
     }
 
-    public List<MDFInfoProdutoPredominante> getProdPred() {
+    public MDFInfoProdutoPredominante getProdPred() {
         return prodPred;
     }
 
-    public void setProdPred(List<MDFInfoProdutoPredominante> prodPred) {
+    public void setProdPred(MDFInfoProdutoPredominante prodPred) {
         this.prodPred = prodPred;
     }
 

--- a/src/main/java/com/fincatto/documentofiscal/mdfe3/classes/nota/MDFInfoModalRodoviarioPedagio.java
+++ b/src/main/java/com/fincatto/documentofiscal/mdfe3/classes/nota/MDFInfoModalRodoviarioPedagio.java
@@ -7,6 +7,7 @@ import org.simpleframework.xml.ElementList;
 import org.simpleframework.xml.Root;
 
 import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.mdfe3.classes.def.MDFTipoCategoriaCombinacaoVeicular;
 import com.fincatto.documentofiscal.validadores.DFListValidador;
 
 /**
@@ -28,10 +29,10 @@ public class MDFInfoModalRodoviarioPedagio extends DFBase {
 	private List<MDFInfoModalRodoviarioPedagioDisp> dispositivos;
 
 	/**
-	 * <h1>Categoria do Combinação Veicular</h1>
+	 * <h1>Categoria de Combinação Veicular</h1>
 	 */
 	@Element(name = "categCombVeic", required = false)
-	private String categoriaCombinacaoVeicular;
+	private MDFTipoCategoriaCombinacaoVeicular categoriaCombinacaoVeicular;
 
 	public List<MDFInfoModalRodoviarioPedagioDisp> getDispositivos() {
 		return this.dispositivos;
@@ -41,11 +42,11 @@ public class MDFInfoModalRodoviarioPedagio extends DFBase {
 		this.dispositivos = DFListValidador.validaListaObrigatoria(dispositivos, "Dispositivos do Vale Pedagio");
 	}
 
-	public String getCategoriaCombinacaoVeicular() {
+	public MDFTipoCategoriaCombinacaoVeicular getCategoriaCombinacaoVeicular() {
 		return categoriaCombinacaoVeicular;
 	}
 
-	public void setCategoriaCombinacaoVeicular(String categoriaCombinacaoVeicular) {
+	public void setCategoriaCombinacaoVeicular(MDFTipoCategoriaCombinacaoVeicular categoriaCombinacaoVeicular) {
 		this.categoriaCombinacaoVeicular = categoriaCombinacaoVeicular;
 	}
 

--- a/src/main/java/com/fincatto/documentofiscal/mdfe3/classes/nota/MDFInfoModalRodoviarioPedagioDisp.java
+++ b/src/main/java/com/fincatto/documentofiscal/mdfe3/classes/nota/MDFInfoModalRodoviarioPedagioDisp.java
@@ -1,7 +1,6 @@
 package com.fincatto.documentofiscal.mdfe3.classes.nota;
 
 import com.fincatto.documentofiscal.DFBase;
-import com.fincatto.documentofiscal.mdfe3.classes.def.MDFTipoCategoriaCombinacaoVeicular;
 import com.fincatto.documentofiscal.mdfe3.classes.def.MDFTipoValePedagio;
 import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
 import com.fincatto.documentofiscal.validadores.DFStringValidador;
@@ -56,12 +55,6 @@ public class MDFInfoModalRodoviarioPedagioDisp extends DFBase {
      */
     @Element(name = "tpValePed", required = false)
     private MDFTipoValePedagio tipoValePedagio;
-
-    /**
-     * <h1>Categoria de Combinação Veicular</h1>
-     */
-    @Element(name = "categCombVeic", required = false)
-    private MDFTipoCategoriaCombinacaoVeicular categoriaCombinacaoVeicular;
 
     public String getCnpjFornecedora() {
         return this.cnpjFornecedora;
@@ -119,13 +112,5 @@ public class MDFInfoModalRodoviarioPedagioDisp extends DFBase {
 
     public void setTipoValePedagio(MDFTipoValePedagio tipoValePedagio) {
         this.tipoValePedagio = tipoValePedagio;
-    }
-
-    public MDFTipoCategoriaCombinacaoVeicular getCategoriaCombinacaoVeicular() {
-        return categoriaCombinacaoVeicular;
-    }
-
-    public void setCategoriaCombinacaoVeicular(MDFTipoCategoriaCombinacaoVeicular categoriaCombinacaoVeicular) {
-        this.categoriaCombinacaoVeicular = categoriaCombinacaoVeicular;
     }
 }

--- a/src/test/java/com/fincatto/documentofiscal/mdfe3/FabricaDeObjetosFakeMDFe.java
+++ b/src/test/java/com/fincatto/documentofiscal/mdfe3/FabricaDeObjetosFakeMDFe.java
@@ -135,7 +135,7 @@ public class FabricaDeObjetosFakeMDFe {
         a.setMdfInfoModal(getMDFInfoModal());
         a.setInformacoesDocumentos(getMDFInfoInformacoesDocumentos());
         a.setSeguro(Collections.singletonList(getMDFInfoSeguro()));
-        a.setProdPred(Collections.singletonList(getMDFInfoProdutoPredominante()));
+        a.setProdPred(getMDFInfoProdutoPredominante());
         a.setInfoTotal(getMDFInfoTotal());
         a.setLacres(Collections.singletonList(getMDFInfoLacre1A60()));
         a.setAutorizacaoDownload(Collections.singletonList(getMDFInfoAutorizacaoDownload()));

--- a/src/test/java/com/fincatto/documentofiscal/mdfe3/classes/nota/MDFInfoModalRodoviarioPedagioDispTest.java
+++ b/src/test/java/com/fincatto/documentofiscal/mdfe3/classes/nota/MDFInfoModalRodoviarioPedagioDispTest.java
@@ -1,6 +1,5 @@
 package com.fincatto.documentofiscal.mdfe3.classes.nota;
 
-import com.fincatto.documentofiscal.mdfe3.classes.def.MDFTipoCategoriaCombinacaoVeicular;
 import com.fincatto.documentofiscal.mdfe3.classes.def.MDFTipoValePedagio;
 import org.junit.Assert;
 import org.junit.Before;
@@ -155,16 +154,5 @@ public class MDFInfoModalRodoviarioPedagioDispTest {
 
         disp.setTipoValePedagio(null);
         Assert.assertNull(disp.getTipoValePedagio());
-    }
-
-    @Test
-    public void deveSetarEObterCategoriaCombinacaoVeicular() {
-        MDFTipoCategoriaCombinacaoVeicular categoriaCombinacaoVeicular = MDFTipoCategoriaCombinacaoVeicular.values()[0];
-
-        disp.setCategoriaCombinacaoVeicular(categoriaCombinacaoVeicular);
-        Assert.assertEquals(categoriaCombinacaoVeicular, disp.getCategoriaCombinacaoVeicular());
-
-        disp.setCategoriaCombinacaoVeicular(null);
-        Assert.assertNull(disp.getCategoriaCombinacaoVeicular());
     }
 }

--- a/src/test/java/com/fincatto/documentofiscal/mdfe3/classes/nota/MDFInfoModalRodoviarioPedagioTest.java
+++ b/src/test/java/com/fincatto/documentofiscal/mdfe3/classes/nota/MDFInfoModalRodoviarioPedagioTest.java
@@ -1,0 +1,81 @@
+package com.fincatto.documentofiscal.mdfe3.classes.nota;
+
+import com.fincatto.documentofiscal.mdfe3.classes.def.MDFTipoCategoriaCombinacaoVeicular;
+import com.fincatto.documentofiscal.utils.DFPersister;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Correcao: categCombVeic deve ser irmao de disp (filho direto de valePed, uma unica ocorrencia),
+ * conforme mdfeModalRodoviario_v3.00.xsd, e nao um elemento repetido dentro de cada disp.
+ */
+public class MDFInfoModalRodoviarioPedagioTest {
+
+    @Test
+    public void categCombVeicDeveSerSerializadoComoIrmaoDeDispEAposTodosOsDisp() {
+        final MDFInfoModalRodoviarioPedagio pedagio = buildPedagioComDoisDispositivos();
+
+        final String xml = pedagio.toString();
+
+        final int fimUltimoDisp = xml.lastIndexOf("</disp>") + "</disp>".length();
+        final int posicaoCategCombVeic = xml.indexOf("<categCombVeic>");
+
+        Assert.assertTrue("categCombVeic deve estar presente no XML", posicaoCategCombVeic >= 0);
+        Assert.assertTrue("categCombVeic deve vir depois de fechar todos os <disp>", posicaoCategCombVeic >= fimUltimoDisp);
+
+        final String[] blocosDisp = xml.split("<disp>");
+        for (int i = 1; i < blocosDisp.length; i++) {
+            final String conteudoDisp = blocosDisp[i].substring(0, blocosDisp[i].indexOf("</disp>"));
+            Assert.assertFalse("categCombVeic nao deve aparecer dentro de <disp>", conteudoDisp.contains("categCombVeic"));
+        }
+    }
+
+    @Test
+    public void naoDeveGerarCategCombVeicQuandoNaoSetado() {
+        final MDFInfoModalRodoviarioPedagio pedagio = new MDFInfoModalRodoviarioPedagio();
+        pedagio.setDispositivos(buildDispositivos());
+
+        final String xml = pedagio.toString();
+
+        Assert.assertFalse("categCombVeic nao deve aparecer quando nulo", xml.contains("categCombVeic"));
+    }
+
+    @Test
+    public void deveRealizarRoundTripDeSerializacao() throws Exception {
+        final DFPersister persister = new DFPersister();
+        final MDFInfoModalRodoviarioPedagio original = buildPedagioComDoisDispositivos();
+
+        final String xml = original.toString();
+        final MDFInfoModalRodoviarioPedagio lido = persister.read(MDFInfoModalRodoviarioPedagio.class, xml);
+
+        Assert.assertNotNull(lido);
+        Assert.assertEquals(original.getCategoriaCombinacaoVeicular(), lido.getCategoriaCombinacaoVeicular());
+        Assert.assertEquals(original.getDispositivos().size(), lido.getDispositivos().size());
+        Assert.assertEquals(original.getDispositivos().get(0).getCnpjFornecedora(), lido.getDispositivos().get(0).getCnpjFornecedora());
+    }
+
+    private MDFInfoModalRodoviarioPedagio buildPedagioComDoisDispositivos() {
+        final MDFInfoModalRodoviarioPedagio pedagio = new MDFInfoModalRodoviarioPedagio();
+        pedagio.setDispositivos(buildDispositivos());
+        pedagio.setCategoriaCombinacaoVeicular(MDFTipoCategoriaCombinacaoVeicular.VEICULO_COMERCIAL_5_EIXOS);
+        return pedagio;
+    }
+
+    private List<MDFInfoModalRodoviarioPedagioDisp> buildDispositivos() {
+        final List<MDFInfoModalRodoviarioPedagioDisp> dispositivos = new ArrayList<>();
+        dispositivos.add(buildDisp("27865757000102"));
+        dispositivos.add(buildDisp("40151127000126"));
+        return dispositivos;
+    }
+
+    private MDFInfoModalRodoviarioPedagioDisp buildDisp(final String cnpjFornecedora) {
+        final MDFInfoModalRodoviarioPedagioDisp disp = new MDFInfoModalRodoviarioPedagioDisp();
+        disp.setCnpjFornecedora(cnpjFornecedora);
+        disp.setValor(new BigDecimal("104.24"));
+        return disp;
+    }
+}


### PR DESCRIPTION
## Resumo

Corrige dois desvios do leiaute MDF-e 3.00 na serialização do modal rodoviário e
do produto predominante, alinhando as classes ao XSD oficial. São duas correções
independentes, uma por commit.

## 1. `categCombVeic` — deve ser irmão de `<disp>`, não filho dele

Segundo `mdfeModalRodoviario_v3.00.xsd`, `categCombVeic` é **filho direto de
`<valePed>` (irmão de `<disp>`, ocorrência 0..1)** — e não um elemento repetido
dentro de cada `<disp>`.

- Move `categoriaCombinacaoVeicular` de `MDFInfoModalRodoviarioPedagioDisp` para
  `MDFInfoModalRodoviarioPedagio`, posicionado **após** a lista de dispositivos.
- Passa o campo de `String` para o enum tipado `MDFTipoCategoriaCombinacaoVeicular`.

**Impacto:** o XML antigo gerava `<categCombVeic>` aninhado em cada `<disp>`, o que é
inválido pelo XSD. Trata-se de mudança de API pública (getter/setter deixam de
existir em `...PedagioDisp` e passam a existir em `...Pedagio`).

## 2. `prodPred` — cardinalidade 0..1, não 0..n

Segundo `mdfeTiposBasico_v3.00.xsd` (`<xs:element name="prodPred" minOccurs="0">`),
`prodPred` ocorre **0..1**.

- Em `MDFInfo`, troca o mapeamento de `@ElementList` (`List<MDFInfoProdutoPredominante>`,
  0..n) para `@Element` único (`MDFInfoProdutoPredominante`).
- Ajusta getter/setter e a `FabricaDeObjetosFakeMDFe`.

**Impacto:** mudança de API pública — `getProdPred()`/`setProdPred(...)` passam de
`List<MDFInfoProdutoPredominante>` para `MDFInfoProdutoPredominante`.

## Testes

- Novo `MDFInfoModalRodoviarioPedagioTest`: valida que `categCombVeic` é serializado
  **depois** de todos os `<disp>`, que **não** aparece dentro de nenhum `<disp>`, que
  não é emitido quando nulo, e faz round-trip de (de)serialização.
- Removido o teste correspondente de `categCombVeic` em
  `MDFInfoModalRodoviarioPedagioDispTest` (campo não existe mais ali).
- Suíte MDF-e relevante verde localmente (`MDFInfoModalRodoviarioPedagioTest`,
  `MDFInfoModalRodoviarioPedagioDispTest`, `MDFProcessadoTest`): 21/21.

## Observação sobre compatibilidade

Ambas são mudanças de assinatura pública (breaking) — necessárias para conformar ao
XSD. Quem seta `categCombVeic` no disp ou passa uma lista em `prodPred` precisará
ajustar para o novo ponto/tipo.