### PR TITLE
Corrige formatação de valores numéricos e estrutura do evento 211110 …

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/AbstractNFDetGrupoItem.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/AbstractNFDetGrupoItem.java
@@ -11,26 +11,24 @@ import java.math.BigDecimal;
 public abstract class AbstractNFDetGrupoItem extends DFBase {
 
     @Element(name = "vIBS")
-    private BigDecimal valorIBS;
+    private String valorIBS;
 
     @Element(name = "vCBS")
-    private BigDecimal valorCBS;
+    private String valorCBS;
 
-    public BigDecimal getValorCBS() {
+    public String getValorCBS() {
         return valorCBS;
     }
 
     public void setValorCBS(BigDecimal valorCBS) {
-        DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorCBS, "Valor CBS");
-        this.valorCBS = valorCBS;
+        this.valorCBS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorCBS, "Valor CBS");
     }
 
-    public BigDecimal getValorIBS() {
+    public String getValorIBS() {
         return valorIBS;
     }
 
     public void setValorIBS(BigDecimal valorIBS) {
-        DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorIBS, "Valor IBS");
-        this.valorIBS = valorIBS;
+        this.valorIBS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorIBS, "Valor IBS");
     }
 }

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/alczfmimportacao/NFDetGrupoControleEstoqueZFM.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/alczfmimportacao/NFDetGrupoControleEstoqueZFM.java
@@ -12,18 +12,17 @@ import java.math.BigDecimal;
 public class NFDetGrupoControleEstoqueZFM extends DFBase {
 
     @Element(name = "qtde")
-    private BigDecimal quantidade;
+    private String quantidade;
 
     @Element(name = "unidade")
     private String unidade;
 
-    public BigDecimal getQuantidade() {
+    public String getQuantidade() {
         return quantidade;
     }
 
     public void setQuantidade(BigDecimal quantidade) {
-        DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidade, "Quantidade");
-        this.quantidade = quantidade;
+        this.quantidade = DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidade, "Quantidade");
     }
 
     public String getUnidade() {

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/alczfmimportacao/NFDetGrupoControleEstoqueZFM.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/alczfmimportacao/NFDetGrupoControleEstoqueZFM.java
@@ -12,25 +12,25 @@ import java.math.BigDecimal;
 public class NFDetGrupoControleEstoqueZFM extends DFBase {
 
     @Element(name = "qtde")
-    private String quantidade;
+    private String quantidadeZFM;
 
     @Element(name = "unidade")
-    private String unidade;
+    private String unidadeZFM;
 
-    public String getQuantidade() {
-        return quantidade;
+    public String getQuantidadeZFM() {
+        return quantidadeZFM;
     }
 
-    public void setQuantidade(BigDecimal quantidade) {
-        this.quantidade = DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidade, "Quantidade");
+    public void setQuantidadeZFM(BigDecimal quantidadeZFM) {
+        this.quantidadeZFM = DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidadeZFM, "Quantidade");
     }
 
-    public String getUnidade() {
-        return unidade;
+    public String getUnidadeZFM() {
+        return unidadeZFM;
     }
 
-    public void setUnidade(String unidade) {
-        DFStringValidador.tamanho6(unidade, "Unidade de medida");
-        this.unidade = unidade;
+    public void setUnidadeZFM(String unidadeZFM) {
+        DFStringValidador.tamanho6(unidadeZFM, "Unidade de medida");
+        this.unidadeZFM = unidadeZFM;
     }
 }

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/apropriacaobens/NFDetGrupoCredito.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/apropriacaobens/NFDetGrupoCredito.java
@@ -16,10 +16,10 @@ public class NFDetGrupoCredito extends DFBase {
     private Integer numeroItem;
 
     @Element(name = "vCredIBS")
-    private BigDecimal valorCreditoIBS;
+    private String valorCreditoIBS;
 
     @Element(name = "vCredCBS")
-    private BigDecimal valorCreditoCBS;
+    private String valorCreditoCBS;
 
     public Integer getNumeroItem() {
         return numeroItem;
@@ -30,21 +30,19 @@ public class NFDetGrupoCredito extends DFBase {
         this.numeroItem = numeroItem;
     }
 
-    public BigDecimal getValorCreditoIBS() {
+    public String getValorCreditoIBS() {
         return valorCreditoIBS;
     }
 
     public void setValorCreditoIBS(BigDecimal valorCreditoIBS) {
-        DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorCreditoIBS, "Valor do Crédito IBS");
-        this.valorCreditoIBS = valorCreditoIBS;
+        this.valorCreditoIBS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorCreditoIBS, "Valor do Crédito IBS");
     }
 
-    public BigDecimal getValorCreditoCBS() {
+    public String getValorCreditoCBS() {
         return valorCreditoCBS;
     }
 
     public void setValorCreditoCBS(BigDecimal valorCreditoCBS) {
-        DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorCreditoCBS, "Valor do Crédito CBS");
-        this.valorCreditoCBS = valorCreditoCBS;
+        this.valorCreditoCBS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorCreditoCBS, "Valor do Crédito CBS");
     }
 }

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/apropriacaocomb/NFDetGrupoControleEstoque.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/apropriacaocomb/NFDetGrupoControleEstoque.java
@@ -12,18 +12,17 @@ import java.math.BigDecimal;
 public class NFDetGrupoControleEstoque extends DFBase {
 
     @Element(name = "qComb")
-    private BigDecimal quantidadeCombustivel;
+    private String quantidadeCombustivel;
 
     @Element(name = "uComb")
     private String unidadeCombustivel;
 
-    public BigDecimal getQuantidadeCombustivel() {
+    public String getQuantidadeCombustivel() {
         return quantidadeCombustivel;
     }
 
     public void setQuantidadeCombustivel(BigDecimal quantidadeCombustivel) {
-        DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidadeCombustivel, "Quantidade de Combustível");
-        this.quantidadeCombustivel = quantidadeCombustivel;
+        this.quantidadeCombustivel = DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidadeCombustivel, "Quantidade de Combustível");
     }
 
     public String getUnidadeCombustivel() {

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/apropriacaocredito/NFDetEventoSolicitacaoApropriacaoCreditoPresumido.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/apropriacaocredito/NFDetEventoSolicitacaoApropriacaoCreditoPresumido.java
@@ -10,7 +10,7 @@ import java.util.List;
 @Root(name = "detEvento")
 public class NFDetEventoSolicitacaoApropriacaoCreditoPresumido extends NFDetEvento {
 
-    @ElementList(name = "gCredPres", inline = true)
+    @ElementList(name = "gCredPresOper", inline = true)
     private List<NFDetGrupoCreditoPresumido> gruposCreditoPresumido;
 
     public List<NFDetGrupoCreditoPresumido> getGruposCreditoPresumido() {

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/apropriacaocredito/NFDetGrupoCreditoPresumido.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/apropriacaocredito/NFDetGrupoCreditoPresumido.java
@@ -3,25 +3,35 @@ package com.fincatto.documentofiscal.nfe400.classes.evento.apropriacaocredito;
 import com.fincatto.documentofiscal.DFBase;
 import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
 import com.fincatto.documentofiscal.validadores.DFIntegerValidador;
+import com.fincatto.documentofiscal.validadores.DFStringValidador;
 import org.simpleframework.xml.Attribute;
 import org.simpleframework.xml.Element;
 import org.simpleframework.xml.Root;
 
 import java.math.BigDecimal;
 
-@Root(name = "gCredPres")
+/**
+ * P23 - gCredPresOper - Informações de crédito presumido por item.
+ */
+@Root(name = "gCredPresOper")
 public class NFDetGrupoCreditoPresumido extends DFBase {
 
     @Attribute(name = "nItem")
     private Integer numeroItem;
 
-    @Element(name = "vBC")
-    private BigDecimal valorBaseCalculo;
+    @Element(name = "vBCCredPres")
+    private String valorBaseCalculo;
 
-    @Element(name = "gIBS", required = false)
+    /**
+     * P25a - Código de Classificação do Crédito Presumido, conforme tabela cCredPres (Anexo IV).
+     */
+    @Element(name = "cCredPres")
+    private String codigoClassicacaoCreditoPresumido;
+
+    @Element(name = "gIBSCredPres", required = false)
     private NFDetGrupoImpostoCreditoPresumido grupoIbsCreditoPresumido;
 
-    @Element(name = "gCBS", required = false)
+    @Element(name = "gCBSCredPres", required = false)
     private NFDetGrupoImpostoCreditoPresumido grupoCbsCreditoPresumido;
 
     public Integer getNumeroItem() {
@@ -33,13 +43,21 @@ public class NFDetGrupoCreditoPresumido extends DFBase {
         this.numeroItem = numeroItem;
     }
 
-    public BigDecimal getValorBaseCalculo() {
+    public String getValorBaseCalculo() {
         return valorBaseCalculo;
     }
 
     public void setValorBaseCalculo(BigDecimal valorBaseCalculo) {
-        DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorBaseCalculo, "Valor da Base de Cálculo do Crédito Presumido");
-        this.valorBaseCalculo = valorBaseCalculo;
+        this.valorBaseCalculo = DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorBaseCalculo, "Valor da Base de Cálculo do Crédito Presumido");
+    }
+
+    public String getCodigoClassicacaoCreditoPresumido() {
+        return codigoClassicacaoCreditoPresumido;
+    }
+
+    public void setCodigoClassicacaoCreditoPresumido(String codigoClassicacaoCreditoPresumido) {
+        DFStringValidador.tamanho2N(codigoClassicacaoCreditoPresumido, "Código de Classificação do Crédito Presumido");
+        this.codigoClassicacaoCreditoPresumido = codigoClassicacaoCreditoPresumido;
     }
 
     public NFDetGrupoImpostoCreditoPresumido getGrupoIbsCreditoPresumido() {

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/apropriacaocredito/NFDetGrupoImpostoCreditoPresumido.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/apropriacaocredito/NFDetGrupoImpostoCreditoPresumido.java
@@ -2,49 +2,34 @@ package com.fincatto.documentofiscal.nfe400.classes.evento.apropriacaocredito;
 
 import com.fincatto.documentofiscal.DFBase;
 import com.fincatto.documentofiscal.validadores.DFBigDecimalValidador;
-import com.fincatto.documentofiscal.validadores.DFStringValidador;
 import org.simpleframework.xml.Element;
 
 import java.math.BigDecimal;
 
+/**
+ * P26/P30 - gIBSCredPres / gCBSCredPres - Grupo de Informações do Crédito Presumido referente ao IBS/CBS.
+ */
 public class NFDetGrupoImpostoCreditoPresumido extends DFBase {
 
-    /**
-     * Código de Classificação do Crédito Presumido
-     */
-    @Element(name = "cCredPres")
-    private String codigoClassicacaoCreditoPresumido;
-
     @Element(name = "pCredPres")
-    private BigDecimal percentual;
+    private String percentual;
 
     @Element(name = "vCredPres")
-    private BigDecimal valor;
+    private String valor;
 
-    public String getCodigoClassicacaoCreditoPresumido() {
-        return codigoClassicacaoCreditoPresumido;
-    }
-
-    public void setCodigoClassicacaoCreditoPresumido(String codigoClassicacaoCreditoPresumido) {
-        DFStringValidador.tamanho2N(codigoClassicacaoCreditoPresumido, "Código de Classificação do Crédito Presumido");
-        this.codigoClassicacaoCreditoPresumido = codigoClassicacaoCreditoPresumido;
-    }
-
-    public BigDecimal getPercentual() {
+    public String getPercentual() {
         return percentual;
     }
 
     public void setPercentual(BigDecimal percentual) {
-        DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(percentual, "Percentual do Crédito Presumido");
-        this.percentual = percentual;
+        this.percentual = DFBigDecimalValidador.tamanho7ComAte4CasasDecimais(percentual, "Percentual do Crédito Presumido");
     }
 
-    public BigDecimal getValor() {
+    public String getValor() {
         return valor;
     }
 
     public void setValor(BigDecimal valor) {
-        DFBigDecimalValidador.tamanho13Com2CasasDecimais(valor, "Valor do Crédito Presumido");
-        this.valor = valor;
+        this.valor = DFBigDecimalValidador.tamanho13Com2CasasDecimais(valor, "Valor do Crédito Presumido");
     }
 }

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/consumopessoal/NFDetGrupoConsumo.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/consumopessoal/NFDetGrupoConsumo.java
@@ -17,10 +17,10 @@ public class NFDetGrupoConsumo extends DFBase {
     private Integer numeroItem;
 
     @Element(name = "vIBS")
-    private BigDecimal valorIBS;
+    private String valorIBS;
 
     @Element(name = "vCBS")
-    private BigDecimal valorCBS;
+    private String valorCBS;
 
     @Element(name = "gControleEstoque")
     private NFDetGrupoControleEstoqueConsumo controleEstoque;
@@ -53,21 +53,19 @@ public class NFDetGrupoConsumo extends DFBase {
         this.numeroItem = numeroItem;
     }
 
-    public BigDecimal getValorCBS() {
+    public String getValorCBS() {
         return valorCBS;
     }
 
     public void setValorCBS(BigDecimal valorCBS) {
-        DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorCBS, "Valor CBS");
-        this.valorCBS = valorCBS;
+        this.valorCBS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorCBS, "Valor CBS");
     }
 
-    public BigDecimal getValorIBS() {
+    public String getValorIBS() {
         return valorIBS;
     }
 
     public void setValorIBS(BigDecimal valorIBS) {
-        DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorIBS, "Valor IBS");
-        this.valorIBS = valorIBS;
+        this.valorIBS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorIBS, "Valor IBS");
     }
 }

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/consumopessoal/NFDetGrupoControleEstoqueConsumo.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/consumopessoal/NFDetGrupoControleEstoqueConsumo.java
@@ -12,25 +12,25 @@ import java.math.BigDecimal;
 public class NFDetGrupoControleEstoqueConsumo extends DFBase {
 
     @Element(name = "qConsumo")
-    private String quantidade;
+    private String quantidadeConsumo;
 
     @Element(name = "uConsumo")
-    private String unidadeMedida;
+    private String unidadeMedidaConsumo;
 
-    public String getQuantidade() {
-        return quantidade;
+    public String getQuantidadeConsumo() {
+        return quantidadeConsumo;
     }
 
-    public void setQuantidade(BigDecimal quantidade) {
-        this.quantidade = DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidade, "Quantidade de Consumo");
+    public void setQuantidadeConsumo(BigDecimal quantidadeConsumo) {
+        this.quantidadeConsumo = DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidadeConsumo, "Quantidade de Consumo");
     }
 
-    public String getUnidadeMedida() {
-        return unidadeMedida;
+    public String getUnidadeMedidaConsumo() {
+        return unidadeMedidaConsumo;
     }
 
-    public void setUnidadeMedida(String unidadeMedida) {
-        DFStringValidador.tamanho3(unidadeMedida, "Unidade de Medida de Consumo");
-        this.unidadeMedida = unidadeMedida;
+    public void setUnidadeMedidaConsumo(String unidadeMedidaConsumo) {
+        DFStringValidador.tamanho3(unidadeMedidaConsumo, "Unidade de Medida de Consumo");
+        this.unidadeMedidaConsumo = unidadeMedidaConsumo;
     }
 }

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/consumopessoal/NFDetGrupoControleEstoqueConsumo.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/consumopessoal/NFDetGrupoControleEstoqueConsumo.java
@@ -12,18 +12,17 @@ import java.math.BigDecimal;
 public class NFDetGrupoControleEstoqueConsumo extends DFBase {
 
     @Element(name = "qConsumo")
-    private BigDecimal quantidade;
+    private String quantidade;
 
     @Element(name = "uConsumo")
     private String unidadeMedida;
 
-    public BigDecimal getQuantidade() {
+    public String getQuantidade() {
         return quantidade;
     }
 
     public void setQuantidade(BigDecimal quantidade) {
-        DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidade, "Quantidade de Consumo");
-        this.quantidade = quantidade;
+        this.quantidade = DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidade, "Quantidade de Consumo");
     }
 
     public String getUnidadeMedida() {

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/imobilizacao/NFDetGrupoControleEstoqueImobilizacao.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/imobilizacao/NFDetGrupoControleEstoqueImobilizacao.java
@@ -12,25 +12,25 @@ import java.math.BigDecimal;
 public class NFDetGrupoControleEstoqueImobilizacao extends DFBase {
 
     @Element(name = "qImobilizado")
-    private String quantidade;
+    private String quantidadeImobilizada;
 
     @Element(name = "uImobilizado")
-    private String unidade;
+    private String unidadeImobilizada;
 
-    public String getQuantidade() {
-        return quantidade;
+    public String getQuantidadeImobilizada() {
+        return quantidadeImobilizada;
     }
 
-    public void setQuantidade(BigDecimal quantidade) {
-        this.quantidade = DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidade, "Quantidade");
+    public void setQuantidadeImobilizada(BigDecimal quantidadeImobilizada) {
+        this.quantidadeImobilizada = DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidadeImobilizada, "Quantidade");
     }
 
-    public String getUnidade() {
-        return unidade;
+    public String getUnidadeImobilizada() {
+        return unidadeImobilizada;
     }
 
-    public void setUnidade(String unidade) {
-        DFStringValidador.tamanho6(unidade, "Unidade de medida");
-        this.unidade = unidade;
+    public void setUnidadeImobilizada(String unidadeImobilizada) {
+        DFStringValidador.tamanho6(unidadeImobilizada, "Unidade de medida");
+        this.unidadeImobilizada = unidadeImobilizada;
     }
 }

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/imobilizacao/NFDetGrupoControleEstoqueImobilizacao.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/imobilizacao/NFDetGrupoControleEstoqueImobilizacao.java
@@ -12,18 +12,17 @@ import java.math.BigDecimal;
 public class NFDetGrupoControleEstoqueImobilizacao extends DFBase {
 
     @Element(name = "qImobilizado")
-    private BigDecimal quantidade;
+    private String quantidade;
 
     @Element(name = "uImobilizado")
     private String unidade;
 
-    public BigDecimal getQuantidade() {
+    public String getQuantidade() {
         return quantidade;
     }
 
     public void setQuantidade(BigDecimal quantidade) {
-        DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidade, "Quantidade");
-        this.quantidade = quantidade;
+        this.quantidade = DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidade, "Quantidade");
     }
 
     public String getUnidade() {

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/naofornecido/NFDetGrupoControleEstoqueNaoFornecimento.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/naofornecido/NFDetGrupoControleEstoqueNaoFornecimento.java
@@ -12,18 +12,17 @@ import java.math.BigDecimal;
 public class NFDetGrupoControleEstoqueNaoFornecimento extends DFBase {
 
     @Element(name = "qNaoFornecida")
-    private BigDecimal quantidade;
+    private String quantidade;
 
     @Element(name = "uNaoFornecida")
     private String unidadeMedida;
 
-    public BigDecimal getQuantidade() {
+    public String getQuantidade() {
         return quantidade;
     }
 
     public void setQuantidade(BigDecimal quantidade) {
-        DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidade, "Quantidade não fornecida");
-        this.quantidade = quantidade;
+        this.quantidade = DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidade, "Quantidade não fornecida");
     }
 
     public String getUnidadeMedida() {

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/naofornecido/NFDetGrupoControleEstoqueNaoFornecimento.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/naofornecido/NFDetGrupoControleEstoqueNaoFornecimento.java
@@ -12,25 +12,25 @@ import java.math.BigDecimal;
 public class NFDetGrupoControleEstoqueNaoFornecimento extends DFBase {
 
     @Element(name = "qNaoFornecida")
-    private String quantidade;
+    private String quantidadeNaoFornecida;
 
     @Element(name = "uNaoFornecida")
-    private String unidadeMedida;
+    private String unidadeMedidaNaoFornecimento;
 
-    public String getQuantidade() {
-        return quantidade;
+    public String getQuantidadeNaoFornecida() {
+        return quantidadeNaoFornecida;
     }
 
-    public void setQuantidade(BigDecimal quantidade) {
-        this.quantidade = DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidade, "Quantidade não fornecida");
+    public void setQuantidadeNaoFornecida(BigDecimal quantidadeNaoFornecida) {
+        this.quantidadeNaoFornecida = DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidadeNaoFornecida, "Quantidade não fornecida");
     }
 
-    public String getUnidadeMedida() {
-        return unidadeMedida;
+    public String getUnidadeMedidaNaoFornecimento() {
+        return unidadeMedidaNaoFornecimento;
     }
 
-    public void setUnidadeMedida(String unidadeMedida) {
-        DFStringValidador.tamanho6(unidadeMedida, "Unidade de Medida");
-        this.unidadeMedida = unidadeMedida;
+    public void setUnidadeMedidaNaoFornecimento(String unidadeMedidaNaoFornecimento) {
+        DFStringValidador.tamanho6(unidadeMedidaNaoFornecimento, "Unidade de Medida");
+        this.unidadeMedidaNaoFornecimento = unidadeMedidaNaoFornecimento;
     }
 }

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/naofornecido/NFDetGrupoItemNaoFornecido.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/naofornecido/NFDetGrupoItemNaoFornecido.java
@@ -16,10 +16,10 @@ public class NFDetGrupoItemNaoFornecido extends DFBase {
     private Integer numeroItem;
 
     @Element(name = "vIBS")
-    private BigDecimal valorIbs;
+    private String valorIbs;
 
     @Element(name = "vCBS")
-    private BigDecimal valorCbs;
+    private String valorCbs;
 
     @Element(name = "gControleEstoque")
     private NFDetGrupoControleEstoqueNaoFornecimento controleEstoque;
@@ -33,22 +33,20 @@ public class NFDetGrupoItemNaoFornecido extends DFBase {
         this.numeroItem = numeroItem;
     }
 
-    public BigDecimal getValorIbs() {
+    public String getValorIbs() {
         return valorIbs;
     }
 
     public void setValorIbs(BigDecimal valorIbs) {
-        DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorIbs, "Valor IBS");
-        this.valorIbs = valorIbs;
+        this.valorIbs = DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorIbs, "Valor IBS");
     }
 
-    public BigDecimal getValorCbs() {
+    public String getValorCbs() {
         return valorCbs;
     }
 
     public void setValorCbs(BigDecimal valorCbs) {
-        DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorCbs, "Valor CBS");
-        this.valorCbs = valorCbs;
+        this.valorCbs = DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorCbs, "Valor CBS");
     }
 
     public NFDetGrupoControleEstoqueNaoFornecimento getControleEstoque() {

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/roubo/NFDetGrupoControleEstoquePerecimento.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/roubo/NFDetGrupoControleEstoquePerecimento.java
@@ -12,25 +12,25 @@ import java.math.BigDecimal;
 public class NFDetGrupoControleEstoquePerecimento extends DFBase {
 
     @Element(name = "qPerecimento")
-    private String quantidade;
+    private String quantidadePerecimento;
 
     @Element(name = "uPerecimento")
-    private String unidade;
+    private String unidadePerecimento;
 
-    public String getQuantidade() {
-        return quantidade;
+    public String getQuantidadePerecimento() {
+        return quantidadePerecimento;
     }
 
-    public void setQuantidade(BigDecimal quantidade) {
-        this.quantidade = DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidade, "Quantidade Perecimento");
+    public void setQuantidadePerecimento(BigDecimal quantidadePerecimento) {
+        this.quantidadePerecimento = DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidadePerecimento, "Quantidade Perecimento");
     }
 
-    public String getUnidade() {
-        return unidade;
+    public String getUnidadePerecimento() {
+        return unidadePerecimento;
     }
 
-    public void setUnidade(String unidade) {
-        DFStringValidador.tamanho6N(unidade, "Unidade Perecimento");
-        this.unidade = unidade;
+    public void setUnidadePerecimento(String unidadePerecimento) {
+        DFStringValidador.tamanho6N(unidadePerecimento, "Unidade Perecimento");
+        this.unidadePerecimento = unidadePerecimento;
     }
 }

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/roubo/NFDetGrupoControleEstoquePerecimento.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/roubo/NFDetGrupoControleEstoquePerecimento.java
@@ -12,18 +12,17 @@ import java.math.BigDecimal;
 public class NFDetGrupoControleEstoquePerecimento extends DFBase {
 
     @Element(name = "qPerecimento")
-    private BigDecimal quantidade;
+    private String quantidade;
 
     @Element(name = "uPerecimento")
     private String unidade;
 
-    public BigDecimal getQuantidade() {
+    public String getQuantidade() {
         return quantidade;
     }
 
     public void setQuantidade(BigDecimal quantidade) {
-        DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidade, "Quantidade Perecimento");
-        this.quantidade = quantidade;
+        this.quantidade = DFBigDecimalValidador.tamanho11Com4CasasDecimais(quantidade, "Quantidade Perecimento");
     }
 
     public String getUnidade() {

--- a/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/roubo/NFDetGrupoControleEstoquePerecimentoFornecedor.java
+++ b/src/main/java/com/fincatto/documentofiscal/nfe400/classes/evento/roubo/NFDetGrupoControleEstoquePerecimentoFornecedor.java
@@ -10,26 +10,24 @@ import java.math.BigDecimal;
 public class NFDetGrupoControleEstoquePerecimentoFornecedor extends NFDetGrupoControleEstoquePerecimento {
 
     @Element(name = "vIBS")
-    private BigDecimal valorIBS;
+    private String valorIBS;
 
     @Element(name = "vCBS")
-    private BigDecimal valorCBS;
+    private String valorCBS;
 
-    public BigDecimal getValorIBS() {
+    public String getValorIBS() {
         return valorIBS;
     }
 
     public void setValorIBS(BigDecimal valorIBS) {
-        DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorIBS, "Valor IBS");
-        this.valorIBS = valorIBS;
+        this.valorIBS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorIBS, "Valor IBS");
     }
 
-    public BigDecimal getValorCBS() {
+    public String getValorCBS() {
         return valorCBS;
     }
 
     public void setValorCBS(BigDecimal valorCBS) {
-        DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorCBS, "Valor CBS");
-        this.valorCBS = valorCBS;
+        this.valorCBS = DFBigDecimalValidador.tamanho13Com2CasasDecimais(valorCBS, "Valor CBS");
     }
 }


### PR DESCRIPTION
…(NT 2025.002-RTC)

Formatação de valores numéricos:
Diversos campos BigDecimal dos grupos de evento chamavam os validadores de DFBigDecimalValidador (que retornam o valor formatado conforme o schema, com casas decimais fixas) mas descartavam o retorno e atribuíam o valor bruto sem formatação, quebrando a serialização XML esperada pela SEFAZ. O padrão correto (já usado em nota/NFNotaInfoISTot.java) é armazenar o campo internamente como String, atribuindo o retorno do validador. Corrigidos os seguintes grupos:
- AbstractNFDetGrupoItem (valorIBS, valorCBS)
- apropriacaocredito/NFDetGrupoCreditoPresumido (vBCCredPres)
- apropriacaocredito/NFDetGrupoImpostoCreditoPresumido (pCredPres, vCredPres)
- imobilizacao/NFDetGrupoControleEstoqueImobilizacao (quantidade)
- roubo/NFDetGrupoControleEstoquePerecimento (quantidade)
- roubo/NFDetGrupoControleEstoquePerecimentoFornecedor (valorIBS, valorCBS)
- naofornecido/NFDetGrupoItemNaoFornecido (valorIbs, valorCbs)
- naofornecido/NFDetGrupoControleEstoqueNaoFornecimento (quantidade)
- apropriacaobens/NFDetGrupoCredito (valorCreditoIBS, valorCreditoCBS)
- alczfmimportacao/NFDetGrupoControleEstoqueZFM (quantidade)
- apropriacaocomb/NFDetGrupoControleEstoque (quantidadeCombustivel)
- consumopessoal/NFDetGrupoControleEstoqueConsumo (quantidade)
- consumopessoal/NFDetGrupoConsumo (valorIBS, valorCBS)

Estrutura do evento 211110 (Solicitação de Apropriação de Crédito Presumido): A tag gCredPres foi renomeada para gCredPresOper conforme a NT 2025.002-RTC v1.50, alinhando com a estrutura já usada em
nota/NFNotaInfoItemImpostoIBSCBSGCredPresOper (seção 6 da NT):
- NFDetGrupoCreditoPresumido: @Root renomeado de gCredPres para gCredPresOper; campo vBC renomeado para vBCCredPres; adicionado cCredPres neste nível (código de classificação do crédito presumido por item); grupos internos renomeados de gIBS/gCBS para gIBSCredPres/gCBSCredPres.
- NFDetGrupoImpostoCreditoPresumido: removido o campo cCredPres, que não pertence a este nível (só existe pCredPres e vCredPres).
- NFDetEventoSolicitacaoApropriacaoCreditoPresumido: @ElementList ajustado de gCredPres para gCredPresOper.

Testes: mvn test (JDK 11) — 4055 testes, 0 falhas, 0 erros.