### PR TITLE
CTe: campos da NT 2026.002 (ISUFEmit e antecipação de pagamento)

### DIFF
--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeNotaInfoEmitente.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeNotaInfoEmitente.java
@@ -38,6 +38,9 @@ public class CTeNotaInfoEmitente extends DFBase {
     @Element(name = "CRT")
     private CTTipoRegimeTributario tipoRegimeTributario;
 
+    @Element(name = "ISUFEmit", required = false)
+    private String inscricaoSuframa;
+
     public String getCnpj() {
         return this.cnpj;
     }
@@ -117,5 +120,20 @@ public class CTeNotaInfoEmitente extends DFBase {
     public CTeNotaInfoEmitente setTipoRegimeTributario(CTTipoRegimeTributario tipoRegimeTributario) {
         this.tipoRegimeTributario = tipoRegimeTributario;
         return this;
+    }
+
+    public String getISUFEmit() {
+        return this.inscricaoSuframa;
+    }
+
+    /**
+     * Inscrição do emitente na Suframa (8 a 9 dígitos).<br>
+     * NT 2026.002 - obrigatório nas operações que se beneficiam de incentivos
+     * fiscais nas áreas sob controle da SUFRAMA com alíquota zero da CBS
+     * (arts. 451 e 466 da LC 214/25).
+     */
+    public void setISUFEmit(final String inscricaoSuframa) {
+        DFStringValidador.tamanho8a9(inscricaoSuframa, "Inscrição do emitente na Suframa");
+        this.inscricaoSuframa = inscricaoSuframa;
     }
 }

--- a/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeNotaInfoIdentificacao.java
+++ b/src/main/java/com/fincatto/documentofiscal/cte400/classes/nota/CTeNotaInfoIdentificacao.java
@@ -10,11 +10,13 @@ import com.fincatto.documentofiscal.cte400.classes.*;
 import com.fincatto.documentofiscal.validadores.DFIntegerValidador;
 import com.fincatto.documentofiscal.validadores.DFStringValidador;
 import org.simpleframework.xml.Element;
+import org.simpleframework.xml.ElementList;
 import org.simpleframework.xml.Namespace;
 import org.simpleframework.xml.Root;
 
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
+import java.util.List;
 
 /**
  * Identificacao do CT-e
@@ -126,7 +128,13 @@ public class CTeNotaInfoIdentificacao extends DFBase {
     
     @Element(name = "xJust", required = false)
     private String justificativa;
-    
+
+    @Element(name = "tpPagAnt", required = false)
+    private String tipoPagamentoAntecipado;
+
+    @Element(name = "gPagAntecipado", required = false)
+    private GrupoPagamentoAntecipado grupoPagamentoAntecipado;
+
     public DFUnidadeFederativa getCodigoUF() {
         return this.codigoUF;
     }
@@ -572,5 +580,53 @@ public class CTeNotaInfoIdentificacao extends DFBase {
     public void setJustificativa(final String justificativa) {
         DFStringValidador.tamanho15a256(justificativa, "Justificativa da entrada em contingencia");
         this.justificativa = justificativa;
+    }
+
+    public String getTpPagAnt() {
+        return this.tipoPagamentoAntecipado;
+    }
+
+    /**
+     * NT 2026.002 - Tipo de pagamento antecipado.<br>
+     * 1 = Pagamento Antecipado; 3 = Fornecimento com pagamento realizado
+     * anteriormente. Opcional; informar apenas em caso de antecipacao de
+     * pagamento.
+     */
+    public void setTpPagAnt(final String tipoPagamentoAntecipado) {
+        this.tipoPagamentoAntecipado = tipoPagamentoAntecipado;
+    }
+
+    public GrupoPagamentoAntecipado getGPagAntecipado() {
+        return this.grupoPagamentoAntecipado;
+    }
+
+    /**
+     * NT 2026.002 - Grupo de antecipacao de pagamento.<br>
+     * Permite informar apenas quando tpPagAnt = 3.
+     */
+    public void setGPagAntecipado(final GrupoPagamentoAntecipado grupoPagamentoAntecipado) {
+        this.grupoPagamentoAntecipado = grupoPagamentoAntecipado;
+    }
+
+    /**
+     * Grupo de antecipacao de pagamento (ide/gPagAntecipado).<br>
+     * Contem de 1 a 99 chaves de acesso de CT-e de pagamento antecipado
+     * (chCTePagAnt, com tpPagAnt = 1).
+     */
+    @Root(name = "gPagAntecipado")
+    @Namespace(reference = CTeConfig.NAMESPACE)
+    public static class GrupoPagamentoAntecipado extends DFBase {
+        private static final long serialVersionUID = 7938149076755500267L;
+
+        @ElementList(entry = "chCTePagAnt", inline = true, required = true)
+        private List<String> chavesPagamentoAntecipado;
+
+        public List<String> getChCTePagAnt() {
+            return this.chavesPagamentoAntecipado;
+        }
+
+        public void setChCTePagAnt(final List<String> chavesPagamentoAntecipado) {
+            this.chavesPagamentoAntecipado = chavesPagamentoAntecipado;
+        }
     }
 }


### PR DESCRIPTION
## Objetivo

Adiciona ao CTe os campos introduzidos pela **NT CTe 2026.002** (Reforma Tributária
do Consumo), aplicável a CTe / CTe Simplificado (mod. 57) e CTe OS (mod. 67).

## Mudanças

### `emit/ISUFEmit` — `CTeNotaInfoEmitente`
Inscrição do emitente na Suframa (8 a 9 dígitos). Campo obrigatório nas operações
que se beneficiam de incentivos fiscais nas áreas sob controle da SUFRAMA com
alíquota zero da CBS (arts. 451 e 466 da LC 214/25).
Posicionado **após `CRT`**, conforme a sequência do `emit` no `cteTiposBasico_v4.00.xsd`.

### `ide/tpPagAnt` + `ide/gPagAntecipado` — `CTeNotaInfoIdentificacao`
- `tpPagAnt`: tipo de pagamento antecipado (`1` = Pagamento Antecipado;
  `3` = Fornecimento com pagamento realizado anteriormente).
- `gPagAntecipado`: grupo de antecipação de pagamento com 1 a 99 chaves de acesso
  (`chCTePagAnt`), informado apenas quando `tpPagAnt = 3`.

## Compatibilidade

Ambos os campos são opcionais (`minOccurs=0`) e ficam ao final da respectiva
sequência — não afetam a serialização do CTe normal nem do OS já existentes.

## Observação sobre o nome da chave

No schema, o elemento filho de `gPagAntecipado` chama-se `chCTePagAnt` no root do
**CTe normal (TCTe)** e do **OS (TCTeOS)**, mas `chDFePagAnt` no **CTe Simplificado
(TCTeSimp)**. Esta PR implementa a árvore do CTe normal (`chCTePagAnt`); o
Simplificado tem classe de identificação própria e pode ser tratado separadamente.