### PR TITLE
Adiciona suporte ao CT-e Simplificado (tpCTe=5, NT 2024.002)

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/CTAutorizador400.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/CTAutorizador400.java
@@ -21,6 +21,11 @@ public enum CTAutorizador400 {
         }
 
         @Override
+        public String getCteRecepcaoSimp(DFAmbiente ambiente) {
+            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homologacao.sefaz.mt.gov.br/cte-ws/services/CTeRecepcaoSimpV4" : "https://cte.sefaz.mt.gov.br/cte-ws/services/CTeRecepcaoSimpV4";
+        }
+
+        @Override
         public String getCteRecepcaoGTVe(DFAmbiente ambiente) {
             return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homologacao.sefaz.mt.gov.br/ctews2/services/CTeRecepcaoGTVeV4" : "https://cte.sefaz.mt.gov.br/ctews2/services/CTeRecepcaoGTVeV4";
         }
@@ -60,6 +65,11 @@ public enum CTAutorizador400 {
         @Override
         public String getCteRecepcaoOS(DFAmbiente ambiente) {
             return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homologacao.cte.ms.gov.br/ws/CTeRecepcaoOSV4" : "https://producao.cte.ms.gov.br/ws/CTeRecepcaoOSV4";
+        }
+
+        @Override
+        public String getCteRecepcaoSimp(DFAmbiente ambiente) {
+            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homologacao.cte.ms.gov.br/ws/CTeRecepcaoSimpV4" : "https://producao.cte.ms.gov.br/ws/CTeRecepcaoSimpV4";
         }
 
         @Override
@@ -105,6 +115,11 @@ public enum CTAutorizador400 {
         }
 
         @Override
+        public String getCteRecepcaoSimp(DFAmbiente ambiente) {
+            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://hcte.fazenda.mg.gov.br/cte/services/CTeRecepcaoSimpV4" : "https://cte.fazenda.mg.gov.br/cte/services/CTeRecepcaoSimpV4";
+        }
+
+        @Override
         public String getCteRecepcaoGTVe(DFAmbiente ambiente) {
             return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://hcte.fazenda.mg.gov.br/cte/services/CTeRecepcaoGTVeV4" : "https://cte.fazenda.mg.gov.br/cte/services/CTeRecepcaoGTVeV4";
         }
@@ -144,6 +159,11 @@ public enum CTAutorizador400 {
         @Override
         public String getCteRecepcaoOS(DFAmbiente ambiente) {
             return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homologacao.cte.fazenda.pr.gov.br/cte4/CTeRecepcaoOSV4" : "https://cte.fazenda.pr.gov.br/cte4/CTeRecepcaoOSV4";
+        }
+
+        @Override
+        public String getCteRecepcaoSimp(DFAmbiente ambiente) {
+            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homologacao.cte.fazenda.pr.gov.br/cte4/CTeRecepcaoSimpV4" : "https://cte.fazenda.pr.gov.br/cte4/CTeRecepcaoSimpV4";
         }
 
         @Override
@@ -189,6 +209,11 @@ public enum CTAutorizador400 {
         }
 
         @Override
+        public String getCteRecepcaoSimp(DFAmbiente ambiente) {
+            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://cte-homologacao.svrs.rs.gov.br/ws/CTeRecepcaoSimpV4/CTeRecepcaoSimpV4.asmx" : "https://cte.svrs.rs.gov.br/ws/CTeRecepcaoSimpV4/CTeRecepcaoSimpV4.asmx";
+        }
+
+        @Override
         public String getCteRecepcaoGTVe(DFAmbiente ambiente) {
             return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://cte-homologacao.svrs.rs.gov.br/ws/CTeRecepcaoGTVeV4/CTeRecepcaoGTVeV4.asmx" : "https://cte.svrs.rs.gov.br/ws/CTeRecepcaoGTVeV4/CTeRecepcaoGTVeV4.asmx";
         }
@@ -228,6 +253,11 @@ public enum CTAutorizador400 {
         @Override
         public String getCteRecepcaoOS(DFAmbiente ambiente) {
             return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homologacao.nfe.fazenda.sp.gov.br/CTeWS/WS/CTeRecepcaoOSV4.asmx" : "https://nfe.fazenda.sp.gov.br/CTeWS/WS/CTeRecepcaoOSV4.asmx";
+        }
+
+        @Override
+        public String getCteRecepcaoSimp(DFAmbiente ambiente) {
+            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homologacao.nfe.fazenda.sp.gov.br/CTeWS/WS/CTeRecepcaoSimpV4.asmx" : "https://nfe.fazenda.sp.gov.br/CTeWS/WS/CTeRecepcaoSimpV4.asmx";
         }
 
         @Override
@@ -273,6 +303,11 @@ public enum CTAutorizador400 {
         }
 
         @Override
+        public String getCteRecepcaoSimp(DFAmbiente ambiente) {
+            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://cte-homologacao.svrs.rs.gov.br/ws/CTeRecepcaoSimpV4/CTeRecepcaoSimpV4.asmx" : "https://cte.svrs.rs.gov.br/ws/CTeRecepcaoSimpV4/CTeRecepcaoSimpV4.asmx";
+        }
+
+        @Override
         public String getCteRecepcaoGTVe(DFAmbiente ambiente) {
             return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://cte-homologacao.svrs.rs.gov.br/ws/CTeRecepcaoGTVeV4/CTeRecepcaoGTVeV4.asmx" : "https://cte.svrs.rs.gov.br/ws/CTeRecepcaoGTVeV4/CTeRecepcaoGTVeV4.asmx";
         }
@@ -315,6 +350,11 @@ public enum CTAutorizador400 {
         }
 
         @Override
+        public String getCteRecepcaoSimp(DFAmbiente ambiente) {
+            return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homologacao.nfe.fazenda.sp.gov.br/CTeWS/WS/CTeRecepcaoSimpV4.asmx" : "https://nfe.fazenda.sp.gov.br/CTeWS/WS/CTeRecepcaoSimpV4.asmx";
+        }
+
+        @Override
         public String getCteRecepcaoGTVe(DFAmbiente ambiente) {
             return DFAmbiente.HOMOLOGACAO.equals(ambiente) ? "https://homologacao.nfe.fazenda.sp.gov.br/CTeWS/WS/CTeRecepcaoGTVeV4.asmx" : "https://nfe.fazenda.sp.gov.br/CTeWS/WS/CTeRecepcaoGTVeV4.asmx";
         }
@@ -348,6 +388,8 @@ public enum CTAutorizador400 {
     public abstract String getCteRecepcaoSinc(final DFAmbiente ambiente);
 
     public abstract String getCteRecepcaoOS(final DFAmbiente ambiente);
+
+    public abstract String getCteRecepcaoSimp(final DFAmbiente ambiente);
 
     public abstract String getCteRecepcaoGTVe(final DFAmbiente ambiente);
     

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/envio/CTeSimpEnvioRetorno.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/envio/CTeSimpEnvioRetorno.java
@@ -1,0 +1,114 @@
+package com.fincatto.documentofiscal.cte400.classes.envio;
+
+import com.fincatto.documentofiscal.DFAmbiente;
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.DFUnidadeFederativa;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+@Root(name = "retCTeSimp")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeSimpEnvioRetorno extends DFBase {
+    private static final long serialVersionUID = 1L;
+
+    @Element(name = "tpAmb", required = false)
+    private DFAmbiente ambiente;
+
+    @Element(name = "cUF", required = false)
+    private DFUnidadeFederativa uf;
+
+    @Element(name = "verAplic", required = false)
+    private String versaoAplicacao;
+
+    @Element(name = "cStat", required = false)
+    private String status;
+
+    @Element(name = "xMotivo", required = false)
+    private String motivo;
+
+    @Element(name = "protCTe", required = false)
+    private CTeProtocolo protocolo;
+
+    @Attribute(name = "versao", required = false)
+    private String versao;
+
+    public DFAmbiente getAmbiente() {
+        return this.ambiente;
+    }
+
+    /**
+     * Identificação do Ambiente:1 - Produção; 2 - Homologação
+     */
+    public void setAmbiente(final DFAmbiente ambiente) {
+        this.ambiente = ambiente;
+    }
+
+    public DFUnidadeFederativa getUf() {
+        return this.uf;
+    }
+
+    /**
+     * Identificação da UF
+     */
+    public void setUf(final DFUnidadeFederativa uf) {
+        this.uf = uf;
+    }
+
+    public String getVersaoAplicacao() {
+        return this.versaoAplicacao;
+    }
+
+    /**
+     * Versão do Aplicativo que recebeu o Lote.
+     */
+    public void setVersaoAplicacao(final String versaoAplicacao) {
+        this.versaoAplicacao = versaoAplicacao;
+    }
+
+    public String getStatus() {
+        return this.status;
+    }
+
+    /**
+     * Código do status da mensagem enviada.
+     */
+    public void setStatus(final String status) {
+        this.status = status;
+    }
+
+    public String getMotivo() {
+        return this.motivo;
+    }
+
+    /**
+     * Descrição literal do status do serviço solicitado.
+     */
+    public void setMotivo(final String motivo) {
+        this.motivo = motivo;
+    }
+
+    public CTeProtocolo getProtocolo() {
+        return this.protocolo;
+    }
+
+    /**
+     * Dados do protocolo do processamento do CT-e
+     */
+    public void setProtocolo(final CTeProtocolo protocolo) {
+        this.protocolo = protocolo;
+    }
+
+    public String getVersao() {
+        return this.versao;
+    }
+
+    /**
+     * versão da aplicação
+     */
+    public void setVersao(final String versao) {
+        this.versao = versao;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/envio/CTeSimpEnvioRetornoDados.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/envio/CTeSimpEnvioRetornoDados.java
@@ -1,0 +1,22 @@
+package com.fincatto.documentofiscal.cte400.classes.envio;
+
+import com.fincatto.documentofiscal.cte400.classes.simp.CTeNotaSimp;
+
+public class CTeSimpEnvioRetornoDados {
+
+    private final CTeSimpEnvioRetorno retorno;
+    private final CTeNotaSimp loteAssinado;
+
+    public CTeSimpEnvioRetornoDados(CTeSimpEnvioRetorno retorno, CTeNotaSimp loteAssinado) {
+        this.retorno = retorno;
+        this.loteAssinado = loteAssinado;
+    }
+
+    public CTeSimpEnvioRetorno getRetorno() {
+        return retorno;
+    }
+
+    public CTeNotaSimp getLoteAssinado() {
+        return loteAssinado;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimp.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimp.java
@@ -1,0 +1,52 @@
+package com.fincatto.documentofiscal.cte400.classes.simp;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.nota.CTeNotaInfoSuplementares;
+import com.fincatto.documentofiscal.cte400.classes.nota.assinatura.CTeSignature;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+/**
+ * Conhecimento de Transporte Eletrônico Simplificado (Modelo 57), conforme
+ * NT 2024.002. Raiz do documento (elemento CTeSimp).
+ */
+@Root(name = "CTeSimp")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeNotaSimp extends DFBase {
+    private static final long serialVersionUID = 1L;
+
+    @Element(name = "infCte")
+    private CTeNotaSimpInfo infCte;
+
+    @Element(name = "infCTeSupl", required = false)
+    private CTeNotaInfoSuplementares infCTeSupl;
+
+    @Element(name = "Signature", required = false)
+    private CTeSignature signature;
+
+    public CTeNotaSimpInfo getInfCte() {
+        return this.infCte;
+    }
+
+    public void setInfCte(final CTeNotaSimpInfo infCte) {
+        this.infCte = infCte;
+    }
+
+    public CTeNotaInfoSuplementares getInfCTeSupl() {
+        return this.infCTeSupl;
+    }
+
+    public void setInfCTeSupl(final CTeNotaInfoSuplementares infCTeSupl) {
+        this.infCTeSupl = infCTeSupl;
+    }
+
+    public CTeSignature getSignature() {
+        return this.signature;
+    }
+
+    public void setSignature(final CTeSignature signature) {
+        this.signature = signature;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimpInfo.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimpInfo.java
@@ -1,0 +1,195 @@
+package com.fincatto.documentofiscal.cte400.classes.simp;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.nota.CTeNotaInfoAutorizacaoDownload;
+import com.fincatto.documentofiscal.cte400.classes.nota.CTeNotaInfoCTeNormalCobranca;
+import com.fincatto.documentofiscal.cte400.classes.nota.CTeNotaInfoCTeNormalInfoCarga;
+import com.fincatto.documentofiscal.cte400.classes.nota.CTeNotaInfoCTeNormalInfoModal;
+import com.fincatto.documentofiscal.cte400.classes.nota.CTeNotaInfoEmitente;
+import com.fincatto.documentofiscal.cte400.classes.nota.CTeNotaInfoInformacoesRelativasImpostos;
+import com.fincatto.documentofiscal.cte400.classes.nota.CTeNotaInfoResponsavelTecnico;
+import com.fincatto.documentofiscal.validadores.DFListValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.util.List;
+
+/**
+ * Informações do CT-e Simplificado (grupo infCte). A ordem dos elementos segue o
+ * XSD cteSimp_v4.00.xsd. Reaproveita os grupos comuns ao CT-e normal (emit,
+ * infCarga, infModal, imp, cobr, autXML, infRespTec) e traz o próprio grupo det.
+ */
+@Root(name = "infCte")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeNotaSimpInfo extends DFBase {
+    public static final String IDENT = "CTe";
+    private static final long serialVersionUID = 1L;
+
+    @Attribute(name = "Id")
+    private String id;
+
+    @Attribute(name = "versao")
+    private String versao;
+
+    @Element(name = "ide")
+    private CTeNotaSimpInfoIdentificacao ide;
+
+    @Element(name = "emit")
+    private CTeNotaInfoEmitente emit;
+
+    @Element(name = "toma")
+    private CTeNotaSimpInfoTomador toma;
+
+    @Element(name = "infCarga")
+    private CTeNotaInfoCTeNormalInfoCarga infCarga;
+
+    @ElementList(name = "det", inline = true)
+    private List<CTeNotaSimpInfoDet> det;
+
+    @Element(name = "infModal")
+    private CTeNotaInfoCTeNormalInfoModal infModal;
+
+    @Element(name = "cobr", required = false)
+    private CTeNotaInfoCTeNormalCobranca cobr;
+
+    @Element(name = "imp")
+    private CTeNotaInfoInformacoesRelativasImpostos imp;
+
+    @Element(name = "total")
+    private CTeNotaSimpInfoTotal total;
+
+    @ElementList(name = "autXML", inline = true, required = false)
+    private List<CTeNotaInfoAutorizacaoDownload> autXML;
+
+    @Element(name = "infRespTec", required = false)
+    private CTeNotaInfoResponsavelTecnico infRespTec;
+
+    public String getId() {
+        return this.id;
+    }
+
+    /**
+     * Identificador da tag a ser assinada. Informar a chave de acesso do CT-e,
+     * precedida do literal "CTe".
+     */
+    public void setId(final String id) {
+        DFStringValidador.exatamente44(id, "Identificador");
+        this.id = CTeNotaSimpInfo.IDENT + id;
+    }
+
+    /**
+     * Chave de acesso a partir do identificador.
+     */
+    public String getChaveAcesso() {
+        return this.id.replace(CTeNotaSimpInfo.IDENT, "");
+    }
+
+    public String getVersao() {
+        return this.versao;
+    }
+
+    /**
+     * Versão do leiaute
+     */
+    public void setVersao(final String versao) {
+        this.versao = versao;
+    }
+
+    public CTeNotaSimpInfoIdentificacao getIde() {
+        return this.ide;
+    }
+
+    public void setIde(final CTeNotaSimpInfoIdentificacao ide) {
+        this.ide = ide;
+    }
+
+    public CTeNotaInfoEmitente getEmit() {
+        return this.emit;
+    }
+
+    public void setEmit(final CTeNotaInfoEmitente emit) {
+        this.emit = emit;
+    }
+
+    public CTeNotaSimpInfoTomador getToma() {
+        return this.toma;
+    }
+
+    public void setToma(final CTeNotaSimpInfoTomador toma) {
+        this.toma = toma;
+    }
+
+    public CTeNotaInfoCTeNormalInfoCarga getInfCarga() {
+        return this.infCarga;
+    }
+
+    public void setInfCarga(final CTeNotaInfoCTeNormalInfoCarga infCarga) {
+        this.infCarga = infCarga;
+    }
+
+    public List<CTeNotaSimpInfoDet> getDet() {
+        return this.det;
+    }
+
+    /**
+     * Detalhamento das entregas / prestações (1 a 999 itens).
+     */
+    public void setDet(final List<CTeNotaSimpInfoDet> det) {
+        DFListValidador.tamanho990(det, "Detalhamento das prestacoes (det)");
+        this.det = det;
+    }
+
+    public CTeNotaInfoCTeNormalInfoModal getInfModal() {
+        return this.infModal;
+    }
+
+    public void setInfModal(final CTeNotaInfoCTeNormalInfoModal infModal) {
+        this.infModal = infModal;
+    }
+
+    public CTeNotaInfoCTeNormalCobranca getCobr() {
+        return this.cobr;
+    }
+
+    public void setCobr(final CTeNotaInfoCTeNormalCobranca cobr) {
+        this.cobr = cobr;
+    }
+
+    public CTeNotaInfoInformacoesRelativasImpostos getImp() {
+        return this.imp;
+    }
+
+    public void setImp(final CTeNotaInfoInformacoesRelativasImpostos imp) {
+        this.imp = imp;
+    }
+
+    public CTeNotaSimpInfoTotal getTotal() {
+        return this.total;
+    }
+
+    public void setTotal(final CTeNotaSimpInfoTotal total) {
+        this.total = total;
+    }
+
+    public List<CTeNotaInfoAutorizacaoDownload> getAutXML() {
+        return this.autXML;
+    }
+
+    public void setAutXML(final List<CTeNotaInfoAutorizacaoDownload> autXML) {
+        DFListValidador.tamanho10(autXML, "Autorizados para download do XML do DF-e");
+        this.autXML = autXML;
+    }
+
+    public CTeNotaInfoResponsavelTecnico getInfRespTec() {
+        return this.infRespTec;
+    }
+
+    public void setInfRespTec(final CTeNotaInfoResponsavelTecnico infRespTec) {
+        this.infRespTec = infRespTec;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimpInfoDet.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimpInfoDet.java
@@ -1,0 +1,164 @@
+package com.fincatto.documentofiscal.cte400.classes.simp;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Detalhamento das entregas / prestações do CT-e Simplificado (grupo det, 1-999).
+ */
+@Root(name = "det")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeNotaSimpInfoDet extends DFBase {
+    private static final long serialVersionUID = 1L;
+
+    @Attribute(name = "nItem")
+    private String nItem;
+
+    @Element(name = "cMunIni")
+    private String cMunIni;
+
+    @Element(name = "xMunIni")
+    private String xMunIni;
+
+    @Element(name = "cMunFim")
+    private String cMunFim;
+
+    @Element(name = "xMunFim")
+    private String xMunFim;
+
+    @Element(name = "vPrest")
+    private String vPrest;
+
+    @Element(name = "vRec")
+    private String vRec;
+
+    @ElementList(name = "Comp", inline = true, required = false)
+    private List<CTeNotaSimpInfoDetComp> comp;
+
+    @ElementList(name = "infNFe", inline = true, required = false)
+    private List<CTeNotaSimpInfoDetInfNFe> infNFe;
+
+    @ElementList(name = "infDocAnt", inline = true, required = false)
+    private List<CTeNotaSimpInfoDetInfDocAnt> infDocAnt;
+
+    public String getNItem() {
+        return this.nItem;
+    }
+
+    /**
+     * Número identificador do item agrupador da prestação (1 a 990)
+     */
+    public void setNItem(final String nItem) {
+        this.nItem = nItem;
+    }
+
+    public String getCMunIni() {
+        return this.cMunIni;
+    }
+
+    /**
+     * Código do Município de início da prestação (tabela IBGE; 9999999 para o exterior)
+     */
+    public void setCMunIni(final String cMunIni) {
+        DFStringValidador.exatamente7N(cMunIni, "Codigo do Municipio de inicio da prestacao");
+        this.cMunIni = cMunIni;
+    }
+
+    public String getXMunIni() {
+        return this.xMunIni;
+    }
+
+    /**
+     * Nome do Município do início da prestação ('EXTERIOR' para o exterior)
+     */
+    public void setXMunIni(final String xMunIni) {
+        DFStringValidador.tamanho2ate60(xMunIni, "Nome do Municipio de inicio da prestacao");
+        this.xMunIni = xMunIni;
+    }
+
+    public String getCMunFim() {
+        return this.cMunFim;
+    }
+
+    /**
+     * Código do Município de término da prestação (tabela IBGE; 9999999 para o exterior)
+     */
+    public void setCMunFim(final String cMunFim) {
+        DFStringValidador.exatamente7N(cMunFim, "Codigo do Municipio de termino da prestacao");
+        this.cMunFim = cMunFim;
+    }
+
+    public String getXMunFim() {
+        return this.xMunFim;
+    }
+
+    /**
+     * Nome do Município do término da prestação ('EXTERIOR' para o exterior)
+     */
+    public void setXMunFim(final String xMunFim) {
+        DFStringValidador.tamanho2ate60(xMunFim, "Nome do Municipio de termino da prestacao");
+        this.xMunFim = xMunFim;
+    }
+
+    public String getVPrest() {
+        return this.vPrest;
+    }
+
+    /**
+     * Valor da Prestação do Serviço
+     */
+    public void setVPrest(final BigDecimal vPrest) {
+        this.vPrest = DFBigDecimalValidador.tamanho15Com2CasasDecimais(vPrest, "Valor da Prestacao do Servico");
+    }
+
+    public String getVRec() {
+        return this.vRec;
+    }
+
+    /**
+     * Valor a Receber
+     */
+    public void setVRec(final BigDecimal vRec) {
+        this.vRec = DFBigDecimalValidador.tamanho15Com2CasasDecimais(vRec, "Valor a Receber");
+    }
+
+    public List<CTeNotaSimpInfoDetComp> getComp() {
+        return this.comp;
+    }
+
+    public void setComp(final List<CTeNotaSimpInfoDetComp> comp) {
+        this.comp = comp;
+    }
+
+    public List<CTeNotaSimpInfoDetInfNFe> getInfNFe() {
+        return this.infNFe;
+    }
+
+    /**
+     * Informações das NF-e. Exclusivo com infDocAnt (choice do XSD).
+     */
+    public void setInfNFe(final List<CTeNotaSimpInfoDetInfNFe> infNFe) {
+        this.infNFe = infNFe;
+    }
+
+    public List<CTeNotaSimpInfoDetInfDocAnt> getInfDocAnt() {
+        return this.infDocAnt;
+    }
+
+    /**
+     * Documentos anteriores. Exclusivo com infNFe (choice do XSD).
+     */
+    public void setInfDocAnt(final List<CTeNotaSimpInfoDetInfDocAnt> infDocAnt) {
+        this.infDocAnt = infDocAnt;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimpInfoDetComp.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimpInfoDetComp.java
@@ -1,0 +1,50 @@
+package com.fincatto.documentofiscal.cte400.classes.simp;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+/**
+ * Componentes do Valor da Prestação (CT-e Simplificado - grupo det)
+ */
+@Root(name = "Comp")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeNotaSimpInfoDetComp extends DFBase {
+    private static final long serialVersionUID = 1L;
+
+    @Element(name = "xNome")
+    private String xNome;
+
+    @Element(name = "vComp")
+    private String vComp;
+
+    public String getXNome() {
+        return this.xNome;
+    }
+
+    /**
+     * Nome do componente<br>
+     * Exemplos: FRETE PESO, FRETE VALOR, SEC/CAT, ADEME, AGENDAMENTO, etc
+     */
+    public void setXNome(final String xNome) {
+        DFStringValidador.tamanho15(xNome, "Nome do componente");
+        this.xNome = xNome;
+    }
+
+    public String getVComp() {
+        return this.vComp;
+    }
+
+    /**
+     * Valor do componente
+     */
+    public void setVComp(final BigDecimal vComp) {
+        this.vComp = DFBigDecimalValidador.tamanho15Com2CasasDecimais(vComp, "Valor do componente");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimpInfoDetInfDocAnt.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimpInfoDetInfDocAnt.java
@@ -1,0 +1,68 @@
+package com.fincatto.documentofiscal.cte400.classes.simp;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.util.List;
+
+/**
+ * Documentos anteriores (CT-e Simplificado - grupo det)
+ */
+@Root(name = "infDocAnt")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeNotaSimpInfoDetInfDocAnt extends DFBase {
+    private static final long serialVersionUID = 1L;
+
+    @Element(name = "chCTe")
+    private String chCTe;
+
+    @Element(name = "tpPrest")
+    private String tpPrest;
+
+    @ElementList(name = "infNFeTranspParcial", inline = true, required = false)
+    private List<CTeNotaSimpInfoDetInfDocAntNFeTranspParcial> infNFeTranspParcial;
+
+    public String getChCTe() {
+        return this.chCTe;
+    }
+
+    /**
+     * Chave de acesso do CT-e anterior
+     */
+    public void setChCTe(final String chCTe) {
+        DFStringValidador.exatamente44(chCTe, "Chave de acesso do CT-e anterior");
+        this.chCTe = chCTe;
+    }
+
+    public String getTpPrest() {
+        return this.tpPrest;
+    }
+
+    /**
+     * Indica se a prestação é total ou parcial em relação às notas do documento
+     * anterior. Preencher com: 1 - Total; 2 - Parcial.
+     */
+    public void setTpPrest(final String tpPrest) {
+        DFStringValidador.exatamente1(tpPrest, "Tipo da prestação do documento anterior");
+        if (!"1".equals(tpPrest) && !"2".equals(tpPrest)) {
+            throw new IllegalStateException("Tipo da prestação do documento anterior deve ser 1 (Total) ou 2 (Parcial)");
+        }
+        this.tpPrest = tpPrest;
+    }
+
+    public List<CTeNotaSimpInfoDetInfDocAntNFeTranspParcial> getInfNFeTranspParcial() {
+        return this.infNFeTranspParcial;
+    }
+
+    /**
+     * Chaves das NF-e transportadas parcialmente (obrigatório quando tpPrest = 2).
+     */
+    public void setInfNFeTranspParcial(final List<CTeNotaSimpInfoDetInfDocAntNFeTranspParcial> infNFeTranspParcial) {
+        this.infNFeTranspParcial = infNFeTranspParcial;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimpInfoDetInfDocAntNFeTranspParcial.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimpInfoDetInfDocAntNFeTranspParcial.java
@@ -1,0 +1,33 @@
+package com.fincatto.documentofiscal.cte400.classes.simp;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+/**
+ * Chaves das NF-e transportadas parcialmente em relação ao documento anterior
+ * (CT-e Simplificado - grupo det/infDocAnt). Informado quando tpPrest = 2 (Parcial).
+ */
+@Root(name = "infNFeTranspParcial")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeNotaSimpInfoDetInfDocAntNFeTranspParcial extends DFBase {
+    private static final long serialVersionUID = 1L;
+
+    @Element(name = "chNFe")
+    private String chNFe;
+
+    public String getChNFe() {
+        return this.chNFe;
+    }
+
+    /**
+     * Chave de acesso da NF-e transportada parcialmente
+     */
+    public void setChNFe(final String chNFe) {
+        DFStringValidador.exatamente44(chNFe, "Chave de acesso da NF-e (transporte parcial)");
+        this.chNFe = chNFe;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimpInfoDetInfNFe.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimpInfoDetInfNFe.java
@@ -1,0 +1,62 @@
+package com.fincatto.documentofiscal.cte400.classes.simp;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.time.LocalDate;
+
+/**
+ * Informações das NF-e (CT-e Simplificado - grupo det)
+ */
+@Root(name = "infNFe")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeNotaSimpInfoDetInfNFe extends DFBase {
+    private static final long serialVersionUID = 1L;
+
+    @Element(name = "chNFe")
+    private String chNFe;
+
+    @Element(name = "PIN", required = false)
+    private String PIN;
+
+    @Element(name = "dPrev", required = false)
+    private LocalDate dPrev;
+
+    public String getChNFe() {
+        return this.chNFe;
+    }
+
+    /**
+     * Chave de acesso da NF-e
+     */
+    public void setChNFe(final String chNFe) {
+        DFStringValidador.exatamente44(chNFe, "Chave de acesso da NF-e");
+        this.chNFe = chNFe;
+    }
+
+    public String getPIN() {
+        return this.PIN;
+    }
+
+    /**
+     * PIN atribuído pela SUFRAMA para a operação
+     */
+    public void setPIN(final String PIN) {
+        this.PIN = PIN;
+    }
+
+    public LocalDate getDPrev() {
+        return this.dPrev;
+    }
+
+    /**
+     * Data prevista de entrega (AAAA-MM-DD)
+     */
+    public void setDPrev(final LocalDate dPrev) {
+        this.dPrev = dPrev;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimpInfoIdentificacao.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimpInfoIdentificacao.java
@@ -1,0 +1,418 @@
+package com.fincatto.documentofiscal.cte400.classes.simp;
+
+import com.fincatto.documentofiscal.DFAmbiente;
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.DFModelo;
+import com.fincatto.documentofiscal.DFUnidadeFederativa;
+import com.fincatto.documentofiscal.cte.CTTipoEmissao;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.CTModal;
+import com.fincatto.documentofiscal.cte400.classes.CTProcessoEmissao;
+import com.fincatto.documentofiscal.cte400.classes.CTRetirada;
+import com.fincatto.documentofiscal.cte400.classes.CTTipoImpressao;
+import com.fincatto.documentofiscal.cte400.classes.CTTipoServico;
+import com.fincatto.documentofiscal.validadores.DFIntegerValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+
+/**
+ * Identificação do CT-e Simplificado (grupo ide).
+ * Diferente do CT-e normal: tpCTe assume 5 (Simplificado) ou 6 (Substituição do
+ * Simplificado); modal restrito a 01/02/03; município de início/fim da prestação
+ * é informado por item no grupo det, não aqui.
+ */
+@Root(name = "ide")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeNotaSimpInfoIdentificacao extends DFBase {
+    private static final long serialVersionUID = 1L;
+
+    @Element(name = "cUF")
+    private DFUnidadeFederativa cUF;
+
+    @Element(name = "cCT")
+    private String cCT;
+
+    @Element(name = "CFOP")
+    private String CFOP;
+
+    @Element(name = "natOp")
+    private String natOp;
+
+    @Element(name = "mod")
+    private DFModelo mod;
+
+    @Element(name = "serie")
+    private Integer serie;
+
+    @Element(name = "nCT")
+    private Integer nCT;
+
+    @Element(name = "dhEmi")
+    private ZonedDateTime dhEmi;
+
+    @Element(name = "tpImp")
+    private CTTipoImpressao tpImp;
+
+    @Element(name = "tpEmis")
+    private CTTipoEmissao tpEmis;
+
+    @Element(name = "cDV")
+    private Integer cDV;
+
+    @Element(name = "tpAmb")
+    private DFAmbiente tpAmb;
+
+    @Element(name = "tpCTe")
+    private String tpCTe;
+
+    @Element(name = "procEmi")
+    private CTProcessoEmissao procEmi;
+
+    @Element(name = "verProc")
+    private String verProc;
+
+    @Element(name = "cMunEnv")
+    private String cMunEnv;
+
+    @Element(name = "xMunEnv")
+    private String xMunEnv;
+
+    @Element(name = "UFEnv")
+    private String UFEnv;
+
+    @Element(name = "modal")
+    private CTModal modal;
+
+    @Element(name = "tpServ")
+    private CTTipoServico tpServ;
+
+    @Element(name = "UFIni")
+    private String UFIni;
+
+    @Element(name = "UFFim")
+    private String UFFim;
+
+    @Element(name = "retira")
+    private CTRetirada retira;
+
+    @Element(name = "xDetRetira", required = false)
+    private String xDetRetira;
+
+    @Element(name = "dhCont", required = false)
+    private LocalDateTime dhCont;
+
+    @Element(name = "xJust", required = false)
+    private String xJust;
+
+    public DFUnidadeFederativa getCUF() {
+        return this.cUF;
+    }
+
+    /**
+     * Código da UF do emitente do CT-e.
+     */
+    public void setCUF(final DFUnidadeFederativa cUF) {
+        this.cUF = cUF;
+    }
+
+    public String getCCT() {
+        return this.cCT;
+    }
+
+    /**
+     * Código numérico que compõe a Chave de Acesso.
+     */
+    public void setCCT(final String cCT) {
+        DFStringValidador.exatamente8N(cCT, "Codigo Numerico");
+        this.cCT = cCT;
+    }
+
+    public String getCFOP() {
+        return this.CFOP;
+    }
+
+    /**
+     * Código Fiscal de Operações e Prestações
+     */
+    public void setCFOP(final String CFOP) {
+        DFStringValidador.exatamente4N(CFOP, "CFOP");
+        this.CFOP = CFOP;
+    }
+
+    public String getNatOp() {
+        return this.natOp;
+    }
+
+    /**
+     * Natureza da Operação
+     */
+    public void setNatOp(final String natOp) {
+        DFStringValidador.tamanho2ate60(natOp, "Natureza da Operacao");
+        this.natOp = natOp;
+    }
+
+    public DFModelo getMod() {
+        return this.mod;
+    }
+
+    /**
+     * Modelo do documento fiscal (código 57 para o CT-e).
+     */
+    public void setMod(final DFModelo mod) {
+        this.mod = mod;
+    }
+
+    public Integer getSerie() {
+        return this.serie;
+    }
+
+    /**
+     * Série do CT-e
+     */
+    public void setSerie(final Integer serie) {
+        DFIntegerValidador.tamanho3(serie, "Serie");
+        this.serie = serie;
+    }
+
+    public Integer getNCT() {
+        return this.nCT;
+    }
+
+    /**
+     * Número do CT-e
+     */
+    public void setNCT(final Integer nCT) {
+        DFIntegerValidador.tamanho9(nCT, "Numero");
+        this.nCT = nCT;
+    }
+
+    public ZonedDateTime getDhEmi() {
+        return this.dhEmi;
+    }
+
+    /**
+     * Data e hora de emissão do CT-e (AAAA-MM-DDTHH:MM:DD TZD)
+     */
+    public void setDhEmi(final ZonedDateTime dhEmi) {
+        this.dhEmi = dhEmi;
+    }
+
+    public CTTipoImpressao getTpImp() {
+        return this.tpImp;
+    }
+
+    /**
+     * Formato de impressão do DACTE (1 - Retrato; 2 - Paisagem).
+     */
+    public void setTpImp(final CTTipoImpressao tpImp) {
+        this.tpImp = tpImp;
+    }
+
+    public CTTipoEmissao getTpEmis() {
+        return this.tpEmis;
+    }
+
+    /**
+     * Forma de emissão do CT-e (1 - Normal; 3 - Regime Especial NFF; 4 - EPEC SVC;
+     * 7 - SVC-RS; 8 - SVC-SP).
+     */
+    public void setTpEmis(final CTTipoEmissao tpEmis) {
+        this.tpEmis = tpEmis;
+    }
+
+    public Integer getCDV() {
+        return this.cDV;
+    }
+
+    /**
+     * Dígito Verificador da chave de acesso do CT-e
+     */
+    public void setCDV(final Integer cDV) {
+        DFIntegerValidador.exatamente1(cDV, "DV");
+        this.cDV = cDV;
+    }
+
+    public DFAmbiente getTpAmb() {
+        return this.tpAmb;
+    }
+
+    /**
+     * Tipo do Ambiente (1 - Produção; 2 - Homologação).
+     */
+    public void setTpAmb(final DFAmbiente tpAmb) {
+        this.tpAmb = tpAmb;
+    }
+
+    public String getTpCTe() {
+        return this.tpCTe;
+    }
+
+    /**
+     * Tipo do CT-e Simplificado. Preencher com: 5 - CT-e Simplificado;
+     * 6 - Substituição do CT-e Simplificado.
+     */
+    public void setTpCTe(final String tpCTe) {
+        DFStringValidador.exatamente1(tpCTe, "Tipo do CT-e Simplificado");
+        if (!"5".equals(tpCTe) && !"6".equals(tpCTe)) {
+            throw new IllegalStateException("Tipo do CT-e Simplificado deve ser 5 (Simplificado) ou 6 (Substituicao)");
+        }
+        this.tpCTe = tpCTe;
+    }
+
+    public CTProcessoEmissao getProcEmi() {
+        return this.procEmi;
+    }
+
+    /**
+     * Identificador do processo de emissão do CT-e
+     */
+    public void setProcEmi(final CTProcessoEmissao procEmi) {
+        this.procEmi = procEmi;
+    }
+
+    public String getVerProc() {
+        return this.verProc;
+    }
+
+    /**
+     * Versão do processo de emissão
+     */
+    public void setVerProc(final String verProc) {
+        DFStringValidador.tamanho20(verProc, "Versao Aplicativo Emissor");
+        this.verProc = verProc;
+    }
+
+    public String getCMunEnv() {
+        return this.cMunEnv;
+    }
+
+    /**
+     * Código do Município de envio do CT-e (tabela IBGE; 9999999 para o exterior).
+     */
+    public void setCMunEnv(final String cMunEnv) {
+        DFStringValidador.exatamente7N(cMunEnv, "Codigo do Municipio de envio do CT-e");
+        this.cMunEnv = cMunEnv;
+    }
+
+    public String getXMunEnv() {
+        return this.xMunEnv;
+    }
+
+    /**
+     * Nome do Município de envio do CT-e.
+     */
+    public void setXMunEnv(final String xMunEnv) {
+        DFStringValidador.tamanho2ate60(xMunEnv, "Nome do Municipio de envio do CT-e");
+        this.xMunEnv = xMunEnv;
+    }
+
+    public String getUFEnv() {
+        return this.UFEnv;
+    }
+
+    /**
+     * Sigla da UF de envio do CT-e ('EX' para operações com o exterior).
+     */
+    public void setUFEnv(final String UFEnv) {
+        DFStringValidador.exatamente2(UFEnv, "Sigla da UF de envio do CT-e");
+        this.UFEnv = UFEnv;
+    }
+
+    public CTModal getModal() {
+        return this.modal;
+    }
+
+    /**
+     * Modal (01 - Rodoviário; 02 - Aéreo; 03 - Aquaviário).
+     */
+    public void setModal(final CTModal modal) {
+        this.modal = modal;
+    }
+
+    public CTTipoServico getTpServ() {
+        return this.tpServ;
+    }
+
+    /**
+     * Tipo do Serviço (0 - Normal; 1 - Subcontratação; 2 - Redespacho).
+     */
+    public void setTpServ(final CTTipoServico tpServ) {
+        this.tpServ = tpServ;
+    }
+
+    public String getUFIni() {
+        return this.UFIni;
+    }
+
+    /**
+     * UF do início da prestação ('EX' para operações com o exterior).
+     */
+    public void setUFIni(final String UFIni) {
+        DFStringValidador.exatamente2(UFIni, "UF do inicio da prestacao");
+        this.UFIni = UFIni;
+    }
+
+    public String getUFFim() {
+        return this.UFFim;
+    }
+
+    /**
+     * UF do término da prestação ('EX' para operações com o exterior).
+     */
+    public void setUFFim(final String UFFim) {
+        DFStringValidador.exatamente2(UFFim, "UF do termino da prestacao");
+        this.UFFim = UFFim;
+    }
+
+    public CTRetirada getRetira() {
+        return this.retira;
+    }
+
+    /**
+     * Indicador se o Recebedor retira no Aeroporto/Filial/Porto/Estação de Destino
+     * (0 - sim; 1 - não).
+     */
+    public void setRetira(final CTRetirada retira) {
+        this.retira = retira;
+    }
+
+    public String getXDetRetira() {
+        return this.xDetRetira;
+    }
+
+    /**
+     * Detalhes da retirada
+     */
+    public void setXDetRetira(final String xDetRetira) {
+        DFStringValidador.tamanho160(xDetRetira, "Detalhes da retirada");
+        this.xDetRetira = xDetRetira;
+    }
+
+    public LocalDateTime getDhCont() {
+        return this.dhCont;
+    }
+
+    /**
+     * Data e Hora da entrada em contingência (AAAA-MM-DDTHH:MM:SS).
+     */
+    public void setDhCont(final LocalDateTime dhCont) {
+        this.dhCont = dhCont;
+    }
+
+    public String getXJust() {
+        return this.xJust;
+    }
+
+    /**
+     * Justificativa da entrada em contingência
+     */
+    public void setXJust(final String xJust) {
+        DFStringValidador.tamanho15a256(xJust, "Justificativa da entrada em contingencia");
+        this.xJust = xJust;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimpInfoTomador.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimpInfoTomador.java
@@ -1,0 +1,171 @@
+package com.fincatto.documentofiscal.cte400.classes.simp;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.CTIndicadorTomador;
+import com.fincatto.documentofiscal.cte400.classes.CTTomadorServico;
+import com.fincatto.documentofiscal.cte400.classes.nota.CTeNotaEndereco;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+/**
+ * Identificação do tomador do serviço no CT-e Simplificado (grupo toma).
+ * Diferente do CT-e normal: o tomador pode ser qualquer papel (0 a 4) e o
+ * indicador de inscrição estadual (indIEToma) é informado dentro deste grupo.
+ */
+@Root(name = "toma")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeNotaSimpInfoTomador extends DFBase {
+    private static final long serialVersionUID = 1L;
+
+    @Element(name = "toma")
+    private CTTomadorServico toma;
+
+    @Element(name = "indIEToma")
+    private CTIndicadorTomador indIEToma;
+
+    @Element(name = "CNPJ", required = false)
+    private String CNPJ;
+
+    @Element(name = "CPF", required = false)
+    private String CPF;
+
+    @Element(name = "IE", required = false)
+    private String IE;
+
+    @Element(name = "xNome")
+    private String xNome;
+
+    @Element(name = "ISUF", required = false)
+    private String ISUF;
+
+    @Element(name = "fone", required = false)
+    private String fone;
+
+    @Element(name = "enderToma")
+    private CTeNotaEndereco enderToma;
+
+    @Element(name = "email", required = false)
+    private String email;
+
+    public CTTomadorServico getToma() {
+        return this.toma;
+    }
+
+    /**
+     * Tomador do Serviço. Preencher com: 0-Remetente; 1-Expedidor; 2-Recebedor;
+     * 3-Destinatário; 4-Terceiro.
+     */
+    public void setToma(final CTTomadorServico toma) {
+        this.toma = toma;
+    }
+
+    public CTIndicadorTomador getIndIEToma() {
+        return this.indIEToma;
+    }
+
+    /**
+     * Indicador do papel do tomador na prestação do serviço: 1 - Contribuinte ICMS;
+     * 2 - Contribuinte isento de inscrição; 9 - Não Contribuinte.
+     */
+    public void setIndIEToma(final CTIndicadorTomador indIEToma) {
+        this.indIEToma = indIEToma;
+    }
+
+    public String getCNPJ() {
+        return this.CNPJ;
+    }
+
+    /**
+     * Número do CNPJ do tomador. Informar os zeros não significativos.
+     */
+    public void setCNPJ(final String CNPJ) {
+        DFStringValidador.cnpj(CNPJ);
+        this.CNPJ = CNPJ;
+    }
+
+    public String getCPF() {
+        return this.CPF;
+    }
+
+    /**
+     * Número do CPF do tomador. Informar os zeros não significativos.
+     */
+    public void setCPF(final String CPF) {
+        DFStringValidador.cpf(CPF);
+        this.CPF = CPF;
+    }
+
+    public String getIE() {
+        return this.IE;
+    }
+
+    /**
+     * Inscrição Estadual do tomador (ou ISENTO).
+     */
+    public void setIE(final String IE) {
+        DFStringValidador.inscricaoEstadual(IE);
+        this.IE = IE;
+    }
+
+    public String getXNome() {
+        return this.xNome;
+    }
+
+    /**
+     * Razão Social ou Nome do tomador
+     */
+    public void setXNome(final String xNome) {
+        DFStringValidador.tamanho2ate60(xNome, "Razão Social ou Nome do tomador");
+        this.xNome = xNome;
+    }
+
+    public String getISUF() {
+        return this.ISUF;
+    }
+
+    /**
+     * Inscrição na SUFRAMA (obrigatório nas operações com áreas de incentivos fiscais).
+     */
+    public void setISUF(final String ISUF) {
+        this.ISUF = ISUF;
+    }
+
+    public String getFone() {
+        return this.fone;
+    }
+
+    /**
+     * Telefone do tomador
+     */
+    public void setFone(final String fone) {
+        DFStringValidador.telefone(fone);
+        this.fone = fone;
+    }
+
+    public CTeNotaEndereco getEnderToma() {
+        return this.enderToma;
+    }
+
+    /**
+     * Dados do endereço do tomador
+     */
+    public void setEnderToma(final CTeNotaEndereco enderToma) {
+        this.enderToma = enderToma;
+    }
+
+    public String getEmail() {
+        return this.email;
+    }
+
+    /**
+     * Endereço de email do tomador
+     */
+    public void setEmail(final String email) {
+        DFStringValidador.tamanho60(email, "Endereço de email do tomador");
+        DFStringValidador.email(email);
+        this.email = email;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimpInfoTotal.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimpInfoTotal.java
@@ -1,0 +1,47 @@
+package com.fincatto.documentofiscal.cte400.classes.simp;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.math.BigDecimal;
+
+/**
+ * Valores Totais do CT-e Simplificado (grupo total)
+ */
+@Root(name = "total")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeNotaSimpInfoTotal extends DFBase {
+    private static final long serialVersionUID = 1L;
+
+    @Element(name = "vTPrest")
+    private String vTPrest;
+
+    @Element(name = "vTRec")
+    private String vTRec;
+
+    public String getVTPrest() {
+        return this.vTPrest;
+    }
+
+    /**
+     * Valor Total da Prestação do Serviço
+     */
+    public void setVTPrest(final BigDecimal vTPrest) {
+        this.vTPrest = DFBigDecimalValidador.tamanho15Com2CasasDecimais(vTPrest, "Valor Total da Prestacao do Servico");
+    }
+
+    public String getVTRec() {
+        return this.vTRec;
+    }
+
+    /**
+     * Valor total a Receber
+     */
+    public void setVTRec(final BigDecimal vTRec) {
+        this.vTRec = DFBigDecimalValidador.tamanho15Com2CasasDecimais(vTRec, "Valor Total a Receber");
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeSimpProcessado.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeSimpProcessado.java
@@ -1,0 +1,90 @@
+package com.fincatto.documentofiscal.cte400.classes.simp;
+
+import com.fincatto.documentofiscal.DFBase;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.envio.CTeProtocolo;
+import org.simpleframework.xml.Attribute;
+import org.simpleframework.xml.Element;
+import org.simpleframework.xml.Namespace;
+import org.simpleframework.xml.Root;
+
+import java.time.ZonedDateTime;
+
+/**
+ * CT-e Simplificado processado (XML de distribuição), com raiz cteSimpProc =
+ * CTeSimp + protCTe. Espelha CTeOSProcessado (cteOSProc).
+ */
+@Root(name = "cteSimpProc")
+@Namespace(reference = CTeConfig.NAMESPACE)
+public class CTeSimpProcessado extends DFBase {
+    private static final long serialVersionUID = 1L;
+
+    /**
+     * Tipo IP versão 4
+     */
+    @Attribute(name = "ipTransmissor", required = false)
+    private String ipTransmissor;
+
+    @Attribute(name = "nPortaCon", required = false)
+    private String portaConexao;
+
+    @Attribute(name = "dhConexao", required = false)
+    private ZonedDateTime dataHoraConexao;
+
+    @Attribute(name = "versao")
+    private String versao;
+
+    @Element(name = "CTeSimp")
+    private CTeNotaSimp cte;
+
+    @Element(name = "protCTe")
+    private CTeProtocolo protocolo;
+
+    public String getIpTransmissor() {
+        return this.ipTransmissor;
+    }
+
+    public void setIpTransmissor(final String ipTransmissor) {
+        this.ipTransmissor = ipTransmissor;
+    }
+
+    public String getPortaConexao() {
+        return portaConexao;
+    }
+
+    public void setPortaConexao(String portaConexao) {
+        this.portaConexao = portaConexao;
+    }
+
+    public ZonedDateTime getDataHoraConexao() {
+        return dataHoraConexao;
+    }
+
+    public void setDataHoraConexao(ZonedDateTime dataHoraConexao) {
+        this.dataHoraConexao = dataHoraConexao;
+    }
+
+    public String getVersao() {
+        return this.versao;
+    }
+
+    public void setVersao(final String versao) {
+        this.versao = versao;
+    }
+
+    public CTeNotaSimp getCte() {
+        return this.cte;
+    }
+
+    public void setCte(final CTeNotaSimp cte) {
+        this.cte = cte;
+    }
+
+    public CTeProtocolo getProtocolo() {
+        return this.protocolo;
+    }
+
+    public void setProtocolo(final CTeProtocolo protocolo) {
+        this.protocolo = protocolo;
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSFacade.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSFacade.java
@@ -7,6 +7,7 @@ import com.fincatto.documentofiscal.cte.webservices.distribuicao.WSDistribuicaoC
 import com.fincatto.documentofiscal.cte400.classes.consultastatusservico.CTeConsStatServRet;
 import com.fincatto.documentofiscal.cte400.classes.envio.CTeEnvioRetornoDados;
 import com.fincatto.documentofiscal.cte400.classes.envio.CTeOSEnvioRetornoDados;
+import com.fincatto.documentofiscal.cte400.classes.envio.CTeSimpEnvioRetornoDados;
 import com.fincatto.documentofiscal.cte400.classes.evento.CTeEventoRetorno;
 import com.fincatto.documentofiscal.cte400.classes.evento.cartacorrecao.CTeInformacaoCartaCorrecao;
 import com.fincatto.documentofiscal.cte400.classes.evento.comprovanteentrega.CTeEnviaEventoComprovanteEntrega;
@@ -16,6 +17,7 @@ import com.fincatto.documentofiscal.cte400.classes.evento.insucessoentrega.CTeEn
 import com.fincatto.documentofiscal.cte400.classes.nota.CTeNota;
 import com.fincatto.documentofiscal.cte400.classes.nota.consulta.CTeNotaConsultaRetorno;
 import com.fincatto.documentofiscal.cte400.classes.os.CTeOS;
+import com.fincatto.documentofiscal.cte400.classes.simp.CTeNotaSimp;
 import com.fincatto.documentofiscal.utils.DFSocketFactory;
 import org.apache.commons.httpclient.protocol.Protocol;
 
@@ -45,6 +47,7 @@ public class WSFacade {
     private final WSInsucessoEntrega wsInsucessoEntrega;
     private final WSCancelamentoInsucessoEntrega wsCancelamentoInsucessoEntrega;
     private final WSRecepcaoCTeOS wsRecepcaoCTeOS;
+    private final WSRecepcaoCTeSimp wsRecepcaoCTeSimp;
 
     public WSFacade(final CTeConfig config) throws IOException, KeyManagementException, UnrecoverableKeyException, KeyStoreException, NoSuchAlgorithmException, CertificateException {
         Protocol.registerProtocol("https", new Protocol("https", new DFSocketFactory(config), 443));
@@ -64,6 +67,7 @@ public class WSFacade {
         this.wsInsucessoEntrega = new WSInsucessoEntrega(config);
         this.wsCancelamentoInsucessoEntrega = new WSCancelamentoInsucessoEntrega(config);
         this.wsRecepcaoCTeOS = new WSRecepcaoCTeOS(config);
+        this.wsRecepcaoCTeSimp = new WSRecepcaoCTeSimp(config);
     }
 
     /**
@@ -567,6 +571,17 @@ public class WSFacade {
      * */
     public CTeOSEnvioRetornoDados enviaCTe(CTeOS cteOS) throws Exception {
         return this.wsRecepcaoCTeOS.enviaCTe(cteOS);
+    }
+
+    /**
+     * Faz o envio do CT-e Simplificado (modelo 57, NT 2024.002) para a SEFAZ.
+     *
+     * @param cteSimp a ser eviado para a SEFAZ
+     * @return dados do retorno do envio do CT-e Simplificado e o xml assinado
+     * @throws Exception caso nao consiga gerar o xml ou problema de conexao com o sefaz
+     * */
+    public CTeSimpEnvioRetornoDados enviaCTe(CTeNotaSimp cteSimp) throws Exception {
+        return this.wsRecepcaoCTeSimp.enviaCTe(cteSimp);
     }
 
 }

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSRecepcaoCTeSimp.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/WSRecepcaoCTeSimp.java
@@ -1,0 +1,58 @@
+package com.fincatto.documentofiscal.cte400.webservices;
+
+import com.fincatto.documentofiscal.DFLog;
+import com.fincatto.documentofiscal.cte.CTeConfig;
+import com.fincatto.documentofiscal.cte400.classes.CTAutorizador400;
+import com.fincatto.documentofiscal.cte400.classes.envio.CTeSimpEnvioRetorno;
+import com.fincatto.documentofiscal.cte400.classes.envio.CTeSimpEnvioRetornoDados;
+import com.fincatto.documentofiscal.cte400.classes.simp.CTeNotaSimp;
+import com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoSimpV4Stub;
+import com.fincatto.documentofiscal.utils.DFAssinaturaDigital;
+import com.fincatto.documentofiscal.validadores.DFXMLValidador;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.zip.GZIPOutputStream;
+
+class WSRecepcaoCTeSimp implements DFLog {
+    private final CTeConfig config;
+
+    WSRecepcaoCTeSimp(final CTeConfig config) {
+        this.config = config;
+    }
+
+    public CTeSimpEnvioRetornoDados enviaCTe(CTeNotaSimp cteSimp) throws Exception {
+        final String documentoAssinado = new DFAssinaturaDigital(this.config).assinarDocumento(cteSimp.toString(), "infCte");
+        final CTeNotaSimp cteAssinado = this.config.getPersister().read(CTeNotaSimp.class, documentoAssinado);
+
+        final CTeSimpEnvioRetorno retorno = comunicaLote(documentoAssinado);
+        return new CTeSimpEnvioRetornoDados(retorno, cteAssinado);
+    }
+
+    private CTeSimpEnvioRetorno comunicaLote(final String cteAssinadoXml) throws Exception {
+        DFXMLValidador.validaNotaCteSimp400(cteAssinadoXml);
+
+        String conteudoCompactado;
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream()) {
+             try (GZIPOutputStream gzipOutputStream = new GZIPOutputStream(byteArrayOutputStream)) {
+                 gzipOutputStream.write(cteAssinadoXml.getBytes(StandardCharsets.UTF_8));
+             }
+            conteudoCompactado = Base64.getEncoder().encodeToString(byteArrayOutputStream.toByteArray());
+        }
+
+        final CTeRecepcaoSimpV4Stub.CteDadosMsg dados = new CTeRecepcaoSimpV4Stub.CteDadosMsg();
+        dados.setCteDadosMsg(conteudoCompactado);
+
+        final CTAutorizador400 autorizador = CTAutorizador400.valueOfTipoEmissao(this.config.getTipoEmissao(), this.config.getCUF());
+        final String endpoint = autorizador.getCteRecepcaoSimp(this.config.getAmbiente());
+        if (endpoint == null) {
+            throw new IllegalArgumentException("Nao foi possivel encontrar URL para Recepcao Simp, autorizador " + autorizador.name() + ", UF " + this.config.getCUF().name());
+        }
+        final CTeRecepcaoSimpV4Stub.CteRecepcaoSimpResult autorizacaoLoteResult = new CTeRecepcaoSimpV4Stub(endpoint, config).cteRecepcaoSimp(dados);
+        final CTeSimpEnvioRetorno retorno = this.config.getPersister().read(CTeSimpEnvioRetorno.class, autorizacaoLoteResult.getExtraElement().toString());
+        this.getLogger().debug(retorno.toString());
+        return retorno;
+    }
+
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/gerado/CTeRecepcaoSimpV4Stub.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/gerado/CTeRecepcaoSimpV4Stub.java
@@ -1,0 +1,1085 @@
+/**
+ * CTeRecepcaoSimpV4Stub.java
+ *
+ * This file was auto-generated from WSDL
+ * by the Apache Axis2 version: 1.6.4  Built on : Dec 28, 2015 (10:03:39 GMT)
+ *
+ * NOTA: derivado de CTeRecepcaoOSV4Stub por substituicao de identificadores. Os literais
+ * do contrato foram CONFERIDOS contra os WSDL reais de homologacao de MT
+ * (homologacao.sefaz.mt.gov.br/cte-ws/services/CTeRecepcaoSimpV4?wsdl) e SVRS
+ * (cte-homologacao.svrs.rs.gov.br/ws/CTeRecepcaoSimpV4/CTeRecepcaoSimpV4.asmx?wsdl):
+ * namespace "http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoSimpV4", operacao
+ * "cteRecepcaoSimp", requisicao "cteDadosMsg", retorno "cteRecepcaoSimpResult",
+ * soapAction ".../CTeRecepcaoSimpV4/cteRecepcaoSimp" - todos batem.
+ */
+package com.fincatto.documentofiscal.cte400.webservices.gerado;
+
+
+import com.fincatto.documentofiscal.DFConfig;
+import com.fincatto.documentofiscal.utils.MessageContextFactory;
+
+/*
+ *  CTeRecepcaoSimpV4Stub java implementation
+ */
+public class CTeRecepcaoSimpV4Stub extends org.apache.axis2.client.Stub {
+    private static int counter = 0;
+    protected org.apache.axis2.description.AxisOperation[] _operations;
+
+    //hashmaps to keep the fault mapping
+    private java.util.HashMap faultExceptionNameMap = new java.util.HashMap();
+    private java.util.HashMap faultExceptionClassNameMap = new java.util.HashMap();
+    private java.util.HashMap faultMessageMap = new java.util.HashMap();
+    private javax.xml.namespace.QName[] opNameArray = null;
+    private final DFConfig config;
+
+    /**
+     *Constructor that takes in a configContext
+     */
+    public CTeRecepcaoSimpV4Stub(
+        org.apache.axis2.context.ConfigurationContext configurationContext,
+        java.lang.String targetEndpoint, DFConfig config) throws org.apache.axis2.AxisFault {
+        this(configurationContext, targetEndpoint, false, config);
+    }
+
+    /**
+     * Constructor that takes in a configContext  and useseperate listner
+     */
+    public CTeRecepcaoSimpV4Stub(
+        org.apache.axis2.context.ConfigurationContext configurationContext,
+        java.lang.String targetEndpoint, boolean useSeparateListener, DFConfig config)
+        throws org.apache.axis2.AxisFault {
+        //To populate AxisService
+        populateAxisService();
+        populateFaults();
+
+        _serviceClient = new org.apache.axis2.client.ServiceClient(configurationContext,
+                _service);
+
+        _serviceClient.getOptions()
+                      .setTo(new org.apache.axis2.addressing.EndpointReference(
+                targetEndpoint));
+        _serviceClient.getOptions().setUseSeparateListener(useSeparateListener);
+
+        //Set the soap version
+        _serviceClient.getOptions()
+                      .setSoapVersionURI(org.apache.axiom.soap.SOAP12Constants.SOAP_ENVELOPE_NAMESPACE_URI);
+        this.config = config;
+    }
+
+    /**
+     * Constructor taking the target endpoint
+     */
+    public CTeRecepcaoSimpV4Stub(java.lang.String targetEndpoint, DFConfig config)
+        throws org.apache.axis2.AxisFault {
+        this(null, targetEndpoint, config);
+    }
+
+    private static synchronized java.lang.String getUniqueSuffix() {
+        // reset the counter if it is greater than 99999
+        if (counter > 99999) {
+            counter = 0;
+        }
+
+        counter = counter + 1;
+
+        return java.lang.Long.toString(java.lang.System.currentTimeMillis()) +
+        "_" + counter;
+    }
+
+    private void populateAxisService() throws org.apache.axis2.AxisFault {
+        //creating the Service with a unique name
+        _service = new org.apache.axis2.description.AxisService(
+                "CTeRecepcaoSimpV4" + getUniqueSuffix());
+        addAnonymousOperations();
+
+        //creating the operations
+        org.apache.axis2.description.AxisOperation __operation;
+
+        _operations = new org.apache.axis2.description.AxisOperation[1];
+
+        __operation = new org.apache.axis2.description.OutInAxisOperation();
+
+        __operation.setName(new javax.xml.namespace.QName(
+                "http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoSimpV4",
+                "cteRecepcaoSimp"));
+        _service.addOperation(__operation);
+
+        _operations[0] = __operation;
+    }
+
+    //populates the faults
+    private void populateFaults() {
+    }
+
+    /**
+     * Auto generated method signature
+     *
+     * @see com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoSimpV4#cteRecepcaoSimp
+     * @param cteDadosMsg
+     */
+    public com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoSimpV4Stub.CteRecepcaoSimpResult cteRecepcaoSimp(
+        com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoSimpV4Stub.CteDadosMsg cteDadosMsg)
+        throws java.rmi.RemoteException {
+        org.apache.axis2.context.MessageContext _messageContext = null;
+
+        try {
+            org.apache.axis2.client.OperationClient _operationClient = _serviceClient.createClient(_operations[0].getName());
+            _operationClient.getOptions()
+                            .setAction("http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoSimpV4/cteRecepcaoSimp");
+            _operationClient.getOptions().setExceptionToBeThrownOnSOAPFault(true);
+
+            addPropertyToOperationClient(_operationClient,
+                org.apache.axis2.description.WSDL2Constants.ATTR_WHTTP_QUERY_PARAMETER_SEPARATOR,
+                "&");
+
+            // create a message context
+            _messageContext = MessageContextFactory.INSTANCE.create(config);
+
+            // create SOAP envelope with that payload
+            org.apache.axiom.soap.SOAPEnvelope env = null;
+
+            env = toEnvelope(getFactory(_operationClient.getOptions()
+                                                        .getSoapVersionURI()),
+                    cteDadosMsg,
+                    optimizeContent(
+                        new javax.xml.namespace.QName(
+                            "http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoSimpV4",
+                            "cteRecepcaoSimp")),
+                    new javax.xml.namespace.QName(
+                        "http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoSimpV4",
+                        "cteRecepcaoSimp"));
+
+            //adding SOAP soap_headers
+            _serviceClient.addHeadersToEnvelope(env);
+            // set the message context with that soap envelope
+            _messageContext.setEnvelope(env);
+
+            // add the message contxt to the operation client
+            _operationClient.addMessageContext(_messageContext);
+
+            //execute the operation client
+            _operationClient.execute(true);
+
+            org.apache.axis2.context.MessageContext _returnMessageContext = _operationClient.getMessageContext(org.apache.axis2.wsdl.WSDLConstants.MESSAGE_LABEL_IN_VALUE);
+            org.apache.axiom.soap.SOAPEnvelope _returnEnv = _returnMessageContext.getEnvelope();
+
+            java.lang.Object object = fromOM(_returnEnv.getBody()
+                                                       .getFirstElement(),
+                    com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoSimpV4Stub.CteRecepcaoSimpResult.class,
+                    getEnvelopeNamespaces(_returnEnv));
+
+            return (com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoSimpV4Stub.CteRecepcaoSimpResult) object;
+        } catch (org.apache.axis2.AxisFault f) {
+            org.apache.axiom.om.OMElement faultElt = f.getDetail();
+
+            if (faultElt != null) {
+                if (faultExceptionNameMap.containsKey(
+                            new org.apache.axis2.client.FaultMapKey(
+                                faultElt.getQName(), "cteRecepcaoSimp"))) {
+                    //make the fault by reflection
+                    try {
+                        java.lang.String exceptionClassName = (java.lang.String) faultExceptionClassNameMap.get(new org.apache.axis2.client.FaultMapKey(
+                                    faultElt.getQName(), "cteRecepcaoSimp"));
+                        java.lang.Class exceptionClass = java.lang.Class.forName(exceptionClassName);
+                        java.lang.reflect.Constructor constructor = exceptionClass.getConstructor(java.lang.String.class);
+                        java.lang.Exception ex = (java.lang.Exception) constructor.newInstance(f.getMessage());
+
+                        //message class
+                        java.lang.String messageClassName = (java.lang.String) faultMessageMap.get(new org.apache.axis2.client.FaultMapKey(
+                                    faultElt.getQName(), "cteRecepcaoSimp"));
+                        java.lang.Class messageClass = java.lang.Class.forName(messageClassName);
+                        java.lang.Object messageObject = fromOM(faultElt,
+                                messageClass, null);
+                        java.lang.reflect.Method m = exceptionClass.getMethod("setFaultMessage",
+                                new java.lang.Class[] { messageClass });
+                        m.invoke(ex, new java.lang.Object[] { messageObject });
+
+                        throw new java.rmi.RemoteException(ex.getMessage(), ex);
+                    } catch (java.lang.ClassCastException e) {
+                        // we cannot intantiate the class - throw the original Axis fault
+                        throw f;
+                    } catch (java.lang.ClassNotFoundException e) {
+                        // we cannot intantiate the class - throw the original Axis fault
+                        throw f;
+                    } catch (java.lang.NoSuchMethodException e) {
+                        // we cannot intantiate the class - throw the original Axis fault
+                        throw f;
+                    } catch (java.lang.reflect.InvocationTargetException e) {
+                        // we cannot intantiate the class - throw the original Axis fault
+                        throw f;
+                    } catch (java.lang.IllegalAccessException e) {
+                        // we cannot intantiate the class - throw the original Axis fault
+                        throw f;
+                    } catch (java.lang.InstantiationException e) {
+                        // we cannot intantiate the class - throw the original Axis fault
+                        throw f;
+                    }
+                } else {
+                    throw f;
+                }
+            } else {
+                throw f;
+            }
+        } finally {
+            if (_messageContext.getTransportOut() != null) {
+                _messageContext.getTransportOut().getSender()
+                               .cleanup(_messageContext);
+            }
+        }
+    }
+
+    /**
+     *  A utility method that copies the namepaces from the SOAPEnvelope
+     */
+    private java.util.Map getEnvelopeNamespaces(
+        org.apache.axiom.soap.SOAPEnvelope env) {
+        java.util.Map returnMap = new java.util.HashMap();
+        java.util.Iterator namespaceIterator = env.getAllDeclaredNamespaces();
+
+        while (namespaceIterator.hasNext()) {
+            org.apache.axiom.om.OMNamespace ns = (org.apache.axiom.om.OMNamespace) namespaceIterator.next();
+            returnMap.put(ns.getPrefix(), ns.getNamespaceURI());
+        }
+
+        return returnMap;
+    }
+
+    private boolean optimizeContent(javax.xml.namespace.QName opName) {
+        if (opNameArray == null) {
+            return false;
+        }
+
+        for (int i = 0; i < opNameArray.length; i++) {
+            if (opName.equals(opNameArray[i])) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private org.apache.axiom.om.OMElement toOM(
+        com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoSimpV4Stub.CteDadosMsg param,
+        boolean optimizeContent) throws org.apache.axis2.AxisFault {
+        try {
+            return param.getOMElement(com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoSimpV4Stub.CteDadosMsg.MY_QNAME,
+                org.apache.axiom.om.OMAbstractFactory.getOMFactory());
+        } catch (org.apache.axis2.databinding.ADBException e) {
+            throw org.apache.axis2.AxisFault.makeFault(e);
+        }
+    }
+
+    private org.apache.axiom.om.OMElement toOM(
+        com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoSimpV4Stub.CteRecepcaoSimpResult param,
+        boolean optimizeContent) throws org.apache.axis2.AxisFault {
+        try {
+            return param.getOMElement(com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoSimpV4Stub.CteRecepcaoSimpResult.MY_QNAME,
+                org.apache.axiom.om.OMAbstractFactory.getOMFactory());
+        } catch (org.apache.axis2.databinding.ADBException e) {
+            throw org.apache.axis2.AxisFault.makeFault(e);
+        }
+    }
+
+    private org.apache.axiom.soap.SOAPEnvelope toEnvelope(
+        org.apache.axiom.soap.SOAPFactory factory,
+        com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoSimpV4Stub.CteDadosMsg param,
+        boolean optimizeContent, javax.xml.namespace.QName methodQName)
+        throws org.apache.axis2.AxisFault {
+        try {
+            org.apache.axiom.soap.SOAPEnvelope emptyEnvelope = factory.getDefaultEnvelope();
+            emptyEnvelope.getBody()
+                         .addChild(param.getOMElement(
+                    com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoSimpV4Stub.CteDadosMsg.MY_QNAME,
+                    factory));
+
+            return emptyEnvelope;
+        } catch (org.apache.axis2.databinding.ADBException e) {
+            throw org.apache.axis2.AxisFault.makeFault(e);
+        }
+    }
+
+    /* methods to provide back word compatibility */
+
+    /**
+     *  get the default envelope
+     */
+    private org.apache.axiom.soap.SOAPEnvelope toEnvelope(
+        org.apache.axiom.soap.SOAPFactory factory) {
+        return factory.getDefaultEnvelope();
+    }
+
+    private java.lang.Object fromOM(org.apache.axiom.om.OMElement param,
+        java.lang.Class type, java.util.Map extraNamespaces)
+        throws org.apache.axis2.AxisFault {
+        try {
+            if (com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoSimpV4Stub.CteDadosMsg.class.equals(
+                        type)) {
+                return com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoSimpV4Stub.CteDadosMsg.Factory.parse(param.getXMLStreamReaderWithoutCaching());
+            }
+
+            if (com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoSimpV4Stub.CteRecepcaoSimpResult.class.equals(
+                        type)) {
+                return com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoSimpV4Stub.CteRecepcaoSimpResult.Factory.parse(param.getXMLStreamReaderWithoutCaching());
+            }
+        } catch (java.lang.Exception e) {
+            throw org.apache.axis2.AxisFault.makeFault(e);
+        }
+
+        return null;
+    }
+
+    public static class CteRecepcaoSimpResult implements org.apache.axis2.databinding.ADBBean {
+        public static final javax.xml.namespace.QName MY_QNAME = new javax.xml.namespace.QName("http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoSimpV4",
+                "cteRecepcaoSimpResult", "");
+
+        /**
+         * field for ExtraElement
+         */
+        protected org.apache.axiom.om.OMElement localExtraElement;
+
+        /**
+         * Auto generated getter method
+         * @return org.apache.axiom.om.OMElement
+         */
+        public org.apache.axiom.om.OMElement getExtraElement() {
+            return localExtraElement;
+        }
+
+        /**
+         * Auto generated setter method
+         * @param param ExtraElement
+         */
+        public void setExtraElement(org.apache.axiom.om.OMElement param) {
+            this.localExtraElement = param;
+        }
+
+        /**
+         *
+         * @param parentQName
+         * @param factory
+         * @return org.apache.axiom.om.OMElement
+         */
+        public org.apache.axiom.om.OMElement getOMElement(
+            final javax.xml.namespace.QName parentQName,
+            final org.apache.axiom.om.OMFactory factory)
+            throws org.apache.axis2.databinding.ADBException {
+            org.apache.axiom.om.OMDataSource dataSource = new org.apache.axis2.databinding.ADBDataSource(this,
+                    MY_QNAME);
+
+            return factory.createOMElement(dataSource, MY_QNAME);
+        }
+
+        public void serialize(final javax.xml.namespace.QName parentQName,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException,
+                org.apache.axis2.databinding.ADBException {
+            serialize(parentQName, xmlWriter, false);
+        }
+
+        public void serialize(final javax.xml.namespace.QName parentQName,
+            javax.xml.stream.XMLStreamWriter xmlWriter, boolean serializeType)
+            throws javax.xml.stream.XMLStreamException,
+                org.apache.axis2.databinding.ADBException {
+            java.lang.String prefix = null;
+            java.lang.String namespace = null;
+
+            prefix = parentQName.getPrefix();
+            namespace = parentQName.getNamespaceURI();
+            writeStartElement(prefix, namespace, parentQName.getLocalPart(),
+                xmlWriter);
+
+            if (serializeType) {
+                java.lang.String namespacePrefix = registerPrefix(xmlWriter,
+                        "http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoSimpV4");
+
+                if ((namespacePrefix != null) &&
+                        (namespacePrefix.trim().length() > 0)) {
+                    writeAttribute("xsi",
+                        "http://www.w3.org/2001/XMLSchema-instance", "type",
+                        namespacePrefix + ":cteRecepcaoSimpResult", xmlWriter);
+                } else {
+                    writeAttribute("xsi",
+                        "http://www.w3.org/2001/XMLSchema-instance", "type",
+                        "cteRecepcaoSimpResult", xmlWriter);
+                }
+            }
+
+            if (localExtraElement != null) {
+                localExtraElement.serialize(xmlWriter);
+            } else {
+                throw new org.apache.axis2.databinding.ADBException(
+                    "extraElement cannot be null!!");
+            }
+
+            xmlWriter.writeEndElement();
+        }
+
+        private static java.lang.String generatePrefix(
+            java.lang.String namespace) {
+            if (namespace.equals(
+                        "http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoSimpV4")) {
+                return "";
+            }
+
+            return org.apache.axis2.databinding.utils.BeanUtil.getUniquePrefix();
+        }
+
+        /**
+         * Utility method to write an element start tag.
+         */
+        private void writeStartElement(java.lang.String prefix,
+            java.lang.String namespace, java.lang.String localPart,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            java.lang.String writerPrefix = xmlWriter.getPrefix(namespace);
+
+            if (writerPrefix != null) {
+                xmlWriter.writeStartElement(namespace, localPart);
+            } else {
+                if (namespace.length() == 0) {
+                    prefix = "";
+                } else if (prefix == null) {
+                    prefix = generatePrefix(namespace);
+                }
+
+                xmlWriter.writeStartElement(prefix, localPart, namespace);
+                xmlWriter.writeNamespace(prefix, namespace);
+                xmlWriter.setPrefix(prefix, namespace);
+            }
+        }
+
+        /**
+         * Util method to write an attribute with the ns prefix
+         */
+        private void writeAttribute(java.lang.String prefix,
+            java.lang.String namespace, java.lang.String attName,
+            java.lang.String attValue,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            if (xmlWriter.getPrefix(namespace) == null) {
+                xmlWriter.writeNamespace(prefix, namespace);
+                xmlWriter.setPrefix(prefix, namespace);
+            }
+
+            xmlWriter.writeAttribute(namespace, attName, attValue);
+        }
+
+        /**
+         * Util method to write an attribute without the ns prefix
+         */
+        private void writeAttribute(java.lang.String namespace,
+            java.lang.String attName, java.lang.String attValue,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            if (namespace.equals("")) {
+                xmlWriter.writeAttribute(attName, attValue);
+            } else {
+                registerPrefix(xmlWriter, namespace);
+                xmlWriter.writeAttribute(namespace, attName, attValue);
+            }
+        }
+
+        /**
+         * Util method to write an attribute without the ns prefix
+         */
+        private void writeQNameAttribute(java.lang.String namespace,
+            java.lang.String attName, javax.xml.namespace.QName qname,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            java.lang.String attributeNamespace = qname.getNamespaceURI();
+            java.lang.String attributePrefix = xmlWriter.getPrefix(attributeNamespace);
+
+            if (attributePrefix == null) {
+                attributePrefix = registerPrefix(xmlWriter, attributeNamespace);
+            }
+
+            java.lang.String attributeValue;
+
+            if (attributePrefix.trim().length() > 0) {
+                attributeValue = attributePrefix + ":" + qname.getLocalPart();
+            } else {
+                attributeValue = qname.getLocalPart();
+            }
+
+            if (namespace.equals("")) {
+                xmlWriter.writeAttribute(attName, attributeValue);
+            } else {
+                registerPrefix(xmlWriter, namespace);
+                xmlWriter.writeAttribute(namespace, attName, attributeValue);
+            }
+        }
+
+        /**
+         *  method to handle Qnames
+         */
+        private void writeQName(javax.xml.namespace.QName qname,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            java.lang.String namespaceURI = qname.getNamespaceURI();
+
+            if (namespaceURI != null) {
+                java.lang.String prefix = xmlWriter.getPrefix(namespaceURI);
+
+                if (prefix == null) {
+                    prefix = generatePrefix(namespaceURI);
+                    xmlWriter.writeNamespace(prefix, namespaceURI);
+                    xmlWriter.setPrefix(prefix, namespaceURI);
+                }
+
+                if (prefix.trim().length() > 0) {
+                    xmlWriter.writeCharacters(prefix + ":" +
+                        org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                            qname));
+                } else {
+                    // i.e this is the default namespace
+                    xmlWriter.writeCharacters(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                            qname));
+                }
+            } else {
+                xmlWriter.writeCharacters(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                        qname));
+            }
+        }
+
+        private void writeQNames(javax.xml.namespace.QName[] qnames,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            if (qnames != null) {
+                // we have to store this data until last moment since it is not possible to write any
+                // namespace data after writing the charactor data
+                java.lang.StringBuffer stringToWrite = new java.lang.StringBuffer();
+                java.lang.String namespaceURI = null;
+                java.lang.String prefix = null;
+
+                for (int i = 0; i < qnames.length; i++) {
+                    if (i > 0) {
+                        stringToWrite.append(" ");
+                    }
+
+                    namespaceURI = qnames[i].getNamespaceURI();
+
+                    if (namespaceURI != null) {
+                        prefix = xmlWriter.getPrefix(namespaceURI);
+
+                        if ((prefix == null) || (prefix.length() == 0)) {
+                            prefix = generatePrefix(namespaceURI);
+                            xmlWriter.writeNamespace(prefix, namespaceURI);
+                            xmlWriter.setPrefix(prefix, namespaceURI);
+                        }
+
+                        if (prefix.trim().length() > 0) {
+                            stringToWrite.append(prefix).append(":")
+                                         .append(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                                    qnames[i]));
+                        } else {
+                            stringToWrite.append(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                                    qnames[i]));
+                        }
+                    } else {
+                        stringToWrite.append(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                                qnames[i]));
+                    }
+                }
+
+                xmlWriter.writeCharacters(stringToWrite.toString());
+            }
+        }
+
+        /**
+         * Register a namespace prefix
+         */
+        private java.lang.String registerPrefix(
+            javax.xml.stream.XMLStreamWriter xmlWriter,
+            java.lang.String namespace)
+            throws javax.xml.stream.XMLStreamException {
+            java.lang.String prefix = xmlWriter.getPrefix(namespace);
+
+            if (prefix == null) {
+                prefix = generatePrefix(namespace);
+
+                javax.xml.namespace.NamespaceContext nsContext = xmlWriter.getNamespaceContext();
+
+                while (true) {
+                    java.lang.String uri = nsContext.getNamespaceURI(prefix);
+
+                    if ((uri == null) || (uri.length() == 0)) {
+                        break;
+                    }
+
+                    prefix = org.apache.axis2.databinding.utils.BeanUtil.getUniquePrefix();
+                }
+
+                xmlWriter.writeNamespace(prefix, namespace);
+                xmlWriter.setPrefix(prefix, namespace);
+            }
+
+            return prefix;
+        }
+
+        /**
+         *  Factory class that keeps the parse method
+         */
+        public static class Factory {
+            /**
+             * static method to create the object
+             * Precondition:  If this object is an element, the current or next start element starts this object and any intervening reader events are ignorable
+             *                If this object is not an element, it is a complex type and the reader is at the event just after the outer start element
+             * Postcondition: If this object is an element, the reader is positioned at its end element
+             *                If this object is a complex type, the reader is positioned at the end element of its outer element
+             */
+            public static CteRecepcaoSimpResult parse(
+                javax.xml.stream.XMLStreamReader reader)
+                throws java.lang.Exception {
+                CteRecepcaoSimpResult object = new CteRecepcaoSimpResult();
+
+                int event;
+                java.lang.String nillableValue = null;
+                java.lang.String prefix = "";
+                java.lang.String namespaceuri = "";
+
+                try {
+                    while (!reader.isStartElement() && !reader.isEndElement())
+                        reader.next();
+
+                    if (reader.getAttributeValue(
+                                "http://www.w3.org/2001/XMLSchema-instance",
+                                "type") != null) {
+                        java.lang.String fullTypeName = reader.getAttributeValue("http://www.w3.org/2001/XMLSchema-instance",
+                                "type");
+
+                        if (fullTypeName != null) {
+                            java.lang.String nsPrefix = null;
+
+                            if (fullTypeName.indexOf(":") > -1) {
+                                nsPrefix = fullTypeName.substring(0,
+                                        fullTypeName.indexOf(":"));
+                            }
+
+                            nsPrefix = (nsPrefix == null) ? "" : nsPrefix;
+
+                            java.lang.String type = fullTypeName.substring(fullTypeName.indexOf(
+                                        ":") + 1);
+
+                            if (!"cteRecepcaoSimpResult".equals(type)) {
+                                //find namespace for the prefix
+                                java.lang.String nsUri = reader.getNamespaceContext()
+                                                               .getNamespaceURI(nsPrefix);
+
+                                return (CteRecepcaoSimpResult) ExtensionMapper.getTypeObject(nsUri,
+                                    type, reader);
+                            }
+                        }
+                    }
+
+                    // Note all attributes that were handled. Used to differ normal attributes
+                    // from anyAttributes.
+                    java.util.Vector handledAttributes = new java.util.Vector();
+
+                    reader.next();
+
+                    while (!reader.isStartElement() && !reader.isEndElement())
+                        reader.next();
+
+                    if (reader.isStartElement()) {
+                        //use the QName from the parser as the name for the builder
+                        javax.xml.namespace.QName startQname1 = reader.getName();
+
+                        // We need to wrap the reader so that it produces a fake START_DOCUMENT event
+                        // this is needed by the builder classes
+                        org.apache.axis2.databinding.utils.NamedStaxOMBuilder builder1 =
+                            new org.apache.axis2.databinding.utils.NamedStaxOMBuilder(new org.apache.axis2.util.StreamWrapper(
+                                    reader), startQname1);
+                        object.setExtraElement(builder1.getOMElement());
+
+                        reader.next();
+                    } // End of if for expected property start element
+
+                    else {
+                        // A start element we are not expecting indicates an invalid parameter was passed
+                        throw new org.apache.axis2.databinding.ADBException(
+                            "Unexpected subelement " + reader.getName());
+                    }
+
+                    while (!reader.isStartElement() && !reader.isEndElement())
+                        reader.next();
+
+                    if (reader.isStartElement()) {
+                        // A start element we are not expecting indicates a trailing invalid property
+                        throw new org.apache.axis2.databinding.ADBException(
+                            "Unexpected subelement " + reader.getName());
+                    }
+                } catch (javax.xml.stream.XMLStreamException e) {
+                    throw new java.lang.Exception(e);
+                }
+
+                return object;
+            }
+        } //end of factory class
+    }
+
+    public static class CteDadosMsg implements org.apache.axis2.databinding.ADBBean {
+        public static final javax.xml.namespace.QName MY_QNAME = new javax.xml.namespace.QName("http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoSimpV4",
+                "cteDadosMsg", "");
+
+        /**
+         * field for CteDadosMsg
+         */
+        protected java.lang.String localCteDadosMsg;
+
+        /**
+         * Auto generated getter method
+         * @return java.lang.String
+         */
+        public java.lang.String getCteDadosMsg() {
+            return localCteDadosMsg;
+        }
+
+        /**
+         * Auto generated setter method
+         * @param param CteDadosMsg
+         */
+        public void setCteDadosMsg(java.lang.String param) {
+            this.localCteDadosMsg = param;
+        }
+
+        /**
+         *
+         * @param parentQName
+         * @param factory
+         * @return org.apache.axiom.om.OMElement
+         */
+        public org.apache.axiom.om.OMElement getOMElement(
+            final javax.xml.namespace.QName parentQName,
+            final org.apache.axiom.om.OMFactory factory)
+            throws org.apache.axis2.databinding.ADBException {
+            org.apache.axiom.om.OMDataSource dataSource = new org.apache.axis2.databinding.ADBDataSource(this,
+                    MY_QNAME);
+
+            return factory.createOMElement(dataSource, MY_QNAME);
+        }
+
+        public void serialize(final javax.xml.namespace.QName parentQName,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException,
+                org.apache.axis2.databinding.ADBException {
+            serialize(parentQName, xmlWriter, false);
+        }
+
+        public void serialize(final javax.xml.namespace.QName parentQName,
+            javax.xml.stream.XMLStreamWriter xmlWriter, boolean serializeType)
+            throws javax.xml.stream.XMLStreamException,
+                org.apache.axis2.databinding.ADBException {
+            //We can safely assume an element has only one type associated with it
+            java.lang.String namespace = "http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoSimpV4";
+            java.lang.String _localName = "cteDadosMsg";
+
+            writeStartElement(null, namespace, _localName, xmlWriter);
+
+            // add the type details if this is used in a simple type
+            if (serializeType) {
+                java.lang.String namespacePrefix = registerPrefix(xmlWriter,
+                        "http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoSimpV4");
+
+                if ((namespacePrefix != null) &&
+                        (namespacePrefix.trim().length() > 0)) {
+                    writeAttribute("xsi",
+                        "http://www.w3.org/2001/XMLSchema-instance", "type",
+                        namespacePrefix + ":cteDadosMsg", xmlWriter);
+                } else {
+                    writeAttribute("xsi",
+                        "http://www.w3.org/2001/XMLSchema-instance", "type",
+                        "cteDadosMsg", xmlWriter);
+                }
+            }
+
+            if (localCteDadosMsg == null) {
+                throw new org.apache.axis2.databinding.ADBException(
+                    "cteDadosMsg cannot be null !!");
+            } else {
+                xmlWriter.writeCharacters(localCteDadosMsg);
+            }
+
+            xmlWriter.writeEndElement();
+        }
+
+        private static java.lang.String generatePrefix(
+            java.lang.String namespace) {
+            if (namespace.equals(
+                        "http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoSimpV4")) {
+                return "";
+            }
+
+            return org.apache.axis2.databinding.utils.BeanUtil.getUniquePrefix();
+        }
+
+        /**
+         * Utility method to write an element start tag.
+         */
+        private void writeStartElement(java.lang.String prefix,
+            java.lang.String namespace, java.lang.String localPart,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            java.lang.String writerPrefix = xmlWriter.getPrefix(namespace);
+
+            if (writerPrefix != null) {
+                xmlWriter.writeStartElement(namespace, localPart);
+            } else {
+                if (namespace.length() == 0) {
+                    prefix = "";
+                } else if (prefix == null) {
+                    prefix = generatePrefix(namespace);
+                }
+
+                xmlWriter.writeStartElement(prefix, localPart, namespace);
+                xmlWriter.writeNamespace(prefix, namespace);
+                xmlWriter.setPrefix(prefix, namespace);
+            }
+        }
+
+        /**
+         * Util method to write an attribute with the ns prefix
+         */
+        private void writeAttribute(java.lang.String prefix,
+            java.lang.String namespace, java.lang.String attName,
+            java.lang.String attValue,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            if (xmlWriter.getPrefix(namespace) == null) {
+                xmlWriter.writeNamespace(prefix, namespace);
+                xmlWriter.setPrefix(prefix, namespace);
+            }
+
+            xmlWriter.writeAttribute(namespace, attName, attValue);
+        }
+
+        /**
+         * Util method to write an attribute without the ns prefix
+         */
+        private void writeAttribute(java.lang.String namespace,
+            java.lang.String attName, java.lang.String attValue,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            if (namespace.equals("")) {
+                xmlWriter.writeAttribute(attName, attValue);
+            } else {
+                registerPrefix(xmlWriter, namespace);
+                xmlWriter.writeAttribute(namespace, attName, attValue);
+            }
+        }
+
+        /**
+         * Util method to write an attribute without the ns prefix
+         */
+        private void writeQNameAttribute(java.lang.String namespace,
+            java.lang.String attName, javax.xml.namespace.QName qname,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            java.lang.String attributeNamespace = qname.getNamespaceURI();
+            java.lang.String attributePrefix = xmlWriter.getPrefix(attributeNamespace);
+
+            if (attributePrefix == null) {
+                attributePrefix = registerPrefix(xmlWriter, attributeNamespace);
+            }
+
+            java.lang.String attributeValue;
+
+            if (attributePrefix.trim().length() > 0) {
+                attributeValue = attributePrefix + ":" + qname.getLocalPart();
+            } else {
+                attributeValue = qname.getLocalPart();
+            }
+
+            if (namespace.equals("")) {
+                xmlWriter.writeAttribute(attName, attributeValue);
+            } else {
+                registerPrefix(xmlWriter, namespace);
+                xmlWriter.writeAttribute(namespace, attName, attributeValue);
+            }
+        }
+
+        /**
+         *  method to handle Qnames
+         */
+        private void writeQName(javax.xml.namespace.QName qname,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            java.lang.String namespaceURI = qname.getNamespaceURI();
+
+            if (namespaceURI != null) {
+                java.lang.String prefix = xmlWriter.getPrefix(namespaceURI);
+
+                if (prefix == null) {
+                    prefix = generatePrefix(namespaceURI);
+                    xmlWriter.writeNamespace(prefix, namespaceURI);
+                    xmlWriter.setPrefix(prefix, namespaceURI);
+                }
+
+                if (prefix.trim().length() > 0) {
+                    xmlWriter.writeCharacters(prefix + ":" +
+                        org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                            qname));
+                } else {
+                    // i.e this is the default namespace
+                    xmlWriter.writeCharacters(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                            qname));
+                }
+            } else {
+                xmlWriter.writeCharacters(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                        qname));
+            }
+        }
+
+        private void writeQNames(javax.xml.namespace.QName[] qnames,
+            javax.xml.stream.XMLStreamWriter xmlWriter)
+            throws javax.xml.stream.XMLStreamException {
+            if (qnames != null) {
+                // we have to store this data until last moment since it is not possible to write any
+                // namespace data after writing the charactor data
+                java.lang.StringBuffer stringToWrite = new java.lang.StringBuffer();
+                java.lang.String namespaceURI = null;
+                java.lang.String prefix = null;
+
+                for (int i = 0; i < qnames.length; i++) {
+                    if (i > 0) {
+                        stringToWrite.append(" ");
+                    }
+
+                    namespaceURI = qnames[i].getNamespaceURI();
+
+                    if (namespaceURI != null) {
+                        prefix = xmlWriter.getPrefix(namespaceURI);
+
+                        if ((prefix == null) || (prefix.length() == 0)) {
+                            prefix = generatePrefix(namespaceURI);
+                            xmlWriter.writeNamespace(prefix, namespaceURI);
+                            xmlWriter.setPrefix(prefix, namespaceURI);
+                        }
+
+                        if (prefix.trim().length() > 0) {
+                            stringToWrite.append(prefix).append(":")
+                                         .append(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                                    qnames[i]));
+                        } else {
+                            stringToWrite.append(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                                    qnames[i]));
+                        }
+                    } else {
+                        stringToWrite.append(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                                qnames[i]));
+                    }
+                }
+
+                xmlWriter.writeCharacters(stringToWrite.toString());
+            }
+        }
+
+        /**
+         * Register a namespace prefix
+         */
+        private java.lang.String registerPrefix(
+            javax.xml.stream.XMLStreamWriter xmlWriter,
+            java.lang.String namespace)
+            throws javax.xml.stream.XMLStreamException {
+            java.lang.String prefix = xmlWriter.getPrefix(namespace);
+
+            if (prefix == null) {
+                prefix = generatePrefix(namespace);
+
+                javax.xml.namespace.NamespaceContext nsContext = xmlWriter.getNamespaceContext();
+
+                while (true) {
+                    java.lang.String uri = nsContext.getNamespaceURI(prefix);
+
+                    if ((uri == null) || (uri.length() == 0)) {
+                        break;
+                    }
+
+                    prefix = org.apache.axis2.databinding.utils.BeanUtil.getUniquePrefix();
+                }
+
+                xmlWriter.writeNamespace(prefix, namespace);
+                xmlWriter.setPrefix(prefix, namespace);
+            }
+
+            return prefix;
+        }
+
+        /**
+         *  Factory class that keeps the parse method
+         */
+        public static class Factory {
+            /**
+             * static method to create the object
+             * Precondition:  If this object is an element, the current or next start element starts this object and any intervening reader events are ignorable
+             *                If this object is not an element, it is a complex type and the reader is at the event just after the outer start element
+             * Postcondition: If this object is an element, the reader is positioned at its end element
+             *                If this object is a complex type, the reader is positioned at the end element of its outer element
+             */
+            public static CteDadosMsg parse(
+                javax.xml.stream.XMLStreamReader reader)
+                throws java.lang.Exception {
+                CteDadosMsg object = new CteDadosMsg();
+
+                int event;
+                java.lang.String nillableValue = null;
+                java.lang.String prefix = "";
+                java.lang.String namespaceuri = "";
+
+                try {
+                    while (!reader.isStartElement() && !reader.isEndElement())
+                        reader.next();
+
+                    // Note all attributes that were handled. Used to differ normal attributes
+                    // from anyAttributes.
+                    java.util.Vector handledAttributes = new java.util.Vector();
+
+                    while (!reader.isEndElement()) {
+                        if (reader.isStartElement()) {
+                            if (reader.isStartElement() &&
+                                    new javax.xml.namespace.QName(
+                                        "http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoSimpV4",
+                                        "cteDadosMsg").equals(reader.getName())) {
+                                nillableValue = reader.getAttributeValue("http://www.w3.org/2001/XMLSchema-instance",
+                                        "nil");
+
+                                if ("true".equals(nillableValue) ||
+                                        "1".equals(nillableValue)) {
+                                    throw new org.apache.axis2.databinding.ADBException(
+                                        "The element: " + "cteDadosMsg" +
+                                        "  cannot be null");
+                                }
+
+                                java.lang.String content = reader.getElementText();
+
+                                object.setCteDadosMsg(org.apache.axis2.databinding.utils.ConverterUtil.convertToString(
+                                        content));
+                            } // End of if for expected property start element
+
+                            else {
+                                // A start element we are not expecting indicates an invalid parameter was passed
+                                throw new org.apache.axis2.databinding.ADBException(
+                                    "Unexpected subelement " +
+                                    reader.getName());
+                            }
+                        } else {
+                            reader.next();
+                        }
+                    } // end of while loop
+                } catch (javax.xml.stream.XMLStreamException e) {
+                    throw new java.lang.Exception(e);
+                }
+
+                return object;
+            }
+        } //end of factory class
+    }
+
+    public static class ExtensionMapper {
+        public static java.lang.Object getTypeObject(
+            java.lang.String namespaceURI, java.lang.String typeName,
+            javax.xml.stream.XMLStreamReader reader) throws java.lang.Exception {
+            throw new org.apache.axis2.databinding.ADBException(
+                "Unsupported type " + namespaceURI + " " + typeName);
+        }
+    }
+}

--- a/src/main/java/com/fincatto/documentofiscal/cte400/webservices/gerado/CTeRecepcaoSimpV4Stub.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/webservices/gerado/CTeRecepcaoSimpV4Stub.java
@@ -170,61 +170,53 @@ public class CTeRecepcaoSimpV4Stub extends org.apache.axis2.client.Stub {
 
             return (com.fincatto.documentofiscal.cte400.webservices.gerado.CTeRecepcaoSimpV4Stub.CteRecepcaoSimpResult) object;
         } catch (org.apache.axis2.AxisFault f) {
-            org.apache.axiom.om.OMElement faultElt = f.getDetail();
-
-            if (faultElt != null) {
-                if (faultExceptionNameMap.containsKey(
-                            new org.apache.axis2.client.FaultMapKey(
-                                faultElt.getQName(), "cteRecepcaoSimp"))) {
-                    //make the fault by reflection
-                    try {
-                        java.lang.String exceptionClassName = (java.lang.String) faultExceptionClassNameMap.get(new org.apache.axis2.client.FaultMapKey(
-                                    faultElt.getQName(), "cteRecepcaoSimp"));
-                        java.lang.Class exceptionClass = java.lang.Class.forName(exceptionClassName);
-                        java.lang.reflect.Constructor constructor = exceptionClass.getConstructor(java.lang.String.class);
-                        java.lang.Exception ex = (java.lang.Exception) constructor.newInstance(f.getMessage());
-
-                        //message class
-                        java.lang.String messageClassName = (java.lang.String) faultMessageMap.get(new org.apache.axis2.client.FaultMapKey(
-                                    faultElt.getQName(), "cteRecepcaoSimp"));
-                        java.lang.Class messageClass = java.lang.Class.forName(messageClassName);
-                        java.lang.Object messageObject = fromOM(faultElt,
-                                messageClass, null);
-                        java.lang.reflect.Method m = exceptionClass.getMethod("setFaultMessage",
-                                new java.lang.Class[] { messageClass });
-                        m.invoke(ex, new java.lang.Object[] { messageObject });
-
-                        throw new java.rmi.RemoteException(ex.getMessage(), ex);
-                    } catch (java.lang.ClassCastException e) {
-                        // we cannot intantiate the class - throw the original Axis fault
-                        throw f;
-                    } catch (java.lang.ClassNotFoundException e) {
-                        // we cannot intantiate the class - throw the original Axis fault
-                        throw f;
-                    } catch (java.lang.NoSuchMethodException e) {
-                        // we cannot intantiate the class - throw the original Axis fault
-                        throw f;
-                    } catch (java.lang.reflect.InvocationTargetException e) {
-                        // we cannot intantiate the class - throw the original Axis fault
-                        throw f;
-                    } catch (java.lang.IllegalAccessException e) {
-                        // we cannot intantiate the class - throw the original Axis fault
-                        throw f;
-                    } catch (java.lang.InstantiationException e) {
-                        // we cannot intantiate the class - throw the original Axis fault
-                        throw f;
-                    }
-                } else {
-                    throw f;
-                }
-            } else {
-                throw f;
-            }
+            throw mapAxisFault(f);
         } finally {
             if (_messageContext.getTransportOut() != null) {
                 _messageContext.getTransportOut().getSender()
                                .cleanup(_messageContext);
             }
+        }
+    }
+
+    //converte um AxisFault na excecao de negocio mapeada (por reflexao); se nao houver
+    //mapeamento ou a reflexao falhar, relanca o proprio AxisFault (que estende RemoteException).
+    private java.rmi.RemoteException mapAxisFault(org.apache.axis2.AxisFault f)
+        throws org.apache.axis2.AxisFault {
+        org.apache.axiom.om.OMElement faultElt = f.getDetail();
+
+        if (faultElt == null) {
+            throw f;
+        }
+
+        org.apache.axis2.client.FaultMapKey faultKey = new org.apache.axis2.client.FaultMapKey(faultElt.getQName(),
+                "cteRecepcaoSimp");
+
+        if (!faultExceptionNameMap.containsKey(faultKey)) {
+            throw f;
+        }
+
+        //make the fault by reflection
+        try {
+            java.lang.String exceptionClassName = (java.lang.String) faultExceptionClassNameMap.get(faultKey);
+            java.lang.Class exceptionClass = java.lang.Class.forName(exceptionClassName);
+            java.lang.reflect.Constructor constructor = exceptionClass.getConstructor(java.lang.String.class);
+            java.lang.Exception ex = (java.lang.Exception) constructor.newInstance(f.getMessage());
+
+            //message class
+            java.lang.String messageClassName = (java.lang.String) faultMessageMap.get(faultKey);
+            java.lang.Class messageClass = java.lang.Class.forName(messageClassName);
+            java.lang.Object messageObject = fromOM(faultElt, messageClass, null);
+            java.lang.reflect.Method m = exceptionClass.getMethod("setFaultMessage",
+                    new java.lang.Class[] { messageClass });
+            m.invoke(ex, new java.lang.Object[] { messageObject });
+
+            return new java.rmi.RemoteException(ex.getMessage(), ex);
+        } catch (java.lang.ClassCastException | java.lang.ClassNotFoundException
+                | java.lang.NoSuchMethodException | java.lang.reflect.InvocationTargetException
+                | java.lang.IllegalAccessException | java.lang.InstantiationException e) {
+            // we cannot intantiate the class - throw the original Axis fault
+            throw f;
         }
     }
 
@@ -329,8 +321,9 @@ public class CTeRecepcaoSimpV4Stub extends org.apache.axis2.client.Stub {
     }
 
     public static class CteRecepcaoSimpResult implements org.apache.axis2.databinding.ADBBean {
+        private static final java.lang.String LOCAL_NAME = "cteRecepcaoSimpResult";
         public static final javax.xml.namespace.QName MY_QNAME = new javax.xml.namespace.QName("http://www.portalfiscal.inf.br/cte/wsdl/CTeRecepcaoSimpV4",
-                "cteRecepcaoSimpResult", "");
+                LOCAL_NAME, "");
 
         /**
          * field for ExtraElement
@@ -396,11 +389,11 @@ public class CTeRecepcaoSimpV4Stub extends org.apache.axis2.client.Stub {
                         (namespacePrefix.trim().length() > 0)) {
                     writeAttribute("xsi",
                         "http://www.w3.org/2001/XMLSchema-instance", "type",
-                        namespacePrefix + ":cteRecepcaoSimpResult", xmlWriter);
+                        namespacePrefix + ":" + LOCAL_NAME, xmlWriter);
                 } else {
                     writeAttribute("xsi",
                         "http://www.w3.org/2001/XMLSchema-instance", "type",
-                        "cteRecepcaoSimpResult", xmlWriter);
+                        LOCAL_NAME, xmlWriter);
                 }
             }
 
@@ -660,7 +653,7 @@ public class CTeRecepcaoSimpV4Stub extends org.apache.axis2.client.Stub {
                             java.lang.String type = fullTypeName.substring(fullTypeName.indexOf(
                                         ":") + 1);
 
-                            if (!"cteRecepcaoSimpResult".equals(type)) {
+                            if (!LOCAL_NAME.equals(type)) {
                                 //find namespace for the prefix
                                 java.lang.String nsUri = reader.getNamespaceContext()
                                                                .getNamespaceURI(nsPrefix);

--- a/src/main/java/com/fincatto/documentofiscal/validadores/DFXMLValidador.java
+++ b/src/main/java/com/fincatto/documentofiscal/validadores/DFXMLValidador.java
@@ -157,6 +157,10 @@ public final class DFXMLValidador {
         return DFXMLValidador.validaCTe400(arquivoXML, "cteOS_v4.00.xsd");
     }
 
+    public static boolean validaNotaCteSimp400(final String arquivoXML) throws Exception {
+        return DFXMLValidador.validaCTe400(arquivoXML, "cteSimp_v4.00.xsd");
+    }
+
     public static boolean validaEventoCTe400(final String arquivoXML) throws Exception {
         return DFXMLValidador.validaCTe400(arquivoXML, "eventoCTe_v4.00.xsd");
     }

--- a/src/test/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimpTest.java
+++ b/src/test/java/com/fincatto/documentofiscal/cte400/classes/simp/CTeNotaSimpTest.java
@@ -1,0 +1,161 @@
+package com.fincatto.documentofiscal.cte400.classes.simp;
+
+import com.fincatto.documentofiscal.DFAmbiente;
+import com.fincatto.documentofiscal.DFConfig;
+import com.fincatto.documentofiscal.DFModelo;
+import com.fincatto.documentofiscal.DFUnidadeFederativa;
+import com.fincatto.documentofiscal.cte.CTTipoEmissao;
+import com.fincatto.documentofiscal.cte400.FabricaDeObjetosFake;
+import com.fincatto.documentofiscal.cte400.classes.CTIndicadorTomador;
+import com.fincatto.documentofiscal.cte400.classes.CTModal;
+import com.fincatto.documentofiscal.cte400.classes.CTProcessoEmissao;
+import com.fincatto.documentofiscal.cte400.classes.CTRetirada;
+import com.fincatto.documentofiscal.cte400.classes.CTTipoImpressao;
+import com.fincatto.documentofiscal.cte400.classes.CTTipoServico;
+import com.fincatto.documentofiscal.cte400.classes.CTTomadorServico;
+import com.fincatto.documentofiscal.cte400.classes.CTUnidadeMedida;
+import com.fincatto.documentofiscal.cte400.classes.nota.CTeNotaInfoCTeNormalInfoModal;
+import com.fincatto.documentofiscal.cte400.classes.nota.CTeNotaInfoCTeNormalInfoCarga;
+import com.fincatto.documentofiscal.cte400.classes.nota.CTeNotaInfoCTeNormalInfoCargaInformacoesQuantidadeCarga;
+import com.fincatto.documentofiscal.cte400.classes.nota.CTeNotaInfoInformacoesRelativasImpostos;
+import com.fincatto.documentofiscal.validadores.DFXMLValidador;
+import org.junit.Assert;
+import org.junit.Test;
+import org.xml.sax.SAXParseException;
+
+import java.math.BigDecimal;
+import java.time.ZonedDateTime;
+import java.util.Collections;
+
+public class CTeNotaSimpTest {
+
+    private static final String CHAVE_44 = "12345678901234567890123456789012345678901234";
+
+    /**
+     * Monta um CT-e Simplificado rodoviario, serializa com o Persister da fincatto e valida
+     * contra cteSimp_v4.00.xsd. Como o teste nao dispoe de certificado, toda a estrutura de
+     * negocio (ide, emit, toma, infCarga, det, infModal, imp, total) deve validar e o unico
+     * pendente e o elemento Signature (aplicado no envio por DFAssinaturaDigital sobre "infCte",
+     * caminho identico ao do CT-e normal/OS e fora das classes de dominio sob teste).
+     */
+    @Test
+    public void deveSerializarEstruturaValidaAteAssinatura() throws Exception {
+        final CTeNotaSimp cteSimp = novoCTeSimpRodoviario();
+        final String xml = cteSimp.toString();
+        try {
+            DFXMLValidador.validaNotaCteSimp400(xml);
+            Assert.fail("Esperava falha de validacao apenas pela ausencia da assinatura (Signature)");
+        } catch (final SAXParseException e) {
+            Assert.assertTrue("Erro de schema inesperado (fora da assinatura): " + e.getMessage(),
+                    e.getMessage().contains("Signature"));
+        }
+    }
+
+    private CTeNotaSimp novoCTeSimpRodoviario() {
+        final CTeNotaSimp nota = new CTeNotaSimp();
+        nota.setInfCte(infCte());
+        return nota;
+    }
+
+    private CTeNotaSimpInfo infCte() {
+        final CTeNotaSimpInfo info = new CTeNotaSimpInfo();
+        info.setVersao("4.00");
+        info.setId(CHAVE_44);
+        info.setIde(ide());
+        info.setEmit(FabricaDeObjetosFake.getInfoEmitente());
+        info.setToma(toma());
+        info.setInfCarga(infCarga());
+        info.setDet(Collections.singletonList(det()));
+        info.setInfModal(infModal());
+        info.setImp(imp());
+        info.setTotal(total());
+        return info;
+    }
+
+    private CTeNotaInfoCTeNormalInfoModal infModal() {
+        final CTeNotaInfoCTeNormalInfoModal infModal = new CTeNotaInfoCTeNormalInfoModal();
+        infModal.setVersao("4.00");
+        infModal.setRodoviario(FabricaDeObjetosFake.getInfoModalRodoviario());
+        return infModal;
+    }
+
+    private CTeNotaInfoCTeNormalInfoCarga infCarga() {
+        final CTeNotaInfoCTeNormalInfoCarga infCarga = new CTeNotaInfoCTeNormalInfoCarga();
+        infCarga.setDescricaoOutrasCaracteristicas("Carga pesada");
+        infCarga.setDescricaoProdutoPredominante("Ferro");
+        infCarga.setValorAverbacao(new BigDecimal("100000"));
+        infCarga.setValorTotalCarga(new BigDecimal("100000"));
+        final CTeNotaInfoCTeNormalInfoCargaInformacoesQuantidadeCarga q = new CTeNotaInfoCTeNormalInfoCargaInformacoesQuantidadeCarga();
+        q.setQuantidade(BigDecimal.ONE);
+        q.setUnidadeMedida(CTUnidadeMedida.M3);
+        q.setTipoMedia("00");
+        infCarga.setInformacoesQuantidadeCarga(Collections.singletonList(q));
+        return infCarga;
+    }
+
+    private CTeNotaSimpInfoIdentificacao ide() {
+        final CTeNotaSimpInfoIdentificacao ide = new CTeNotaSimpInfoIdentificacao();
+        ide.setCUF(DFUnidadeFederativa.SC);
+        ide.setCCT("67890123");
+        ide.setCFOP("5353");
+        ide.setNatOp("Prestacao de servico de transporte");
+        ide.setMod(DFModelo.CTE);
+        ide.setSerie(1);
+        ide.setNCT(123);
+        ide.setDhEmi(ZonedDateTime.of(2025, 1, 22, 10, 10, 10, 0, DFConfig.TIMEZONE_SP.toZoneId()));
+        ide.setTpImp(CTTipoImpressao.RETRATO);
+        ide.setTpEmis(CTTipoEmissao.EMISSAO_NORMAL);
+        ide.setCDV(4);
+        ide.setTpAmb(DFAmbiente.HOMOLOGACAO);
+        ide.setTpCTe("5");
+        ide.setProcEmi(CTProcessoEmissao.EMISSOR_CONTRIBUINTE);
+        ide.setVerProc("1.00");
+        ide.setCMunEnv("4205407");
+        ide.setXMunEnv("Floriano");
+        ide.setUFEnv("SC");
+        ide.setModal(CTModal.RODOVIARIO);
+        ide.setTpServ(CTTipoServico.NORMAL);
+        ide.setUFIni("SC");
+        ide.setUFFim("SC");
+        ide.setRetira(CTRetirada.NAO);
+        return ide;
+    }
+
+    private CTeNotaSimpInfoTomador toma() {
+        final CTeNotaSimpInfoTomador toma = new CTeNotaSimpInfoTomador();
+        toma.setToma(CTTomadorServico.RECEBEDOR);
+        toma.setIndIEToma(CTIndicadorTomador.NAO_CONTRIBUINTE);
+        toma.setCNPJ("00000000000011");
+        toma.setXNome("CTE EMITIDO EM AMBIENTE DE HOMOLOGACAO - SEM VALOR FISCAL");
+        toma.setEnderToma(FabricaDeObjetosFake.getEndereco());
+        return toma;
+    }
+
+    private CTeNotaSimpInfoDet det() {
+        final CTeNotaSimpInfoDet det = new CTeNotaSimpInfoDet();
+        det.setNItem("1");
+        det.setCMunIni("4205407");
+        det.setXMunIni("Floriano");
+        det.setCMunFim("4205407");
+        det.setXMunFim("Floriano");
+        det.setVPrest(new BigDecimal("100.00"));
+        det.setVRec(new BigDecimal("100.00"));
+        final CTeNotaSimpInfoDetInfNFe nfe = new CTeNotaSimpInfoDetInfNFe();
+        nfe.setChNFe(CHAVE_44);
+        det.setInfNFe(Collections.singletonList(nfe));
+        return det;
+    }
+
+    private CTeNotaInfoInformacoesRelativasImpostos imp() {
+        final CTeNotaInfoInformacoesRelativasImpostos imp = new CTeNotaInfoInformacoesRelativasImpostos();
+        imp.setIcms(FabricaDeObjetosFake.getImpostosICMS());
+        return imp;
+    }
+
+    private CTeNotaSimpInfoTotal total() {
+        final CTeNotaSimpInfoTotal total = new CTeNotaSimpInfoTotal();
+        total.setVTPrest(new BigDecimal("100.00"));
+        total.setVTRec(new BigDecimal("100.00"));
+        return total;
+    }
+}


### PR DESCRIPTION
Implementa o Conhecimento de Transporte Eletrônico Simplificado (Ajuste SINIEF 46/2023) como variante de modelo 57, seguindo o CT-e OS como molde e a convenção de nomes = tags XML já usada no IBSCBS. Classes de domínio (cte400/classes/simp/):
- CTeNotaSimp (raiz CTeSimp), CTeNotaSimpInfo, ...Identificacao, ...Tomador, ...Det (+ Comp, InfNFe, InfDocAnt, InfDocAntNFeParcial), ...Total
- Reutiliza emit, infModal, infCarga e imp do CT-e normal
- Raiz CTeSimp sem atributo versao (só infCte o possui) Webservice e transporte:
- WSRecepcaoCTeSimp (assina infCte, GZip+Base64, síncrono sem lote)
- CTeRecepcaoSimpV4Stub — literais conferidos contra os WSDL reais de homologação de MT e SVRS (namespace, operação cteRecepcaoSimp, cteDadosMsg, cteRecepcaoSimpResult, soapAction)
- CTeSimpEnvioRetorno/...Dados e CTeSimpProcessado (cteSimpProc)
- Overload WSFacade.enviaCTe(CTeNotaSimp) Autorizador e validação:
- CTAutorizador400.getCteRecepcaoSimp nos 8 autorizadores (produção + homologação); MT usa path atípico cte-ws/services/
- DFXMLValidador.validaNotaCteSimp400 (cteSimp_v4.00.xsd, RTC 1.14) Teste:
- CTeNotaSimpTest faz round-trip serializa→valida contra o XSD; toda a estrutura de negócio valida (só falta Signature, aplicado no envio)